### PR TITLE
added balance-by-address endpoint to tbc

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -17,6 +17,9 @@ const (
 
 	CmdBtcBlockMetadataByNumRequest  = "tbcapi-btc-block-metadata-by-num-request"
 	CmdBtcBlockMetadataByNumResponse = "tbcapi-btc-block-metadata-by-num-response"
+
+	CmdBtcAddrBalanceRequest  = "tbcapi-btc-addr-bal-request"
+	CmdBtcAddrBalanceResponse = "tbcapi-btc-addr-bal-response"
 )
 
 var (
@@ -64,11 +67,22 @@ type BtcBlockMetadataByNumResponse struct {
 	Block BtcBlockMetadata `json:"block"`
 }
 
+type BtcAddrBalanceRequest struct {
+	Address string `json:"address"`
+}
+
+type BtcAddrBalanceResponse struct {
+	Balance uint64          `json:"balance"`
+	Error   *protocol.Error `json:"error"`
+}
+
 var commands = map[protocol.Command]reflect.Type{
 	CmdPingRequest:                   reflect.TypeOf(PingRequest{}),
 	CmdPingResponse:                  reflect.TypeOf(PingResponse{}),
 	CmdBtcBlockMetadataByNumRequest:  reflect.TypeOf(BtcBlockMetadataByNumRequest{}),
 	CmdBtcBlockMetadataByNumResponse: reflect.TypeOf(BtcBlockMetadataByNumResponse{}),
+	CmdBtcAddrBalanceRequest:         reflect.TypeOf(BtcAddrBalanceRequest{}),
+	CmdBtcAddrBalanceResponse:        reflect.TypeOf(BtcAddrBalanceResponse{}),
 }
 
 type tbcAPI struct{}

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -5,6 +5,7 @@
 package level
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -5,7 +5,6 @@
 package level
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -613,11 +612,8 @@ func (l *ldb) BalanceByScriptHash(ctx context.Context, sh tbcd.ScriptHash) (uint
 	start[0] = 'h'
 	copy(start[1:], sh[:])
 	oDB := l.pool[level.OutputsDB]
-	it := oDB.NewIterator(&util.Range{Start: start[:]}, nil)
+	it := oDB.NewIterator(util.BytesPrefix(start[:]), nil)
 	for it.Next() {
-		if !bytes.Equal(it.Key()[1:33], sh[:]) {
-			break
-		}
 		balance += binary.BigEndian.Uint64(it.Value())
 	}
 	it.Release()

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1186,9 +1186,9 @@ func (s *Server) BlockHeadersByHeight(ctx context.Context, height uint64) ([]wir
 	return bhsw, nil
 }
 
-func (s *Server) BtcBlockMetadataByHeight(ctx context.Context, height uint64) (*tbcapi.BtcBlockMetadata, error) {
-	log.Tracef("BtcBlockMetadataByHeight")
-	defer log.Tracef("BtcBlockMetadataByHeight exit")
+func (s *Server) BlockMetadataByHeight(ctx context.Context, height uint64) (*tbcapi.BtcBlockMetadata, error) {
+	log.Tracef("BlockMetadataByHeight")
+	defer log.Tracef("BlockMetadataByHeight exit")
 
 	bh, err := s.db.BlockHeadersByHeight(ctx, height)
 	if err != nil {
@@ -1229,7 +1229,7 @@ func (s *Server) BtcBlockMetadataByHeight(ctx context.Context, height uint64) (*
 	}, nil
 }
 
-func (s *Server) BtcAddressBalance(ctx context.Context, encodedAddress string) (uint64, error) {
+func (s *Server) AddressBalance(ctx context.Context, encodedAddress string) (uint64, error) {
 	addr, err := btcutil.DecodeAddress(encodedAddress, s.chainParams)
 	if err != nil {
 		return 0, err

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -7,6 +7,7 @@ package tbc
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -23,6 +24,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/dustin/go-humanize"
@@ -630,6 +632,7 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 	bhs, err := s.blockHeadersBest(ctx)
 	if err != nil {
 		log.Errorf("block headers best: %v", err)
+		return
 	}
 	if len(bhs) != 1 {
 		// XXX fix multiple tips
@@ -1224,6 +1227,27 @@ func (s *Server) BtcBlockMetadataByHeight(ctx context.Context, height uint64) (*
 			Nonce:      block.MsgBlock().Header.Nonce,
 		},
 	}, nil
+}
+
+func (s *Server) BtcAddressBalance(ctx context.Context, encodedAddress string) (uint64, error) {
+	addr, err := btcutil.DecodeAddress(encodedAddress, s.chainParams)
+	if err != nil {
+		return 0, err
+	}
+
+	script, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return 0, err
+	}
+
+	scriptHash := sha256.Sum256(script)
+
+	balance, err := s.db.BalanceByScriptHash(ctx, scriptHash)
+	if err != nil {
+		return 0, err
+	}
+
+	return balance, nil
 }
 
 // DBOpen opens the undelying server database. It has been put in its own

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -298,7 +298,7 @@ func TestBalanceByAddress(t *testing.T) {
 		{
 			name: "Pay to public key hash",
 			address: func() string {
-				_, _, btcAddress, err := bitcoin.KeysAndAddressFromHexString(
+				_, _, address, err := bitcoin.KeysAndAddressFromHexString(
 					privateKey,
 					&chaincfg.RegressionNetParams,
 				)
@@ -306,62 +306,62 @@ func TestBalanceByAddress(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				return btcAddress.EncodeAddress()
+				return address.EncodeAddress()
 			},
 		},
 		{
 			name: "Pay to script hash",
 			address: func() string {
-				addressScriptHash, err := btcutil.NewAddressScriptHash([]byte("blahblahscripthash"), &chaincfg.RegressionNetParams)
+				address, err := btcutil.NewAddressScriptHash([]byte("blahblahscripthash"), &chaincfg.RegressionNetParams)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				return addressScriptHash.EncodeAddress()
+				return address.EncodeAddress()
 			},
 		},
 		{
 			name: "Pay to witness public key hash",
 			address: func() string {
-				addressScriptHash, err := btcutil.NewAddressWitnessPubKeyHash([]byte("blahblahwitnesspublickeyhash")[:20], &chaincfg.RegressionNetParams)
+				address, err := btcutil.NewAddressWitnessPubKeyHash([]byte("blahblahwitnesspublickeyhash")[:20], &chaincfg.RegressionNetParams)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				return addressScriptHash.EncodeAddress()
+				return address.EncodeAddress()
 			},
 		},
 		{
 			name: "Pay to witness script hash",
 			address: func() string {
-				addressScriptHash, err := btcutil.NewAddressWitnessScriptHash([]byte("blahblahwitnessscripthashblahblahblah")[:32], &chaincfg.RegressionNetParams)
+				address, err := btcutil.NewAddressWitnessScriptHash([]byte("blahblahwitnessscripthashblahblahblah")[:32], &chaincfg.RegressionNetParams)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				return addressScriptHash.EncodeAddress()
+				return address.EncodeAddress()
 			},
 		},
 		{
 			name: "Pay to taproot",
 			address: func() string {
-				addressScriptHash, err := btcutil.NewAddressTaproot([]byte("blahblahwtaprootblahblahblahblah")[:32], &chaincfg.RegressionNetParams)
+				address, err := btcutil.NewAddressTaproot([]byte("blahblahwtaprootblahblahblahblah")[:32], &chaincfg.RegressionNetParams)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				return addressScriptHash.EncodeAddress()
+				return address.EncodeAddress()
 			},
 		},
 		{
 			name: "no balance",
 			address: func() string {
-				addressScriptHash, err := btcutil.NewAddressTaproot([]byte("blahblahwtaprootblahblahblahblah")[:32], &chaincfg.RegressionNetParams)
+				address, err := btcutil.NewAddressTaproot([]byte("blahblahwtaprootblahblahblahblah")[:32], &chaincfg.RegressionNetParams)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				return addressScriptHash.EncodeAddress()
+				return address.EncodeAddress()
 			},
 			doNotGenerate: true,
 		},

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/docker/go-connections/nat"
 	"github.com/go-test/deep"
@@ -126,7 +127,7 @@ func TestBtcBlockMetadataByNum(t *testing.T) {
 	var response tbcapi.BtcBlockMetadataByNumResponse
 	for {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(1 * time.Second):
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
@@ -244,7 +245,7 @@ func TestBtcBlockMetadataByNumDoesNotExist(t *testing.T) {
 	var response tbcapi.BtcBlockMetadataByNumResponse
 	for {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(1 * time.Second):
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
@@ -281,6 +282,243 @@ func TestBtcBlockMetadataByNumDoesNotExist(t *testing.T) {
 
 	if response.Error.Message != "error getting block at height 550: not found" {
 		t.Fatalf("unexpected error message: %s", response.Error.Message)
+	}
+}
+
+func TestBalanceByAddress(t *testing.T) {
+	skipIfNoDocker(t)
+
+	type testTableItem struct {
+		name          string
+		address       func() string
+		doNotGenerate bool
+	}
+
+	testTable := []testTableItem{
+		{
+			name: "Pay to public key hash",
+			address: func() string {
+				_, _, btcAddress, err := bitcoin.KeysAndAddressFromHexString(
+					privateKey,
+					&chaincfg.RegressionNetParams,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return btcAddress.EncodeAddress()
+			},
+		},
+		{
+			name: "Pay to script hash",
+			address: func() string {
+				addressScriptHash, err := btcutil.NewAddressScriptHash([]byte("blahblahscripthash"), &chaincfg.RegressionNetParams)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return addressScriptHash.EncodeAddress()
+			},
+		},
+		{
+			name: "Pay to witness public key hash",
+			address: func() string {
+				addressScriptHash, err := btcutil.NewAddressWitnessPubKeyHash([]byte("blahblahwitnesspublickeyhash")[:20], &chaincfg.RegressionNetParams)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return addressScriptHash.EncodeAddress()
+			},
+		},
+		{
+			name: "Pay to witness script hash",
+			address: func() string {
+				addressScriptHash, err := btcutil.NewAddressWitnessScriptHash([]byte("blahblahwitnessscripthashblahblahblah")[:32], &chaincfg.RegressionNetParams)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return addressScriptHash.EncodeAddress()
+			},
+		},
+		{
+			name: "Pay to taproot",
+			address: func() string {
+				addressScriptHash, err := btcutil.NewAddressTaproot([]byte("blahblahwtaprootblahblahblahblah")[:32], &chaincfg.RegressionNetParams)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return addressScriptHash.EncodeAddress()
+			},
+		},
+		{
+			name: "no balance",
+			address: func() string {
+				addressScriptHash, err := btcutil.NewAddressTaproot([]byte("blahblahwtaprootblahblahblahblah")[:32], &chaincfg.RegressionNetParams)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return addressScriptHash.EncodeAddress()
+			},
+			doNotGenerate: true,
+		},
+	}
+
+	for _, tti := range testTable {
+		t.Run(tti.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			bitcoindContainer := createBitcoind(ctx, t)
+			bitcoindHost, err := bitcoindContainer.Host(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			peerPort, err := nat.NewPort("tcp", "18444")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rpcPort, err := nat.NewPort("tcp", "18443")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mappedPeerPort, err := bitcoindContainer.MappedPort(ctx, peerPort)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mappedRpcPort, err := bitcoindContainer.MappedPort(ctx, rpcPort)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Logf("bitcoind host is: %s", bitcoindHost)
+			t.Logf("bitcoind peer port is: %s", mappedPeerPort.Port())
+			t.Logf("bitcoind rpc port is: %s", mappedRpcPort.Port())
+
+			address := tti.address()
+
+			if !tti.doNotGenerate {
+				_, err = runBitcoinCommand(
+					ctx,
+					t,
+					bitcoindContainer,
+					[]string{
+						"bitcoin-cli",
+						"-regtest=1",
+						"generatetoaddress",
+						"4",
+						address,
+					})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// generate to another address to ensure it's not included in our query
+			someOtherAddress, err := btcutil.NewAddressScriptHash([]byte("blahblahotherscripthash"), &chaincfg.RegressionNetParams)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = runBitcoinCommand(
+				ctx,
+				t,
+				bitcoindContainer,
+				[]string{
+					"bitcoin-cli",
+					"-regtest=1",
+					"generatetoaddress",
+					"3",
+					someOtherAddress.EncodeAddress(),
+				})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+
+			c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.CloseNow()
+
+			assertPing(ctx, t, c, tbcapi.CmdPingRequest)
+
+			tws := &tbcWs{
+				conn: protocol.NewWSConn(c),
+			}
+
+			var lastErr error
+			var response tbcapi.BtcAddrBalanceResponse
+			for {
+				select {
+				case <-time.After(1 * time.Second):
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				}
+				err = tbcServer.UtxoIndexer(ctx, 0, 1000)
+				if err != nil {
+					t.Fatal(err)
+				}
+				lastErr = nil
+				err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BtcAddrBalanceRequest{
+					Address: address,
+				})
+				if err != nil {
+					lastErr = err
+					continue
+				}
+
+				var v protocol.Message
+				err = wsjson.Read(ctx, c, &v)
+				if err != nil {
+					lastErr = err
+					continue
+				}
+
+				if v.Header.Command == tbcapi.CmdBtcAddrBalanceResponse {
+					if err := json.Unmarshal(v.Payload, &response); err != nil {
+						t.Fatal(err)
+					}
+
+					var pricePerBlock uint64 = 50 * 100000000
+					var blocks uint64 = 4
+					var expectedBalance uint64 = 0
+					if !tti.doNotGenerate {
+						expectedBalance = pricePerBlock * blocks
+					}
+
+					expected := tbcapi.BtcAddrBalanceResponse{
+						Balance: expectedBalance,
+						Error:   nil,
+					}
+					if diff := deep.Equal(expected, response); len(diff) > 0 {
+						if response.Error != nil {
+							t.Error(response.Error.Message)
+						}
+						t.Logf("unexpected diff, : %s", diff)
+
+						// there is a chance we just haven't finished indexing
+						// the blocks and txs, retry until timeout
+						continue
+					}
+					break
+				} else {
+					lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+				}
+
+			}
+
+			if lastErr != nil {
+				t.Fatal(lastErr)
+			}
+		})
 	}
 }
 
@@ -388,7 +626,7 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 
 	// let tbc index
 	select {
-	case <-time.After(10 * time.Second):
+	case <-time.After(1 * time.Second):
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}

--- a/service/tbc/websocket.go
+++ b/service/tbc/websocket.go
@@ -56,16 +56,6 @@ func (ws *tbcWs) handleBtcBlockMetadataByNumRequest(ctx context.Context, payload
 	log.Tracef("handleBtcBlockMetadataByNumRequest: %v", ws.addr)
 	defer log.Tracef("handleBtcBlockMetadataByNumRequest exit: %v", ws.addr)
 
-	// helper to write ws response or return error
-	writeHandleBtcBlockMetadataByNumResponse := func(res tbcapi.BtcBlockMetadataByNumResponse) error {
-		if err := tbcapi.Write(ctx, ws.conn, id, res); err != nil {
-			return fmt.Errorf("handleBtcBlockMetadataByNumRequest write: %v %v",
-				ws.addr, err)
-		}
-
-		return nil
-	}
-
 	// "decode" the input
 	p, ok := payload.(*tbcapi.BtcBlockMetadataByNumRequest)
 	if !ok {
@@ -75,13 +65,13 @@ func (ws *tbcWs) handleBtcBlockMetadataByNumRequest(ctx context.Context, payload
 	// use the api to get the block metadata by height
 	btcBlockMetadata, err := s.BtcBlockMetadataByHeight(ctx, uint64(p.Height))
 	if err != nil {
-		return writeHandleBtcBlockMetadataByNumResponse(tbcapi.BtcBlockMetadataByNumResponse{
+		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockMetadataByNumResponse{
 			Error: protocol.Errorf("error getting block at height %d: %s", p.Height, err),
 		})
 	}
 
 	// "encode" output and write response
-	return writeHandleBtcBlockMetadataByNumResponse(tbcapi.BtcBlockMetadataByNumResponse{
+	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockMetadataByNumResponse{
 		Block: *btcBlockMetadata,
 	})
 }

--- a/service/tbc/websocket.go
+++ b/service/tbc/websocket.go
@@ -18,8 +18,8 @@ import (
 )
 
 type storageApi interface {
-	BtcBlockMetadataByHeight(ctx context.Context, height uint64) (*tbcapi.BtcBlockMetadata, error)
-	BtcAddressBalance(ctx context.Context, encodedAddress string) (uint64, error)
+	BlockMetadataByHeight(ctx context.Context, height uint64) (*tbcapi.BtcBlockMetadata, error)
+	AddressBalance(ctx context.Context, encodedAddress string) (uint64, error)
 }
 
 type tbcWs struct {
@@ -63,7 +63,7 @@ func (ws *tbcWs) handleBtcBlockMetadataByNumRequest(ctx context.Context, payload
 	}
 
 	// use the api to get the block metadata by height
-	btcBlockMetadata, err := s.BtcBlockMetadataByHeight(ctx, uint64(p.Height))
+	btcBlockMetadata, err := s.BlockMetadataByHeight(ctx, uint64(p.Height))
 	if err != nil {
 		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockMetadataByNumResponse{
 			Error: protocol.Errorf("error getting block at height %d: %s", p.Height, err),
@@ -85,7 +85,7 @@ func (ws *tbcWs) handleBtcBalanceByAddrRequest(ctx context.Context, payload any,
 		return fmt.Errorf("handleBtcBlockMetadataByNumRequest invalid payload type: %T", payload)
 	}
 
-	balance, err := s.BtcAddressBalance(ctx, p.Address)
+	balance, err := s.AddressBalance(ctx, p.Address)
 	if err != nil {
 		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcAddrBalanceResponse{
 			Error: protocol.Errorf("error getting balance for address: %s", err),

--- a/service/tbc/websocket.go
+++ b/service/tbc/websocket.go
@@ -90,15 +90,6 @@ func (ws *tbcWs) handleBtcBalanceByAddrRequest(ctx context.Context, payload any,
 	log.Tracef("handleBtcBalanceByAddrRequest: %v", ws.addr)
 	defer log.Tracef("handleBtcBalanceByAddrRequest exit: %v", ws.addr)
 
-	writeHandleBtcBalanceByAddrRequestResponse := func(res tbcapi.BtcAddrBalanceResponse) error {
-		if err := tbcapi.Write(ctx, ws.conn, id, res); err != nil {
-			return fmt.Errorf("handleBtcBalanceByAddrRequest write: %v %v",
-				ws.addr, err)
-		}
-
-		return nil
-	}
-
 	p, ok := payload.(*tbcapi.BtcAddrBalanceRequest)
 	if !ok {
 		return fmt.Errorf("handleBtcBlockMetadataByNumRequest invalid payload type: %T", payload)
@@ -106,12 +97,12 @@ func (ws *tbcWs) handleBtcBalanceByAddrRequest(ctx context.Context, payload any,
 
 	balance, err := s.BtcAddressBalance(ctx, p.Address)
 	if err != nil {
-		return writeHandleBtcBalanceByAddrRequestResponse(tbcapi.BtcAddrBalanceResponse{
+		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcAddrBalanceResponse{
 			Error: protocol.Errorf("error getting balance for address: %s", err),
 		})
 	}
 
-	return writeHandleBtcBalanceByAddrRequestResponse(tbcapi.BtcAddrBalanceResponse{
+	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcAddrBalanceResponse{
 		Balance: balance,
 	})
 }


### PR DESCRIPTION
**Summary**
added balance-by-address endpoint to tbc

**Changes**
added an endpoint to tbc that allows us to get a balance for a given address.  this address is one of the 5 supported: P2PKH, P2SH, P2WPKH, P2WSH, P2TR.

also updated test timing to make it run faster

fixes #42 

updated code to properly querying by key prefix
