### PR TITLE
ci: fix go workflow succeeding even if a step fails

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,14 +50,14 @@ jobs:
           check-latest: true
 
       - name: "Download and verify dependencies"
+        id: deps
         run: make deps
 
       - name: "make race"
-        continue-on-error: true
         run: make race
 
       - name: "make"
-        continue-on-error: true
+        if: (success() || failure()) && steps.deps.outcome == 'success'
         env:
           PGTESTURI: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
         run: |
@@ -65,6 +65,6 @@ jobs:
           git diff --exit-code
 
       - name: "make web popm"
-        continue-on-error: true
+        if: (success() || failure()) && steps.deps.outcome == 'success'
         run: |
           cd web && make


### PR DESCRIPTION
**Summary**
Remove use of `continue-on-error` flag in Go workflow due to it causing the workflow to suceed even if a step failed.

**Changes**
- Replace `continue-on-error` with `if: (success() || failure()) && steps.deps.outcome == 'success'` to mimic behaviour without causing the job to succeed with steps failing.
