### PR TITLE
docker: update golang image to v1.22.1

### DIFF
--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22.0-alpine@sha256:8e96e6cff6a388c2f70f5f662b64120941fcd7d4b89d62fec87520323a316bd9 as builder
+FROM golang:1.22.1-alpine@sha256:fc5e5848529786cf1136563452b33d713d5c60b2c787f6b2a077fa6eeefd9114 as builder
 
 # Add ca-certificates, timezone data, make and git
 RUN apk --no-cache add --update ca-certificates tzdata make git

--- a/docker/bssd/Dockerfile
+++ b/docker/bssd/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22.0-alpine@sha256:8e96e6cff6a388c2f70f5f662b64120941fcd7d4b89d62fec87520323a316bd9 as builder
+FROM golang:1.22.1-alpine@sha256:fc5e5848529786cf1136563452b33d713d5c60b2c787f6b2a077fa6eeefd9114 as builder
 
 # Add ca-certificates, timezone data, make and git
 RUN apk --no-cache add --update ca-certificates tzdata make git

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22.0-alpine@sha256:8e96e6cff6a388c2f70f5f662b64120941fcd7d4b89d62fec87520323a316bd9 as builder
+FROM golang:1.22.1-alpine@sha256:fc5e5848529786cf1136563452b33d713d5c60b2c787f6b2a077fa6eeefd9114 as builder
 
 # Add ca-certificates, timezone data, make and git
 RUN apk --no-cache add --update ca-certificates tzdata make git


### PR DESCRIPTION
**Summary**
Update `golang` image to `1.22.1-alpine`.

Release notes: https://go.dev/doc/devel/release#go1.22.1
More information: https://github.com/golang/go/issues?q=milestone%3AGo1.22.1+label%3ACherryPickApproved

This release contains security fixes.

**Changes**
- Update `golang` image to `golang:1.22.1-alpine@sha256:fc5e5848529786cf1136563452b33d713d5c60b2c787f6b2a077fa6eeefd9114`
