### PR TITLE
Use 'errors.Is' to compare errors

### DIFF
--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -41,7 +41,8 @@ func (he HandshakeError) Error() string {
 }
 
 func (he HandshakeError) Is(target error) bool {
-	return errors.Is(he, target)
+	_, ok := target.(HandshakeError)
+	return ok
 }
 
 var PublicKeyAuthError = websocket.CloseError{

--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -126,7 +127,7 @@ func _main() error {
 	if err != nil {
 		return fmt.Errorf("failed to create BFG server: %w", err)
 	}
-	if err := server.Run(ctx); err != context.Canceled {
+	if err = server.Run(ctx); !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("BFG server terminated: %w", err)
 	}
 

--- a/cmd/bssd/bssd.go
+++ b/cmd/bssd/bssd.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -101,7 +102,7 @@ func _main() error {
 	if err != nil {
 		return fmt.Errorf("failed to create BSS server: %w", err)
 	}
-	if err := server.Run(ctx); err != context.Canceled {
+	if err := server.Run(ctx); !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("BSS server terminated with error: %w", err)
 	}
 

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -255,7 +256,7 @@ func bssLong(ctx context.Context) error {
 	go bsc.connectBSS(ctx)
 
 	<-ctx.Done()
-	if context.Canceled != ctx.Err() && ctx.Err() != context.Canceled {
+	if !errors.Is(ctx.Err(), context.Canceled) {
 		return ctx.Err()
 	}
 

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -105,7 +106,7 @@ func _main() error {
 	if err != nil {
 		return fmt.Errorf("failed to create POP miner: %w", err)
 	}
-	if err := miner.Run(ctx); err != context.Canceled {
+	if err := miner.Run(ctx); !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("POP miner terminated: %w", err)
 	}
 

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -124,7 +124,7 @@ func (p *pgdb) L2KeystonesInsert(ctx context.Context, l2ks []bfgd.L2Keystone) er
 
 	defer func() {
 		err := tx.Rollback()
-		if err != nil && err != sql.ErrTxDone {
+		if err != nil && !errors.Is(err, sql.ErrTxDone) {
 			log.Errorf("L2KeystonesInsert could not rollback db tx: %v",
 				err)
 			return
@@ -210,7 +210,7 @@ func (p *pgdb) L2KeystoneByAbrevHash(ctx context.Context, aHash [32]byte) (*bfgd
 		&l2ks.ParentEPHash, &l2ks.PrevKeystoneEPHash, &l2ks.StateRoot,
 		&l2ks.EPHash, &l2ks.Version, &l2ks.CreatedAt, &l2ks.UpdatedAt,
 	); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, database.NotFoundError("l2 keystone not found")
 		}
 		return nil, err
@@ -257,7 +257,7 @@ func (p *pgdb) L2KeystonesMostRecentN(ctx context.Context, n uint32) ([]bfgd.L2K
 			&k.ParentEPHash, &k.PrevKeystoneEPHash, &k.StateRoot,
 			&k.EPHash, &k.Version, &k.CreatedAt, &k.UpdatedAt,
 		); err != nil {
-			if err == sql.ErrNoRows {
+			if errors.Is(err, sql.ErrNoRows) {
 				return nil, database.NotFoundError("pop data not found")
 			}
 			return nil, err
@@ -312,7 +312,7 @@ func (p *pgdb) BtcBlockByHash(ctx context.Context, hash [32]byte) (*bfgd.BtcBloc
 	row := p.db.QueryRowContext(ctx, q, hash[:])
 	if err := row.Scan(&bb.Hash, &bb.Header, &bb.Height, &bb.CreatedAt,
 		&bb.UpdatedAt); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, database.NotFoundError("btc block not found")
 		}
 		return nil, err
@@ -333,7 +333,7 @@ func (p *pgdb) BtcBlockHeightByHash(ctx context.Context, hash [32]byte) (uint64,
 	var height uint64
 	row := p.db.QueryRowContext(ctx, q, hash[:])
 	if err := row.Scan(&height); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return 0, database.NotFoundError("btc block height not found")
 		}
 		return 0, err

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -260,7 +261,7 @@ func createTestDB(ctx context.Context, t *testing.T) (bfgd.Database, string, *sq
 
 func nextPort() int {
 	port, err := freeport.GetFreePort()
-	if err != nil && err != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		panic(err)
 	}
 
@@ -298,7 +299,7 @@ func createBfgServerWithAuth(ctx context.Context, t *testing.T, pgUri string, el
 
 	go func() {
 		err := bfgServer.Run(ctx)
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
 	}()
@@ -334,7 +335,7 @@ func createBssServer(ctx context.Context, t *testing.T, bfgWsurl string) (*bss.S
 
 	go func() {
 		err := bssServer.Run(ctx)
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
 	}()

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1462,7 +1462,7 @@ func (s *Server) Run(pctx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := d.Run(ctx, cs); err != context.Canceled {
+			if err := d.Run(ctx, cs); !errors.Is(err, context.Canceled) {
 				log.Errorf("prometheus terminated with error: %v", err)
 				return
 			}

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -770,7 +770,7 @@ func (s *Server) Run(parrentCtx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := d.Run(ctx, cs); err != context.Canceled {
+			if err := d.Run(ctx, cs); !errors.Is(err, context.Canceled) {
 				log.Errorf("prometheus terminated with error: %v", err)
 				return
 			}

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -875,7 +875,7 @@ func TestConnectToBFGAndPerformMineWithAuth(t *testing.T) {
 		}
 
 		err = miner.Run(ctx)
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
 	}()
@@ -939,7 +939,7 @@ func TestConnectToBFGAndPerformMine(t *testing.T) {
 		}
 
 		err = miner.Run(ctx)
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
 	}()
@@ -1003,7 +1003,7 @@ func TestConnectToBFGAndPerformMineMultiple(t *testing.T) {
 		}
 
 		err = miner.Run(ctx)
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
 	}()
@@ -1068,7 +1068,7 @@ func TestConnectToBFGAndPerformMineALot(t *testing.T) {
 		}
 
 		err = miner.Run(ctx)
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
 	}()

--- a/service/popm/prometheus.go
+++ b/service/popm/prometheus.go
@@ -8,6 +8,7 @@ package popm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,7 +33,7 @@ func (m *Miner) handlePrometheus(ctx context.Context) error {
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
-		if err := d.Run(ctx, cs); err != context.Canceled {
+		if err := d.Run(ctx, cs); !errors.Is(err, context.Canceled) {
 			log.Errorf("prometheus terminated with error: %v", err)
 			return
 		}

--- a/web/popminer/popminer.go
+++ b/web/popminer/popminer.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -160,7 +161,7 @@ func runPopMiner(this js.Value, args []js.Value) (any, error) {
 	pm.wg.Add(1)
 	go func() {
 		defer pm.wg.Done()
-		if err := pm.miner.Run(pm.ctx); err != context.Canceled {
+		if err := pm.miner.Run(pm.ctx); !errors.Is(err, context.Canceled) {
 			globalMtx.Lock()
 			defer globalMtx.Unlock()
 			pm.err = err // Theoretically this can logic race unless we unset om


### PR DESCRIPTION
**Summary**
Use `errors.Is` to compare errors, instead of using the `==` operator.
More information: https://pkg.go.dev/errors#Is

**Changes**
 - Replace use of `==` for error comparisons with `errors.Is`
