### PR TITLE
Use '%w' verb in fmt.Errorf to wrap errors (fixes #13)

### DIFF
--- a/api/auth/secp256k1.go
+++ b/api/auth/secp256k1.go
@@ -145,7 +145,7 @@ func (s *Secp256k1Auth) HandshakeClient(ctx context.Context, conn protocol.APICo
 	for {
 		_, _, payload, err := protocol.Read(ctx, conn, s)
 		if err != nil {
-			return fmt.Errorf("read: %v", err)
+			return fmt.Errorf("read: %w", err)
 		}
 		log.Tracef(spew.Sdump(payload))
 
@@ -158,13 +158,13 @@ func (s *Secp256k1Auth) HandshakeClient(ctx context.Context, conn protocol.APICo
 
 			hca, err := handleSecp256k1HelloChallenge(s.privKey, c)
 			if err != nil {
-				return fmt.Errorf("handleSecp256k1HelloChallenge: %v", err)
+				return fmt.Errorf("handleSecp256k1HelloChallenge: %w", err)
 			}
 
 			requestID := "HelloChallengeAccepted:" + pubKey
 			err = protocol.Write(ctx, conn, s, requestID, hca)
 			if err != nil {
-				return fmt.Errorf("write HelloChallengeAccepted: %v", err)
+				return fmt.Errorf("write HelloChallengeAccepted: %w", err)
 			}
 
 			// Exit state machine
@@ -186,7 +186,7 @@ func (s *Secp256k1Auth) HandshakeServer(ctx context.Context, conn protocol.APICo
 	for {
 		_, _, payload, err := protocol.Read(ctx, conn, s)
 		if err != nil {
-			return fmt.Errorf("read: %v", err)
+			return fmt.Errorf("read: %w", err)
 		}
 		log.Tracef(spew.Sdump(payload))
 
@@ -206,7 +206,7 @@ func (s *Secp256k1Auth) HandshakeServer(ctx context.Context, conn protocol.APICo
 			err = protocol.Write(ctx, conn, s,
 				"HelloChallenge:"+c.PublicKey, hc)
 			if err != nil {
-				return fmt.Errorf("write HelloChallenge: %v", err)
+				return fmt.Errorf("write HelloChallenge: %w", err)
 			}
 
 		case *Secp256k1HelloChallengeAccepted:
@@ -220,7 +220,7 @@ func (s *Secp256k1Auth) HandshakeServer(ctx context.Context, conn protocol.APICo
 
 			derived, err := handleSecp256k1HelloChallengeAccepted(am, c)
 			if err != nil {
-				return fmt.Errorf("handleSecp256k1HelloChallengeAccepted: %v", err)
+				return fmt.Errorf("handleSecp256k1HelloChallengeAccepted: %w", err)
 			}
 
 			// Exit state machine

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -411,7 +411,7 @@ func (ac *Conn) Connect(ctx context.Context) error {
 	log.Tracef("Connect: dialing %v", ac.serverURL)
 	conn, _, err := websocket.Dial(connectCtx, ac.serverURL, nil)
 	if err != nil {
-		return fmt.Errorf("failed to dial server: %v", err)
+		return fmt.Errorf("failed to dial server: %w", err)
 	}
 	conn.SetReadLimit(512 * 1024) // XXX - default is 32KB
 	defer func() {

--- a/bitcoin/bitcoin.go
+++ b/bitcoin/bitcoin.go
@@ -117,14 +117,14 @@ func SignTx(btx *wire.MsgTx, payToScript []byte, privateKey *dcrsecp256k1.Privat
 		txscript.SigHashAll, btx, 0,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to calculate signature hash: %v", err)
+		return fmt.Errorf("failed to calculate signature hash: %w", err)
 	}
 	pubKeyBytes := publicKey.SerializeCompressed()
 	sig := dcrecdsa.Sign(privateKey, sigHash)
 	sigBytes := append(sig.Serialize(), byte(txscript.SigHashAll))
 	sb := txscript.NewScriptBuilder().AddData(sigBytes).AddData(pubKeyBytes)
 	if btx.TxIn[0].SignatureScript, err = sb.Script(); err != nil {
-		return fmt.Errorf("failed to build signature script: %v", err)
+		return fmt.Errorf("failed to build signature script: %w", err)
 	}
 	return nil
 }
@@ -150,14 +150,14 @@ func PrivKeyFromHexString(s string) (*dcrsecp256k1.PrivateKey, error) {
 func KeysAndAddressFromHexString(s string, chainParams *chaincfg.Params) (*dcrsecp256k1.PrivateKey, *dcrsecp256k1.PublicKey, *btcutil.AddressPubKeyHash, error) {
 	privKey, err := PrivKeyFromHexString(s)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid BTC private key: %v", err)
+		return nil, nil, nil, fmt.Errorf("invalid BTC private key: %w", err)
 	}
 
 	pubKeyBytes := privKey.PubKey().SerializeCompressed()
 	btcAddress, err := btcutil.NewAddressPubKey(pubKeyBytes, chainParams)
 	if err != nil {
 		return nil, nil, nil,
-			fmt.Errorf("failed to create BTC address from public key: %v", err)
+			fmt.Errorf("failed to create BTC address from public key: %w", err)
 	}
 
 	return privKey, privKey.PubKey(), btcAddress.AddressPubKeyHash(), nil

--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -124,10 +124,10 @@ func _main() error {
 
 	server, err := bfg.NewServer(cfg)
 	if err != nil {
-		return fmt.Errorf("Failed to create BFG server: %v", err)
+		return fmt.Errorf("failed to create BFG server: %w", err)
 	}
 	if err := server.Run(ctx); err != context.Canceled {
-		return fmt.Errorf("BFG server terminated: %v", err)
+		return fmt.Errorf("BFG server terminated: %w", err)
 	}
 
 	return nil

--- a/cmd/bssd/bssd.go
+++ b/cmd/bssd/bssd.go
@@ -99,10 +99,10 @@ func _main() error {
 
 	server, err := bss.NewServer(cfg)
 	if err != nil {
-		return fmt.Errorf("Failed to create BSS server: %v", err)
+		return fmt.Errorf("failed to create BSS server: %w", err)
 	}
 	if err := server.Run(ctx); err != context.Canceled {
-		return fmt.Errorf("BSS server terminated with error: %v", err)
+		return fmt.Errorf("BSS server terminated with error: %w", err)
 	}
 
 	return nil

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -93,24 +93,24 @@ func bfgdb() error {
 		// construct pgURI based on reasonable defaults.
 		home, err := homedir.Dir()
 		if err != nil {
-			return fmt.Errorf("Dir: %v", err)
+			return fmt.Errorf("dir: %w", err)
 		}
 		user, err := user.Current()
 		if err != nil {
-			return fmt.Errorf("Current: %v", err)
+			return fmt.Errorf("current: %w", err)
 		}
 
 		filename := filepath.Join(home, ".pgsql-bfgdb-"+user.Username)
 		password, err := os.ReadFile(filename)
 		if err != nil {
-			return fmt.Errorf("ReadFile: %v", err)
+			return fmt.Errorf("read file: %w", err)
 		}
 		pgURI = fmt.Sprintf("database=bfgdb password=%s", password)
 	}
 
 	db, err := postgres.New(ctx, pgURI)
 	if err != nil {
-		return fmt.Errorf("New: %v", err)
+		return fmt.Errorf("new: %w", err)
 	}
 	defer db.Close()
 
@@ -130,7 +130,7 @@ func bfgdb() error {
 
 	o, err := json.Marshal(out)
 	if err != nil {
-		return fmt.Errorf("marshal: %v", err)
+		return fmt.Errorf("marshal: %w", err)
 	}
 	fmt.Printf("%s\n", o)
 
@@ -187,7 +187,7 @@ func (bsc *bssClient) connect(ctx context.Context) error {
 	//	Timestamp: time.Now().Unix(),
 	// })
 	// if err != nil {
-	//	return fmt.Errorf("ping error: %v", err)
+	//	return fmt.Errorf("ping error: %w", err)
 	// }
 
 	simulatePingPong := false
@@ -210,7 +210,7 @@ func (bsc *bssClient) connect(ctx context.Context) error {
 				if err != nil {
 					log.Errorf("ping error: %v", err)
 					continue
-					// return fmt.Errorf("ping error: %v", err)
+					// return fmt.Errorf("ping error: %w", err)
 				}
 			}
 		}()

--- a/cmd/keygen/keygen.go
+++ b/cmd/keygen/keygen.go
@@ -48,7 +48,7 @@ func _main() error {
 	case *secp256k1KeyPair:
 		privKey, err := dcrsecpk256k1.GeneratePrivateKey()
 		if err != nil {
-			return fmt.Errorf("Failed to generate secp256k1 private key: %v", err)
+			return fmt.Errorf("failed to generate secp256k1 private key: %w", err)
 		}
 		btcAddress, err := btcutil.NewAddressPubKey(privKey.PubKey().SerializeCompressed(),
 			btcChainParams)
@@ -75,7 +75,7 @@ func _main() error {
 			}
 			js, err := json.MarshalIndent(s, "", "  ")
 			if err != nil {
-				return fmt.Errorf("marshal: %v", err)
+				return fmt.Errorf("marshal: %w", err)
 			}
 			fmt.Printf("%s\n", js)
 		} else {

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -103,10 +103,10 @@ func _main() error {
 
 	miner, err := popm.NewMiner(cfg)
 	if err != nil {
-		return fmt.Errorf("Failed to create POP miner: %v", err)
+		return fmt.Errorf("failed to create POP miner: %w", err)
 	}
 	if err := miner.Run(ctx); err != context.Canceled {
-		return fmt.Errorf("POP miner terminated: %v", err)
+		return fmt.Errorf("POP miner terminated: %w", err)
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -37,11 +37,11 @@ func Parse(c CfgMap) error {
 	for k, v := range c {
 		// Make sure v.Value is a pointer
 		if reflect.TypeOf(v.Value).Kind() != reflect.Pointer {
-			return fmt.Errorf("Value must be a pointer")
+			return fmt.Errorf("value must be a pointer")
 		}
 		// Make sure we are pointing to the same type
 		if reflect.TypeOf(v.Value).Elem() != reflect.TypeOf(v.DefaultValue) {
-			return fmt.Errorf("Value not the same type as DefaultValue, "+
+			return fmt.Errorf("value not the same type as DefaultValue, "+
 				"wanted %v got %v", reflect.TypeOf(v.Value).Elem(),
 				reflect.TypeOf(v.DefaultValue))
 		}

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -164,11 +164,11 @@ func (p *pgdb) L2KeystonesInsert(ctx context.Context, l2ks []bfgd.L2Keystone) er
 				log.Errorf("integrity violation occurred: %s", err.Constraint)
 				return database.DuplicateError(fmt.Sprintf("constraint error: %s", err))
 			}
-			return fmt.Errorf("failed to insert l2 keystone: %v", err)
+			return fmt.Errorf("failed to insert l2 keystone: %w", err)
 		}
 		rows, err := result.RowsAffected()
 		if err != nil {
-			return fmt.Errorf("failed to insert l2 keystone rows affected: %v", err)
+			return fmt.Errorf("failed to insert l2 keystone rows affected: %w", err)
 		}
 		if rows < 1 {
 			return fmt.Errorf("failed to insert l2 keystone rows: %v", rows)
@@ -285,11 +285,11 @@ func (p *pgdb) BtcBlockInsert(ctx context.Context, bb *bfgd.BtcBlock) error {
 		if err, ok := err.(*pq.Error); ok && err.Code.Class().Name() == "integrity_constraint_violation" {
 			return database.DuplicateError(fmt.Sprintf("duplicate btc block entry: %s", err))
 		}
-		return fmt.Errorf("failed to insert btc block: %v", err)
+		return fmt.Errorf("failed to insert btc block: %w", err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to insert btc block rows affected: %v", err)
+		return fmt.Errorf("failed to insert btc block rows affected: %w", err)
 	}
 	if rows < 1 {
 		return fmt.Errorf("failed to insert btc block rows: %v", rows)
@@ -364,11 +364,11 @@ func (p *pgdb) PopBasisInsertPopMFields(ctx context.Context, pb *bfgd.PopBasis) 
 				return database.DuplicateError(fmt.Sprintf("duplicate pop block entry: %s", err.Error()))
 			}
 		}
-		return fmt.Errorf("failed to insert pop block: %v", err)
+		return fmt.Errorf("failed to insert pop block: %w", err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to insert pop block rows affected: %v", err)
+		return fmt.Errorf("failed to insert pop block rows affected: %w", err)
 	}
 	if rows < 1 {
 		return fmt.Errorf("failed to insert pop block rows: %v", rows)
@@ -416,12 +416,12 @@ func (p *pgdb) PopBasisUpdateBTCFields(ctx context.Context, pb *bfgd.PopBasis) (
 				return 0, database.DuplicateError(fmt.Sprintf("duplicate pop block entry: %s", err.Error()))
 			}
 		}
-		return 0, fmt.Errorf("failed to insert pop block: %v", err)
+		return 0, fmt.Errorf("failed to insert pop block: %w", err)
 	}
 
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return 0, fmt.Errorf("failed to insert pop block rows affected: %v", err)
+		return 0, fmt.Errorf("failed to insert pop block rows affected: %w", err)
 	}
 
 	return rows, nil
@@ -464,11 +464,11 @@ func (p *pgdb) PopBasisInsertFull(ctx context.Context, pb *bfgd.PopBasis) error 
 				return database.DuplicateError(fmt.Sprintf("duplicate pop block entry: %s", err.Error()))
 			}
 		}
-		return fmt.Errorf("failed to insert pop block: %v", err)
+		return fmt.Errorf("failed to insert pop block: %w", err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to insert pop block rows affected: %v", err)
+		return fmt.Errorf("failed to insert pop block rows affected: %w", err)
 	}
 	if rows < 1 {
 		return fmt.Errorf("failed to insert pop block rows: %v", rows)

--- a/database/database.go
+++ b/database/database.go
@@ -119,10 +119,10 @@ func (ba ByteArray) Value() (driver.Value, error) {
 	return []byte(ba), nil
 }
 
-//// XXX figure out why this doens't work
-//func (ba *ByteArray) Value() (driver.Value, error) {
+// // XXX figure out why this doens't work
+// func (ba *ByteArray) Value() (driver.Value, error) {
 //	return *ba, nil
-//}
+// }
 
 var _ driver.Valuer = (*ByteArray)(nil)
 
@@ -320,7 +320,7 @@ func (tz *TimeZone) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if err := tz.Parse(s); err != nil {
-		return fmt.Errorf("invalid timezone: %v", err)
+		return fmt.Errorf("invalid timezone: %w", err)
 	}
 	return nil
 }
@@ -335,7 +335,7 @@ func (tz *TimeZone) Scan(value interface{}) error {
 		return fmt.Errorf("not a string (%T)", value)
 	}
 	if err := tz.Parse(s); err != nil {
-		return fmt.Errorf("invalid timezone: %v", err)
+		return fmt.Errorf("invalid timezone: %w", err)
 	}
 	return nil
 }

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -54,10 +54,10 @@ type Database struct {
 func Connect(ctx context.Context, uri string) (*sql.DB, error) {
 	pool, err := sql.Open("postgres", uri)
 	if err != nil {
-		return nil, fmt.Errorf("postgres open: %v", err)
+		return nil, fmt.Errorf("postgres open: %w", err)
 	}
 	if err := pool.PingContext(ctx); err != nil {
-		return nil, fmt.Errorf("unable to connect to database: %v", err)
+		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}
 	return pool, nil
 }
@@ -256,13 +256,13 @@ func New(ctx context.Context, puri string, version int) (*Database, error) {
 	// Setup and connect to database.
 	pool, err := sql.Open("postgres", puri)
 	if err != nil {
-		return nil, fmt.Errorf("postgres open: %v", err)
+		return nil, fmt.Errorf("postgres open: %w", err)
 	}
 	pool.SetConnMaxLifetime(0)
 	pool.SetMaxIdleConns(5)
 	pool.SetMaxOpenConns(5)
 	if err := pool.PingContext(ctx); err != nil {
-		return nil, fmt.Errorf("unable to connect to database: %v", err)
+		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}
 
 	// Verify version.

--- a/hemi/pop/pop.go
+++ b/hemi/pop/pop.go
@@ -23,7 +23,7 @@ type MinerAddress [20]byte
 func MinerAddressFromString(address string) (*MinerAddress, error) {
 	b, err := hex.DecodeString(address)
 	if err != nil {
-		return nil, fmt.Errorf("invalid miner address: %v", err)
+		return nil, fmt.Errorf("invalid miner address: %w", err)
 	}
 
 	var ma MinerAddress
@@ -87,7 +87,7 @@ func ParseTransactionL2FromOpReturn(script []byte) (*TransactionL2, error) {
 	}
 	ksh, err := hemi.NewL2KeystoneAbrevFromBytes(data[4:])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse keystone header: %v", err)
+		return nil, fmt.Errorf("failed to parse keystone header: %w", err)
 	}
 	return &TransactionL2{L2Keystone: ksh}, nil
 }
@@ -142,7 +142,7 @@ func ParseTransactionFromOpReturn(script []byte) (*Transaction, error) {
 	}
 	ksh, err := hemi.NewHeaderFromBytes(data[4:])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse keystone header: %v", err)
+		return nil, fmt.Errorf("failed to parse keystone header: %w", err)
 	}
 	return &Transaction{Keystone: ksh}, nil
 }

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -181,7 +181,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	var err error
 	s.btcClient, err = electrumx.NewClient(cfg.EXBTCAddress)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create electrumx client: %v", err)
+		return nil, fmt.Errorf("failed to create electrumx client: %w", err)
 	}
 
 	// We could use a PGURI verification here.
@@ -468,7 +468,7 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 				// in a block, so hopefully we've got them all...
 				return nil
 			}
-			return fmt.Errorf("failed to get transaction at position (height %v, index %v): %v", height, index, err)
+			return fmt.Errorf("failed to get transaction at position (height %v, index %v): %w", height, index, err)
 		}
 
 		txHashEncoded := hex.EncodeToString(txHash)
@@ -491,7 +491,7 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 
 		rtx, err := s.btcClient.RawTransaction(ctx, txHash)
 		if err != nil {
-			return fmt.Errorf("failed to get raw transaction with txid %x: %v", txHash, err)
+			return fmt.Errorf("failed to get raw transaction with txid %x: %w", txHash, err)
 		}
 
 		log.Infof("got raw transaction with txid %x", txHash)
@@ -569,7 +569,7 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 func (s *Server) processBitcoinBlocks(ctx context.Context, start, end uint64) error {
 	for i := start; i <= end; i++ {
 		if err := s.processBitcoinBlock(ctx, i); err != nil {
-			return fmt.Errorf("failed to process bitcoin block at height %d: %v", i, err)
+			return fmt.Errorf("failed to process bitcoin block at height %d: %w", i, err)
 		}
 		s.btcHeight = i
 	}
@@ -1345,7 +1345,7 @@ func (s *Server) Run(pctx context.Context) error {
 	var err error
 	s.db, err = postgres.New(ctx, s.cfg.PgURI)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to database: %v", err)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer s.db.Close()
 

--- a/service/bfg/bfg_test.go
+++ b/service/bfg/bfg_test.go
@@ -34,11 +34,11 @@ func checkBitcoinFinality(bf *BitcoinFinality) error {
 	// Parse BTC block header and transaction.
 	btcHeader := &btcwire.BlockHeader{}
 	if err := btcHeader.Deserialize(bytes.NewReader(bf.BTCRawBlockHeader)); err != nil {
-		return fmt.Errorf("failed to deserialize BTC header: %v", err)
+		return fmt.Errorf("failed to deserialize BTC header: %w", err)
 	}
 	btcTransaction := &btcwire.MsgTx{}
 	if err := btcTransaction.Deserialize(bytes.NewReader(bf.BTCRawTransaction)); err != nil {
-		return fmt.Errorf("failed to deserialize BTC transaction: %v", err)
+		return fmt.Errorf("failed to deserialize BTC transaction: %w", err)
 	}
 	btcTxHash := btcchainhash.DoubleHashB(bf.BTCRawTransaction)
 
@@ -48,7 +48,7 @@ func checkBitcoinFinality(bf *BitcoinFinality) error {
 		merkleHashes = append(merkleHashes, merkleHash)
 	}
 	if err := bitcoin.CheckMerkleChain(btcTxHash, bf.BTCTransactionIndex, merkleHashes, btcHeader.MerkleRoot[:]); err != nil {
-		return fmt.Errorf("failed to verify merkle path for transaction: %v", err)
+		return fmt.Errorf("failed to verify merkle path for transaction: %w", err)
 	}
 
 	// XXX - verify HEMI keystone header and PoP miner public key.

--- a/service/deucalion/deucalion.go
+++ b/service/deucalion/deucalion.go
@@ -69,7 +69,7 @@ var (
 
 func init() {
 	if err := config.Parse(cm); err != nil {
-		panic(fmt.Errorf("could not parse config during init: %v", err))
+		panic(fmt.Errorf("could not parse config during init: %w", err))
 	}
 	if cfg.ListenAddress == "" {
 		return
@@ -81,7 +81,7 @@ func init() {
 	ctx := context.Background()
 	d, err := New(cfg)
 	if err != nil {
-		panic(fmt.Errorf("failed to create server: %v", err))
+		panic(fmt.Errorf("failed to create server: %w", err))
 	}
 	go func() {
 		if err = d.Run(ctx, nil); !errors.Is(err, context.Canceled) {

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -262,7 +262,7 @@ func createTx(l2Keystone *hemi.L2Keystone, btcHeight uint64, utxo *bfgapi.Bitcoi
 	popTx := pop.TransactionL2{L2Keystone: aks}
 	popTxOpReturn, err := popTx.EncodeToOpReturn()
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode PoP transaction: %v", err)
+		return nil, fmt.Errorf("failed to encode PoP transaction: %w", err)
 	}
 	btx.TxOut = append(btx.TxOut, btcwire.NewTxOut(0, popTxOpReturn))
 
@@ -278,12 +278,12 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 
 	btcHeight, err := m.bitcoinHeight(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get Bitcoin height: %v", err)
+		return fmt.Errorf("failed to get Bitcoin height: %w", err)
 	}
 
 	payToScript, err := btctxscript.PayToAddrScript(m.btcAddress)
 	if err != nil {
-		return fmt.Errorf("failed to get pay to address script: %v", err)
+		return fmt.Errorf("failed to get pay to address script: %w", err)
 	}
 	if len(payToScript) != 25 {
 		return fmt.Errorf("incorrect length for pay to public key script (%d != 25)", len(payToScript))
@@ -298,7 +298,7 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 	// Check balance.
 	confirmed, unconfirmed, err := m.bitcoinBalance(ctx, scriptHash[:])
 	if err != nil {
-		return fmt.Errorf("failed to get Bitcoin balance: %v", err)
+		return fmt.Errorf("failed to get Bitcoin balance: %w", err)
 	}
 	log.Tracef("Bitcoin balance for miner is: %v confirmed, %v unconfirmed", confirmed, unconfirmed)
 
@@ -306,7 +306,7 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 	log.Tracef("Looking for UTXOs for script hash %v", scriptHash)
 	utxos, err := m.bitcoinUTXOs(ctx, scriptHash[:])
 	if err != nil {
-		return fmt.Errorf("failed to get Bitcoin UTXOs: %v", err)
+		return fmt.Errorf("failed to get Bitcoin UTXOs: %w", err)
 	}
 
 	log.Tracef("Found %d UTXOs at Bitcoin height %d", len(utxos), btcHeight)
@@ -317,7 +317,7 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 
 	utxos, err = pickUTXOs(utxos, feeAmount)
 	if err != nil {
-		return fmt.Errorf("failed to pick UTXOs: %v", err)
+		return fmt.Errorf("failed to pick UTXOs: %w", err)
 	}
 
 	if len(utxos) != 1 {
@@ -339,7 +339,7 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 	// broadcast tx
 	var buf bytes.Buffer
 	if err := btx.Serialize(&buf); err != nil {
-		return fmt.Errorf("failed to serialize Bitcoin transaction: %v", err)
+		return fmt.Errorf("failed to serialize Bitcoin transaction: %w", err)
 	}
 	txb := buf.Bytes()
 
@@ -347,11 +347,11 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 
 	txh, err := m.bitcoinBroadcast(ctx, txb)
 	if err != nil {
-		return fmt.Errorf("failed to broadcast PoP transaction: %v", err)
+		return fmt.Errorf("failed to broadcast PoP transaction: %w", err)
 	}
 	txHash, err := btcchainhash.NewHash(txh)
 	if err != nil {
-		return fmt.Errorf("failed to create BTC hash from transaction hash: %v", err)
+		return fmt.Errorf("failed to create BTC hash from transaction hash: %w", err)
 	}
 
 	log.Infof("Successfully broadcast PoP transaction to Bitcoin with TX hash %v", txHash)

--- a/web/popminer/popminer.go
+++ b/web/popminer/popminer.go
@@ -85,7 +85,7 @@ func generateKey(this js.Value, args []js.Value) (any, error) {
 	}
 	privKey, err := dcrsecpk256k1.GeneratePrivateKey()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate secp256k1 private key: %v", err)
+		return nil, fmt.Errorf("failed to generate secp256k1 private key: %w", err)
 	}
 	btcAddress, err := btcutil.NewAddressPubKey(privKey.PubKey().SerializeCompressed(),
 		btcChainParams)
@@ -152,7 +152,7 @@ func runPopMiner(this js.Value, args []js.Value) (any, error) {
 	pm.miner, err = popm.NewMiner(cfg)
 	if err != nil {
 		globalMtx.Unlock()
-		return nil, fmt.Errorf("Failed to create POP miner: %v", err)
+		return nil, fmt.Errorf("failed to create POP miner: %w", err)
 	}
 	globalMtx.Unlock()
 


### PR DESCRIPTION
**Summary**
It is now best pratice to use the `%w` verb to wrap errors passed to `fmt.Errorf`.
Wrapping errors allows them to be unwrapped with `errors.Unwrap`, checked for with `errors.Is`, and extracted with `errors.As`.

Error wrapping was introduced in Go 1.13, more information: https://go.dev/blog/go1.13-errors

Fixes #13 

**Changes**
- Use `%w` instead of `%v` to wrap errors passed to `fmt.Errorf`
- Begin all errors with a lowercase letter, per https://go.dev/wiki/CodeReviewComments#error-strings
