### PR TITLE
retry mine keystone on failure

### DIFF
--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -382,7 +382,7 @@ func createBfg(ctx context.Context, t *testing.T, pgUri string, electrumxAddr st
 	req := testcontainers.ContainerRequest{
 		Env: map[string]string{
 			"BFG_POSTGRES_URI":     pgUri,
-			"BFG_BTC_START_HEIGHT": "5000",
+			"BFG_BTC_START_HEIGHT": "1",
 			"BFG_EXBTC_ADDRESS":    electrumxAddr,
 			"BFG_LOG_LEVEL":        "TRACE",
 			"BFG_PUBLIC_ADDRESS":   ":8383",

--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -89,7 +89,7 @@ func TestFullNetwork(t *testing.T) {
 			"-rpcuser=user",
 			"-rpcpassword=password",
 			"generatetoaddress",
-			"5000", // need to generate a lot for greater chance to not spend coinbase
+			"200", // need to generate a lot for greater chance to not spend coinbase
 			btcAddress.EncodeAddress(),
 		})
 	if err != nil {

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -916,7 +916,6 @@ func (m *Miner) l2KeystonesForProcessing() []hemi.L2Keystone {
 	m.mtx.Lock()
 
 	for i, v := range m.l2Keystones {
-
 		// if we're currently processing, or we've already processed the keystone
 		// then don't process
 		if !v.requiresProcessing {

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -42,118 +42,14 @@ const (
 	logLevel = "INFO"
 
 	promSubsystem = "popm_service" // Prometheus
+
+	l2KeystonePriorityBufferMaxSize = 10
 )
 
 var log = loggo.GetLogger("popm")
 
 func init() {
 	loggo.ConfigureLoggers(logLevel)
-}
-
-// L2KeystonePriorityBuffer holds up to "size" L2Keystones. it allows a caller
-// to push to it and it will keep the most recent "size" keystones, overriding
-// the oldest if full.  we define "oldest" as "the smallest l2 block number"
-type L2KeystonePriorityBuffer struct {
-	mtx     sync.Mutex
-	mapping map[string]*L2KeystonePriorityBufferElement
-	size    int
-}
-
-// L2KeystonePriorityBufferElement holds an L2Keystone and whether it has been
-// "processed" or not
-type L2KeystonePriorityBufferElement struct {
-	l2Keystone         hemi.L2Keystone
-	requiresProcessing bool
-}
-
-// NewL2KeystonePriorityBuffer creates a L2KeystonePriorityBuffer with size n
-func NewL2KeystonePriorityBuffer(n int) *L2KeystonePriorityBuffer {
-	return &L2KeystonePriorityBuffer{
-		mapping: make(map[string]*L2KeystonePriorityBufferElement),
-		size:    n,
-	}
-}
-
-// Push inserts an L2Keystone, dropping the oldest if full
-func (r *L2KeystonePriorityBuffer) Push(val hemi.L2Keystone) {
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
-
-	item := L2KeystonePriorityBufferElement{
-		l2Keystone:         val,
-		requiresProcessing: true,
-	}
-
-	serialized := hemi.L2KeystoneAbbreviate(val).Serialize()
-	key := hex.EncodeToString(serialized[:])
-
-	// keystone already exists, no-op
-	if _, ok := r.mapping[key]; ok {
-		return
-	}
-
-	if len(r.mapping) < r.size {
-		r.mapping[key] = &item
-		return
-	}
-
-	var smallestL2BlockNumber uint32
-	var smallestKey string
-
-	for k, v := range r.mapping {
-		if smallestL2BlockNumber == 0 || v.l2Keystone.L2BlockNumber < smallestL2BlockNumber {
-			smallestL2BlockNumber = v.l2Keystone.L2BlockNumber
-			smallestKey = k
-		}
-	}
-
-	// do not insert an L2Keystone that is older than all of the ones already
-	// queued
-	if item.l2Keystone.L2BlockNumber < smallestL2BlockNumber {
-		return
-	}
-
-	delete(r.mapping, smallestKey)
-
-	r.mapping[key] = &item
-}
-
-// ForEach is a thread-safe function that calls a callback function to "process"
-// each L2Keystone.  The callback function is called with a copy of the
-// L2Keystone to process.  if the callback returns an error, no-op, otherwise
-// mark the L2Keystone as processed
-func (r *L2KeystonePriorityBuffer) ForEach(cb func(ks hemi.L2Keystone) error) {
-	r.mtx.Lock()
-	copies := []hemi.L2Keystone{}
-	for _, v := range r.mapping {
-		if v.requiresProcessing {
-			copies = append(copies, v.l2Keystone)
-
-			// temporarily set this to false, so another goroutine doesn't
-			// try to process
-			v.requiresProcessing = false
-		}
-	}
-	r.mtx.Unlock()
-
-	// mine the newest keystone first
-	slices.SortFunc(copies, func(a, b hemi.L2Keystone) int {
-		return int(b.L2BlockNumber) - int(a.L2BlockNumber)
-	})
-
-	for _, e := range copies {
-		mined := hemi.L2KeystoneAbbreviate(e).Serialize()
-		key := hex.EncodeToString(mined[:])
-
-		err := cb(e)
-		r.mtx.Lock()
-		// check to see if still in map before marking
-		if _, ok := r.mapping[key]; ok {
-			// don't process again if callback succeeded
-			r.mapping[key].requiresProcessing = err != nil
-		}
-		r.mtx.Unlock()
-	}
 }
 
 type Config struct {
@@ -200,7 +96,6 @@ type Miner struct {
 	btcAddress     *btcutil.AddressPubKeyHash
 
 	lastKeystone *hemi.L2Keystone
-	keystoneBuf  *L2KeystonePriorityBuffer
 
 	// Prometheus
 	isRunning bool
@@ -209,6 +104,8 @@ type Miner struct {
 	bfgCmdCh chan bfgCmd // commands to send to bfg
 
 	mineNowCh chan struct{}
+
+	mapping map[string]hemi.L2Keystone
 }
 
 func NewMiner(cfg *Config) (*Miner, error) {
@@ -218,11 +115,11 @@ func NewMiner(cfg *Config) (*Miner, error) {
 
 	m := &Miner{
 		cfg:            cfg,
-		keystoneBuf:    NewL2KeystonePriorityBuffer(10),
 		bfgCmdCh:       make(chan bfgCmd, 10),
 		holdoffTimeout: 5 * time.Second,
 		requestTimeout: 5 * time.Second,
 		mineNowCh:      make(chan struct{}),
+		mapping:        make(map[string]hemi.L2Keystone),
 	}
 
 	switch strings.ToLower(cfg.BTCChainName) {
@@ -577,13 +474,14 @@ func (m *Miner) BitcoinUTXOs(ctx context.Context, scriptHash string) (*bfgapi.Bi
 }
 
 func (m *Miner) mineKnownKeystones(ctx context.Context) {
-	m.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	m.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		log.Infof("Received keystone for mining with height %v...", ks.L2BlockNumber)
 		if err := m.mineKeystone(ctx, &ks); err != nil {
 			log.Errorf("Failed to mine keystone: %v", err)
-			return err
+			return
 		}
-		return nil
+
+		m.PopL2Keystone(ks)
 	})
 }
 
@@ -602,7 +500,7 @@ func (m *Miner) mine(ctx context.Context) {
 }
 
 func (m *Miner) queueKeystoneForMining(keystone *hemi.L2Keystone) {
-	m.keystoneBuf.Push(*keystone)
+	m.PushL2Keystone(*keystone)
 	select {
 	case m.mineNowCh <- struct{}{}:
 	default:
@@ -940,4 +838,70 @@ func (m *Miner) Run(pctx context.Context) error {
 	log.Infof("pop miner service clean shutdown")
 
 	return err
+}
+
+// Push inserts an L2Keystone, dropping the oldest if full
+func (m *Miner) PushL2Keystone(val hemi.L2Keystone) {
+	serialized := hemi.L2KeystoneAbbreviate(val).Serialize()
+	key := hex.EncodeToString(serialized[:])
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	// keystone already exists, no-op
+	if _, ok := m.mapping[key]; ok {
+		return
+	}
+
+	var smallestL2BlockNumber uint32
+	var smallestKey string
+
+	for k, v := range m.mapping {
+		if smallestL2BlockNumber == 0 || v.L2BlockNumber < smallestL2BlockNumber {
+			smallestL2BlockNumber = v.L2BlockNumber
+			smallestKey = k
+		}
+	}
+
+	// do not insert an L2Keystone that is older than all of the ones already
+	// queued
+	if val.L2BlockNumber < smallestL2BlockNumber {
+		return
+	}
+
+	if len(m.mapping) < l2KeystonePriorityBufferMaxSize {
+		m.mapping[key] = val
+		return
+	}
+
+	delete(m.mapping, smallestKey)
+
+	m.mapping[key] = val
+}
+
+func (m *Miner) PopL2Keystone(ks hemi.L2Keystone) {
+	serialized := hemi.L2KeystoneAbbreviate(ks).Serialize()
+	key := hex.EncodeToString(serialized[:])
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	delete(m.mapping, key)
+}
+
+func (m *Miner) ForEachL2Keystone(cb func(ks hemi.L2Keystone)) {
+	m.mtx.Lock()
+	copies := []hemi.L2Keystone{}
+	for _, v := range m.mapping {
+		copies = append(copies, v)
+	}
+	m.mtx.Unlock()
+
+	// mine the newest keystone first
+	slices.SortFunc(copies, func(a, b hemi.L2Keystone) int {
+		return int(b.L2BlockNumber) - int(a.L2BlockNumber)
+	})
+
+	for _, e := range copies {
+		cb(e)
+	}
 }

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -47,7 +47,8 @@ const (
 )
 
 var (
-	log                    = loggo.GetLogger("popm")
+	log = loggo.GetLogger("popm")
+
 	l2KeystoneRetryTimeout = 15 * time.Second
 )
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -922,7 +922,7 @@ func (m *Miner) AddL2Keystone(val hemi.L2Keystone) {
 }
 
 // l2KeystonesForProcessing creates copies of the l2 keystones, set them to
-// "processing", then returns the copies
+// "processing", then returns the copies with the newest first
 func (m *Miner) l2KeystonesForProcessing() []hemi.L2Keystone {
 	m.mtx.Lock()
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -584,12 +584,13 @@ func TestProcessReceivedOnlyOnceWithError(t *testing.T) {
 	processedKeystonesFirstTime := 0
 	for _, c := range miner.l2KeystonesForProcessing() {
 		processedKeystonesFirstTime++
-		miner.mtx.Lock()
 		serialized := hemi.L2KeystoneAbbreviate(c).Serialize()
 		key := hex.EncodeToString(serialized[:])
-		v := miner.l2Keystones[key]
-		v.requiresProcessing = true
-		miner.l2Keystones[key] = v
+		miner.mtx.Lock()
+		if v, ok := miner.l2Keystones[key]; ok {
+			v.requiresProcessing = true
+			miner.l2Keystones[key] = v
+		}
 		miner.mtx.Unlock()
 	}
 	if processedKeystonesFirstTime != 3 {

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -138,7 +139,9 @@ func TestProcessReceivedKeystones(t *testing.T) {
 		},
 	}
 
-	miner := Miner{}
+	miner := Miner{
+		keystoneBuf: NewL2KeystonePriorityBuffer(10),
+	}
 
 	miner.processReceivedKeystones(context.Background(), firstBatchOfL2Keystones)
 	diff := deep.Equal(*miner.lastKeystone, hemi.L2Keystone{
@@ -496,18 +499,330 @@ func TestProcessReceivedInAscOrder(t *testing.T) {
 
 	receivedKeystones := []hemi.L2Keystone{}
 
-	for {
-		select {
-		case l2Keystone := <-miner.keystoneCh:
-			receivedKeystones = append(receivedKeystones, *l2Keystone)
-			continue
-		default:
-			break
-		}
-		break
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		receivedKeystones = append(receivedKeystones, ks)
+		return nil
+	})
+
+	slices.Reverse(receivedKeystones)
+	diff := deep.Equal(firstBatchOfL2Keystones, receivedKeystones)
+	if len(diff) != 0 {
+		t.Fatalf("received unexpected diff: %s", diff)
+	}
+}
+
+// TestProcessReceivedOnlyOnce ensures that we only process keystones once if
+// no error
+func TestProcessReceivedOnlyOnce(t *testing.T) {
+	keystones := []hemi.L2Keystone{
+		{
+			L2BlockNumber: 3,
+			EPHash:        []byte{3},
+		},
+		{
+			L2BlockNumber: 2,
+			EPHash:        []byte{2},
+		},
+		{
+			L2BlockNumber: 1,
+			EPHash:        []byte{1},
+		},
 	}
 
-	diff := deep.Equal(firstBatchOfL2Keystones, receivedKeystones)
+	miner, err := NewMiner(&Config{
+		BTCPrivateKey: "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641",
+		BTCChainName:  "testnet3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	miner.processReceivedKeystones(context.Background(), keystones)
+
+	processedKeystonesFirstTime := 0
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		processedKeystonesFirstTime++
+		return nil
+	})
+	if processedKeystonesFirstTime != 3 {
+		t.Fatalf("should have processed 3 keystones, processed %d", processedKeystonesFirstTime)
+	}
+
+	processedKeystonesSecondTime := 0
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		processedKeystonesSecondTime++
+		return nil
+	})
+
+	if processedKeystonesSecondTime != 0 {
+		t.Fatal("should have only processed the keystones once")
+	}
+}
+
+// TestProcessReceivedUntilError ensures that we retry until no error
+func TestProcessReceivedOnlyOnceWithError(t *testing.T) {
+	keystones := []hemi.L2Keystone{
+		{
+			L2BlockNumber: 3,
+			EPHash:        []byte{3},
+		},
+		{
+			L2BlockNumber: 2,
+			EPHash:        []byte{2},
+		},
+		{
+			L2BlockNumber: 1,
+			EPHash:        []byte{1},
+		},
+	}
+
+	miner, err := NewMiner(&Config{
+		BTCPrivateKey: "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641",
+		BTCChainName:  "testnet3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	miner.processReceivedKeystones(context.Background(), keystones)
+
+	processedKeystonesFirstTime := 0
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		processedKeystonesFirstTime++
+		return errors.New("something bad happened")
+	})
+	if processedKeystonesFirstTime != 3 {
+		t.Fatalf("should have processed 3 keystones, processed %d", processedKeystonesFirstTime)
+	}
+
+	processedKeystonesSecondTime := 0
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		processedKeystonesSecondTime++
+		return nil
+	})
+
+	if processedKeystonesSecondTime != 3 {
+		t.Fatalf("should have processed 3 keystones, processed %d", processedKeystonesSecondTime)
+	}
+
+	processedKeystonesThirdTime := 0
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		processedKeystonesThirdTime++
+		return nil
+	})
+
+	if processedKeystonesThirdTime != 0 {
+		t.Fatal("keystones should have already been processed")
+	}
+}
+
+// TestProcessReceivedNoDuplicates ensures that we don't queue a duplicate
+func TestProcessReceivedNoDuplicates(t *testing.T) {
+	keystones := []hemi.L2Keystone{
+		{
+			L2BlockNumber: 3,
+			EPHash:        []byte{3},
+		},
+		{
+			L2BlockNumber: 2,
+			EPHash:        []byte{2},
+		},
+		{
+			L2BlockNumber: 3,
+			EPHash:        []byte{3},
+		},
+	}
+
+	miner, err := NewMiner(&Config{
+		BTCPrivateKey: "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641",
+		BTCChainName:  "testnet3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receivedKeystones := []hemi.L2Keystone{}
+
+	miner.processReceivedKeystones(context.Background(), keystones)
+
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		receivedKeystones = append(receivedKeystones, ks)
+		return nil
+	})
+
+	slices.Reverse(keystones)
+
+	diff := deep.Equal([]hemi.L2Keystone{
+		{
+			L2BlockNumber: 3,
+			EPHash:        []byte{3},
+		},
+		{
+			L2BlockNumber: 2,
+			EPHash:        []byte{2},
+		},
+	}, receivedKeystones)
+	if len(diff) != 0 {
+		t.Fatalf("received unexpected diff: %s", diff)
+	}
+}
+
+// TestProcessReceivedInAscOrder ensures that if we queue more than 10 keystones
+// for mining, that we override the oldest
+func TestProcessReceivedInAscOrderOverride(t *testing.T) {
+	keystones := []hemi.L2Keystone{
+		{
+			L2BlockNumber: 1,
+			EPHash:        []byte{1},
+		},
+		{
+			L2BlockNumber: 2,
+			EPHash:        []byte{2},
+		},
+		{
+			L2BlockNumber: 3,
+			EPHash:        []byte{3},
+		},
+		{
+			L2BlockNumber: 4,
+			EPHash:        []byte{4},
+		},
+		{
+			L2BlockNumber: 5,
+			EPHash:        []byte{5},
+		},
+		{
+			L2BlockNumber: 6,
+			EPHash:        []byte{6},
+		},
+		{
+			L2BlockNumber: 7,
+			EPHash:        []byte{7},
+		},
+		{
+			L2BlockNumber: 8,
+			EPHash:        []byte{8},
+		},
+		{
+			L2BlockNumber: 9,
+			EPHash:        []byte{9},
+		},
+		{
+			L2BlockNumber: 10,
+			EPHash:        []byte{10},
+		},
+		{
+			L2BlockNumber: 11,
+			EPHash:        []byte{11},
+		},
+	}
+
+	miner, err := NewMiner(&Config{
+		BTCPrivateKey: "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641",
+		BTCChainName:  "testnet3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, keystone := range keystones {
+		miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{keystone})
+	}
+
+	receivedKeystones := []hemi.L2Keystone{}
+
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		receivedKeystones = append(receivedKeystones, ks)
+		return nil
+	})
+
+	slices.Reverse(keystones)
+
+	diff := deep.Equal(keystones[:10], receivedKeystones)
+	if len(diff) != 0 {
+		t.Fatalf("received unexpected diff: %s", diff)
+	}
+}
+
+// TestProcessReceivedInAscOrderNoInsertIfTooOld ensures that if the queue
+// is full, and we try to insert a keystone that is older than every other
+// keystone, we don't insert it
+func TestProcessReceivedInAscOrderNoInsertIfTooOld(t *testing.T) {
+	keystones := []hemi.L2Keystone{
+		{
+			L2BlockNumber: 1,
+			EPHash:        []byte{1},
+		},
+		{
+			L2BlockNumber: 2,
+			EPHash:        []byte{2},
+		},
+		{
+			L2BlockNumber: 3,
+			EPHash:        []byte{3},
+		},
+		{
+			L2BlockNumber: 4,
+			EPHash:        []byte{4},
+		},
+		{
+			L2BlockNumber: 5,
+			EPHash:        []byte{5},
+		},
+		{
+			L2BlockNumber: 6,
+			EPHash:        []byte{6},
+		},
+		{
+			L2BlockNumber: 7,
+			EPHash:        []byte{7},
+		},
+		{
+			L2BlockNumber: 8,
+			EPHash:        []byte{8},
+		},
+		{
+			L2BlockNumber: 9,
+			EPHash:        []byte{9},
+		},
+		{
+			L2BlockNumber: 10,
+			EPHash:        []byte{10},
+		},
+		{
+			L2BlockNumber: 11,
+			EPHash:        []byte{11},
+		},
+	}
+
+	miner, err := NewMiner(&Config{
+		BTCPrivateKey: "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641",
+		BTCChainName:  "testnet3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, keystone := range keystones {
+		miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{keystone})
+	}
+
+	// this one should be dropped
+	miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{
+		{
+			L2BlockNumber: 1,
+			EPHash:        []byte{1},
+		},
+	})
+
+	receivedKeystones := []hemi.L2Keystone{}
+
+	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+		receivedKeystones = append(receivedKeystones, ks)
+		return nil
+	})
+
+	slices.Reverse(keystones)
+
+	diff := deep.Equal(keystones[:10], receivedKeystones)
 	if len(diff) != 0 {
 		t.Fatalf("received unexpected diff: %s", diff)
 	}
@@ -523,7 +838,7 @@ func TestConnectToBFGAndPerformMineWithAuth(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	server, msgCh, cleanup := createMockBFG(ctx, t, []string{publicKey})
+	server, msgCh, cleanup := createMockBFG(ctx, t, []string{publicKey}, false, 1)
 	defer cleanup()
 
 	go func() {
@@ -587,7 +902,7 @@ func TestConnectToBFGAndPerformMine(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	server, msgCh, cleanup := createMockBFG(ctx, t, []string{})
+	server, msgCh, cleanup := createMockBFG(ctx, t, []string{}, false, 1)
 	defer cleanup()
 
 	go func() {
@@ -643,6 +958,71 @@ func TestConnectToBFGAndPerformMine(t *testing.T) {
 	}
 }
 
+func TestConnectToBFGAndPerformMineMultiple(t *testing.T) {
+	privateKey, err := dcrsecp256k1.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	server, msgCh, cleanup := createMockBFG(ctx, t, []string{}, false, 2)
+	defer cleanup()
+
+	go func() {
+		miner, err := NewMiner(&Config{
+			BFGWSURL:      server.URL + bfgapi.RouteWebsocketPublic,
+			BTCChainName:  "testnet3",
+			BTCPrivateKey: hex.EncodeToString(privateKey.Serialize()),
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		err = miner.Run(ctx)
+		if err != nil && err != context.Canceled {
+			panic(err)
+		}
+	}()
+
+	// we can't guarantee order here, so test that we get all expected messages
+	// from popm within the timeout
+
+	messagesReceived := make(map[string]int)
+
+	messagesExpected := map[protocol.Command]int{
+		EventConnected:                    1,
+		bfgapi.CmdL2KeystonesRequest:      1,
+		bfgapi.CmdBitcoinInfoRequest:      2,
+		bfgapi.CmdBitcoinBalanceRequest:   2,
+		bfgapi.CmdBitcoinUTXOsRequest:     2,
+		bfgapi.CmdBitcoinBroadcastRequest: 2,
+	}
+
+	for {
+		select {
+		case msg := <-msgCh:
+			t.Logf("received message %v", msg)
+			messagesReceived[msg]++
+		case <-ctx.Done():
+			if ctx.Err() != nil {
+				t.Fatal(ctx.Err())
+			}
+		}
+		missing := false
+		for m := range messagesExpected {
+			message := fmt.Sprintf("%s", m)
+			if messagesReceived[message] != messagesExpected[m] {
+				t.Logf("still missing message %v, found %d want %d", m, messagesReceived[message], messagesExpected[m])
+				missing = true
+			}
+		}
+		if missing == false {
+			break
+		}
+	}
+}
+
 func TestConnectToBFGAndPerformMineWithAuthError(t *testing.T) {
 	privateKey, err := dcrsecp256k1.GeneratePrivateKey()
 	if err != nil {
@@ -651,7 +1031,7 @@ func TestConnectToBFGAndPerformMineWithAuthError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	server, msgCh, cleanup := createMockBFG(ctx, t, []string{"incorrect"})
+	server, msgCh, cleanup := createMockBFG(ctx, t, []string{"incorrect"}, false, 1)
 	defer cleanup()
 
 	miner, err := NewMiner(&Config{
@@ -683,7 +1063,7 @@ func TestConnectToBFGAndPerformMineWithAuthError(t *testing.T) {
 	}
 }
 
-func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string) (*httptest.Server, chan string, func()) {
+func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string, keystoneMined bool, keystoneCount int) (*httptest.Server, chan string, func()) {
 	msgCh := make(chan string)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -770,13 +1150,13 @@ func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string) (*htt
 			}()
 
 			if command == bfgapi.CmdL2KeystonesRequest {
-				if err := bfgapi.Write(ctx, conn, id, bfgapi.L2KeystonesResponse{
-					L2Keystones: []hemi.L2Keystone{
-						{
-							L2BlockNumber: 100,
-						},
-					},
-				}); err != nil {
+				response := bfgapi.L2KeystonesResponse{}
+				for i := 0; i < keystoneCount; i++ {
+					response.L2Keystones = append(response.L2Keystones, hemi.L2Keystone{
+						L2BlockNumber: uint32(100 + i),
+					})
+				}
+				if err := bfgapi.Write(ctx, conn, id, response); err != nil {
 					if !errors.Is(ctx.Err(), context.Canceled) {
 						panic(err)
 					}
@@ -834,7 +1214,6 @@ func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string) (*htt
 					}
 				}
 			}
-
 		}
 	}
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -140,7 +140,7 @@ func TestProcessReceivedKeystones(t *testing.T) {
 	}
 
 	miner := Miner{
-		l2Keystones: make(map[string]hemi.L2Keystone),
+		l2Keystones: make(map[string]L2KeystoneProcessingContainer),
 	}
 
 	miner.processReceivedKeystones(context.Background(), firstBatchOfL2Keystones)
@@ -499,8 +499,9 @@ func TestProcessReceivedInAscOrder(t *testing.T) {
 
 	receivedKeystones := []hemi.L2Keystone{}
 
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		receivedKeystones = append(receivedKeystones, ks)
+		return nil
 	})
 
 	slices.Reverse(receivedKeystones)
@@ -538,16 +539,18 @@ func TestProcessReceivedOnlyOnce(t *testing.T) {
 	miner.processReceivedKeystones(context.Background(), keystones)
 
 	processedKeystonesFirstTime := 0
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		processedKeystonesFirstTime++
+		return nil
 	})
 	if processedKeystonesFirstTime != 3 {
 		t.Fatalf("should have processed 3 keystones, processed %d", processedKeystonesFirstTime)
 	}
 
 	processedKeystonesSecondTime := 0
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		processedKeystonesSecondTime++
+		return nil
 	})
 
 	if processedKeystonesSecondTime != 0 {
@@ -582,17 +585,19 @@ func TestProcessReceivedOnlyOnceWithError(t *testing.T) {
 	miner.processReceivedKeystones(context.Background(), keystones)
 
 	processedKeystonesFirstTime := 0
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		processedKeystonesFirstTime++
 		miner.AddL2Keystone(ks)
+		return errors.New("something wrong")
 	})
 	if processedKeystonesFirstTime != 3 {
 		t.Fatalf("should have processed 3 keystones, processed %d", processedKeystonesFirstTime)
 	}
 
 	processedKeystonesSecondTime := 0
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		processedKeystonesSecondTime++
+		return nil
 	})
 
 	if processedKeystonesSecondTime != 3 {
@@ -600,8 +605,9 @@ func TestProcessReceivedOnlyOnceWithError(t *testing.T) {
 	}
 
 	processedKeystonesThirdTime := 0
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		processedKeystonesThirdTime++
+		return nil
 	})
 
 	if processedKeystonesThirdTime != 0 {
@@ -638,8 +644,9 @@ func TestProcessReceivedNoDuplicates(t *testing.T) {
 
 	miner.processReceivedKeystones(context.Background(), keystones)
 
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		receivedKeystones = append(receivedKeystones, ks)
+		return nil
 	})
 
 	slices.Reverse(keystones)
@@ -723,8 +730,9 @@ func TestProcessReceivedInAscOrderOverride(t *testing.T) {
 
 	receivedKeystones := []hemi.L2Keystone{}
 
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		receivedKeystones = append(receivedKeystones, ks)
+		return nil
 	})
 
 	slices.Reverse(keystones)
@@ -808,8 +816,9 @@ func TestProcessReceivedInAscOrderNoInsertIfTooOld(t *testing.T) {
 
 	receivedKeystones := []hemi.L2Keystone{}
 
-	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) error {
 		receivedKeystones = append(receivedKeystones, ks)
+		return nil
 	})
 
 	slices.Reverse(keystones)

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -140,7 +140,7 @@ func TestProcessReceivedKeystones(t *testing.T) {
 	}
 
 	miner := Miner{
-		keystoneBuf: NewL2KeystonePriorityBuffer(10),
+		mapping: make(map[string]hemi.L2Keystone),
 	}
 
 	miner.processReceivedKeystones(context.Background(), firstBatchOfL2Keystones)
