### PR TITLE
ci: fix concurrency cancel-in-progress for pull requests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "go-${{ github.workflow }}-${{ github.event.number || github.ref }}"
-  cancel-in-progress: "${{ github.event.action == 'push' || github.event.action == 'pull_request' }}"
+  cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 permissions:
   contents: read


### PR DESCRIPTION
**Summary**
Fix previous "Go" CI runs not being cancelled when a newer commit is pushed to a pull request.

**Changes**
- Use `github.event_name` instead of `github.event.action` in `cancel-in-progress`
