### PR TITLE
electrumx: fix race condition in client

### DIFF
--- a/hemi/electrumx/electrumx.go
+++ b/hemi/electrumx/electrumx.go
@@ -124,12 +124,13 @@ func (c *Client) call(ctx context.Context, method string, params, result any) er
 
 	c.mtx.Lock()
 	c.id++
+	id := c.id
 	c.mtx.Unlock()
 
 	req := &JSONRPCRequest{
 		JSONRPC: "2.0",
 		Method:  method,
-		ID:      c.id,
+		ID:      id,
 	}
 	if params != any(nil) {
 		b, err := json.Marshal(params)


### PR DESCRIPTION
**Summary**
Fix a race condition in the electrumx client

Previously, the request ID stored in the client was incremented while the lock was held, however it was then read without the lock being held.

**Changes**
- Fix race condition in `electrumx` package