@@ -499,9 +499,9 @@ func TestProcessReceivedInAscOrder(t *testing.T) {
 
 	receivedKeystones := []hemi.L2Keystone{}
 
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		receivedKeystones = append(receivedKeystones, ks)
-		return nil
+		miner.PopL2Keystone(ks)
 	})
 
 	slices.Reverse(receivedKeystones)
@@ -539,18 +539,17 @@ func TestProcessReceivedOnlyOnce(t *testing.T) {
 	miner.processReceivedKeystones(context.Background(), keystones)
 
 	processedKeystonesFirstTime := 0
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		processedKeystonesFirstTime++
-		return nil
+		miner.PopL2Keystone(ks)
 	})
 	if processedKeystonesFirstTime != 3 {
 		t.Fatalf("should have processed 3 keystones, processed %d", processedKeystonesFirstTime)
 	}
 
 	processedKeystonesSecondTime := 0
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		processedKeystonesSecondTime++
-		return nil
 	})
 
 	if processedKeystonesSecondTime != 0 {
@@ -585,18 +584,17 @@ func TestProcessReceivedOnlyOnceWithError(t *testing.T) {
 	miner.processReceivedKeystones(context.Background(), keystones)
 
 	processedKeystonesFirstTime := 0
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		processedKeystonesFirstTime++
-		return errors.New("something bad happened")
 	})
 	if processedKeystonesFirstTime != 3 {
 		t.Fatalf("should have processed 3 keystones, processed %d", processedKeystonesFirstTime)
 	}
 
 	processedKeystonesSecondTime := 0
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		processedKeystonesSecondTime++
-		return nil
+		miner.PopL2Keystone(ks)
 	})
 
 	if processedKeystonesSecondTime != 3 {
@@ -604,9 +602,8 @@ func TestProcessReceivedOnlyOnceWithError(t *testing.T) {
 	}
 
 	processedKeystonesThirdTime := 0
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		processedKeystonesThirdTime++
-		return nil
 	})
 
 	if processedKeystonesThirdTime != 0 {
@@ -643,9 +640,9 @@ func TestProcessReceivedNoDuplicates(t *testing.T) {
 
 	miner.processReceivedKeystones(context.Background(), keystones)
 
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		receivedKeystones = append(receivedKeystones, ks)
-		return nil
+		miner.PopL2Keystone(ks)
 	})
 
 	slices.Reverse(keystones)
