### PR TITLE
allowing BTC Block and L2 Keystone generation rates to be configurable in local network

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,19 @@ bssd has a few crucial requirements to run:
 Prerequisites: `docker`
 
 To run the full network locally, you can run the following.  Note that this will create
-L2Keytones and BTC Blocks at a high rate.  You can modify these in `./e2e/mocktimism/mocktimism.go`
-or `./e2e/docker-compose.yml`.
+L2Keytones and BTC Blocks at a high rate.  
+
+You can modify these via the env variables:
+* `HEMI_LOCAL_BTC_RATE_SECONDS`: generate new BTC Block at this rate of seconds
+* `HEMI_LOCAL_L2K_RATE_SECONDS`: generate new L2 Keystone at this rate of seconds
 
 note: the `--build` flag is optional if you want to rebuild your code
 
 ```
 docker-compose -f ./e2e/docker-compose.yml up --build
 ```
+
+
 
 ### Running the full network tests
 

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     deploy:
       restart_policy:
         condition: any
-        delay: 5s
+        delay: "${HEMI_LOCAL_BTC_RATE_SECONDS:-5}s"
     depends_on:
       - bitcoind
 
@@ -74,7 +74,7 @@ services:
       context: ./..
     environment:
       BFG_POSTGRES_URI: postgres://postgres@postgres:5432/bfg?sslmode=disable
-      BFG_BTC_START_HEIGHT: "100"
+      BFG_BTC_START_HEIGHT: "1"
       BFG_EXBTC_ADDRESS: electrumx:50001
       BFG_LOG_LEVEL: TRACE
       BFG_PUBLIC_ADDRESS: ":8383"
@@ -115,6 +115,7 @@ services:
       context: ./..
     environment:
       MOCKTIMISM_BSS_URL: http://bssd:8081/v1/ws
+      MOCKTIMISM_L2K_RATE_SECONDS: ${HEMI_LOCAL_L2K_RATE_SECONDS}
     depends_on:
       - bssd
 

--- a/e2e/mocktimism/mocktimism.go
+++ b/e2e/mocktimism/mocktimism.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -89,7 +91,7 @@ func main() {
 			l2Keystone.L1BlockNumber++
 			l2Keystone.L2BlockNumber++
 
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Duration(l2BlockCreationSeconds()) * time.Second)
 
 			err = bssapi.Write(ctx, bws.conn, "someotherid", bssapi.PopPayoutsRequest{
 				L2BlockForPayout: firstL2Keystone[:],
@@ -121,4 +123,18 @@ func fillOutBytes(prefix string, size int) []byte {
 	}
 
 	return result
+}
+
+func l2BlockCreationSeconds() int {
+	v := os.Getenv("MOCKTIMISM_L2K_RATE_SECONDS")
+	if v == "" {
+		return 1
+	}
+
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		panic(fmt.Sprintf("invalid value for seconds: %s", v))
+	}
+
+	return i
 }


### PR DESCRIPTION
**Summary**
As of now, we generate L2 Keystones and BTC Blocks at a high rate in the local network, and we don't make it easily configurable to change. This PR gives us that ease.

**Changes**
when running your local network via docker-compose, you can set the following env variables to configure the rates at which BTC Blocks and L2 Keystones are generated, respectively.

* HEMI_LOCAL_BTC_RATE_SECONDS
* HEMI_LOCAL_L2K_RATE_SECONDS

fixes #17 
