### PR TITLE
make: add -local flag to goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build:
 install: $(cmds)
 
 lint:
-	$(shell go env GOPATH)/bin/goimports -w -l .
+	$(shell go env GOPATH)/bin/goimports -local github.com/hemilabs/heminetwork -w -l .
 	$(shell go env GOPATH)/bin/gofumpt -w -l .
 	go vet ./...
 

--- a/e2e/mocktimism/mocktimism.go
+++ b/e2e/mocktimism/mocktimism.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/juju/loggo"
+	"nhooyr.io/websocket"
+
 	"github.com/hemilabs/heminetwork/api/bssapi"
 	"github.com/hemilabs/heminetwork/api/protocol"
 	"github.com/hemilabs/heminetwork/hemi"
-	"github.com/juju/loggo"
-	"nhooyr.io/websocket"
 )
 
 const logLevel = "INFO"

--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -16,14 +16,15 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"nhooyr.io/websocket"
+
 	"github.com/hemilabs/heminetwork/api/bssapi"
 	"github.com/hemilabs/heminetwork/api/protocol"
 	"github.com/hemilabs/heminetwork/bitcoin"
 	"github.com/hemilabs/heminetwork/ethereum"
 	"github.com/hemilabs/heminetwork/hemi"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
-	"nhooyr.io/websocket"
 )
 
 const (


### PR DESCRIPTION
**Summary**
Add `-local` flag to `goimports` command in `make lint`, which will cause all local imports to be grouped together.

**Changes**
- Add `-local github.com/hemilabs/heminetwork` to the `goimports` command in `make lint`.
