### PR TITLE
Use `maps.Clone(m)` to copy returned map in `APICommands()`

### DIFF
--- a/api/bfgapi/bfgapi.go
+++ b/api/bfgapi/bfgapi.go
@@ -7,6 +7,7 @@ package bfgapi
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 
 	"github.com/hemilabs/heminetwork/api"
@@ -223,7 +224,7 @@ func (a *bfgAPI) Commands() map[protocol.Command]reflect.Type {
 }
 
 func APICommands() map[protocol.Command]reflect.Type {
-	return commands // XXX make copy
+	return maps.Clone(commands)
 }
 
 // Write is the low level primitive of a protocol Write. One should generally

--- a/api/bssapi/bssapi.go
+++ b/api/bssapi/bssapi.go
@@ -7,6 +7,7 @@ package bssapi
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/big"
 	"reflect"
 
@@ -134,7 +135,7 @@ func (a *apiCmd) Commands() map[protocol.Command]reflect.Type {
 }
 
 func APICommands() map[protocol.Command]reflect.Type {
-	return commands // XXX make copy
+	return maps.Clone(commands)
 }
 
 // Read reads a command from an APIConn. This is used server side.


### PR DESCRIPTION
**Summary**
Copy the commands map with `maps.Clone` before returning in `{bssapi,bfgapi}.APICommands()`
More information: https://pkg.go.dev/maps#Clone

**Changes**
 - Use `maps.Clone(commands)` to clone the commands map before returning from `APICommands()`
