### PR TITLE
e2e: sync ElectrumX environment variables with infra

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -51,7 +51,10 @@ services:
     image: 'lukechilds/electrumx'
     environment:
       DAEMON_URL: 'http://user:password@bitcoind:18443'
-      COIN: 'BitcoinSegwit'
+      COIN: 'Bitcoin'
+      COST_HARD_LIMIT: '0'
+      COST_SOFT_LIMIT: '0'
+      MAX_SEND: '8388608'
       NET: 'regtest'
     ports:
       - 50001:50001

--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -309,9 +309,12 @@ func createElectrumx(ctx context.Context, t *testing.T, bitcoindEndpoint string)
 	req := testcontainers.ContainerRequest{
 		Image: "lukechilds/electrumx",
 		Env: map[string]string{
-			"DAEMON_URL": bitcoindEndpoint,
-			"COIN":       "BitcoinSegwit",
-			"NET":        "regtest",
+			"DAEMON_URL":      bitcoindEndpoint,
+			"COIN":            "BitcoinSegwit",
+			"COST_HARD_LIMIT": "0",
+			"COST_SOFT_LIMIT": "0",
+			"MAX_SEND":        "8388608",
+			"NET":             "regtest",
 		},
 		ExposedPorts: []string{"50001/tcp"},
 		WaitingFor:   wait.ForLog("INFO:Daemon:daemon #1").WithPollInterval(1 * time.Second),

--- a/e2e/network_test.go
+++ b/e2e/network_test.go
@@ -310,7 +310,7 @@ func createElectrumx(ctx context.Context, t *testing.T, bitcoindEndpoint string)
 		Image: "lukechilds/electrumx",
 		Env: map[string]string{
 			"DAEMON_URL":      bitcoindEndpoint,
-			"COIN":            "BitcoinSegwit",
+			"COIN":            "Bitcoin",
 			"COST_HARD_LIMIT": "0",
 			"COST_SOFT_LIMIT": "0",
 			"MAX_SEND":        "8388608",


### PR DESCRIPTION
**Summary**
Sync ElectrumX environment variables in E2E with infra.

After merging #26 (c5b0fea01e84c7927c601a90a2046220434bbc7f), the electrumx client in BFG started being rate limited by ElectrumX during network tests, which would cause block processing to be significantly slower and cause the network test to timeout.

These environment variables remove the hard/soft (`COST_{HARD,SOFT}_LIMIT`) limits and increases the maximum size of response messages to 8 MiB (`MAX_SEND`).

Fixes #35 

**Changes**
- Sync ElectrumX environment variables with those used in production.
