### PR TITLE
Network test start height + no panic

### DIFF
--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -232,7 +232,8 @@ func TestFullNetwork(t *testing.T) {
 			select {
 			case <-time.After(10 * time.Second):
 			case <-ctx.Done():
-				panic(ctx.Err())
+				t.Log(ctx.Err())
+				return
 			}
 
 			// generate a new btc block, this should include the l2 keystone
@@ -258,7 +259,8 @@ func TestFullNetwork(t *testing.T) {
 			select {
 			case <-time.After(10 * time.Second):
 			case <-ctx.Done():
-				panic(ctx.Err())
+				t.Log(ctx.Err())
+				return
 			}
 
 			// ensure the l2 keystone is in the chain
@@ -383,7 +385,7 @@ func createBfg(ctx context.Context, t *testing.T, pgUri string, electrumxAddr st
 	req := testcontainers.ContainerRequest{
 		Env: map[string]string{
 			"BFG_POSTGRES_URI":     pgUri,
-			"BFG_BTC_START_HEIGHT": "100",
+			"BFG_BTC_START_HEIGHT": "5000",
 			"BFG_EXBTC_ADDRESS":    electrumxAddr,
 			"BFG_LOG_LEVEL":        "TRACE",
 			"BFG_PUBLIC_ADDRESS":   ":8383",


### PR DESCRIPTION
**Summary**
Upon testing with @joshuasing , I realized that we generate 5000 btc blocks in our test, but we tell bfg to start at block 100.  This causes bfg to take too long to catch up.

Also, don't panic in go routines if the context is done, this can cause tests to fail when they shouldn't

**Changes** 
* start bfg btc height high so we don't take too long to process
* don't panic in go routines if context is done