@@ -729,9 +726,9 @@ func TestProcessReceivedInAscOrderOverride(t *testing.T) {
 
 	receivedKeystones := []hemi.L2Keystone{}
 
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		receivedKeystones = append(receivedKeystones, ks)
-		return nil
+		miner.PopL2Keystone(ks)
 	})
 
 	slices.Reverse(keystones)
@@ -815,9 +812,9 @@ func TestProcessReceivedInAscOrderNoInsertIfTooOld(t *testing.T) {
 
 	receivedKeystones := []hemi.L2Keystone{}
 
-	miner.keystoneBuf.ForEach(func(ks hemi.L2Keystone) error {
+	miner.ForEachL2Keystone(func(ks hemi.L2Keystone) {
 		receivedKeystones = append(receivedKeystones, ks)
-		return nil
+		miner.PopL2Keystone(ks)
 	})
 
 	slices.Reverse(keystones)

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -742,6 +742,30 @@ func TestProcessReceivedInAscOrderOverride(t *testing.T) {
 	}
 }
 
+func TestProcesAllKeystonesIfAble(t *testing.T) {
+	miner, err := NewMiner(&Config{
+		BTCPrivateKey: "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641",
+		BTCChainName:  "testnet3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := uint32(1); i < 1000; i++ {
+		keystone := hemi.L2Keystone{
+			L2BlockNumber: i,
+			EPHash:        []byte{byte(i)},
+		}
+		miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{keystone})
+		for _, c := range miner.l2KeystonesForProcessing() {
+			diff := deep.Equal(c, keystone)
+			if len(diff) != 0 {
+				t.Fatalf("unexpected diff: %s", diff)
+			}
+		}
+	}
+}
+
 // TestProcessReceivedInAscOrderNoInsertIfTooOld ensures that if the queue
 // is full, and we try to insert a keystone that is older than every other
 // keystone, we don't insert it

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -1050,10 +1050,10 @@ func TestConnectToBFGAndPerformMineALot(t *testing.T) {
 	messagesExpected := map[protocol.Command]int{
 		EventConnected:                    1,
 		bfgapi.CmdL2KeystonesRequest:      1,
-		bfgapi.CmdBitcoinInfoRequest:      l2KeystonePriorityBufferMaxSize,
-		bfgapi.CmdBitcoinBalanceRequest:   l2KeystonePriorityBufferMaxSize,
-		bfgapi.CmdBitcoinUTXOsRequest:     l2KeystonePriorityBufferMaxSize,
-		bfgapi.CmdBitcoinBroadcastRequest: l2KeystonePriorityBufferMaxSize,
+		bfgapi.CmdBitcoinInfoRequest:      l2KeystonesMaxSize,
+		bfgapi.CmdBitcoinBalanceRequest:   l2KeystonesMaxSize,
+		bfgapi.CmdBitcoinUTXOsRequest:     l2KeystonesMaxSize,
+		bfgapi.CmdBitcoinBroadcastRequest: l2KeystonesMaxSize,
 	}
 
 	for {


### PR DESCRIPTION
**Summary**
We need a way to retry mining keystones if they fail, this provides a solution.

Fixes #7 

**Changes**
* keep buffer of 10 newest keystones known
* upon receiving a keystone, only insert into buffer if it is newer than the oldest keystone
* if buffer is full, drop oldest keystone upon inserting another
* when a keystone is mined, mark it as "processed" to not repeat mining same keystone
* generate fewer btc blocks in full network e2e test, since we have a retry strategy now 
* remove retry from full network e2e test
