### PR TITLE
tbcapi: add blockheaders-best API and RPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /pkg/
 .gocache
 *.sw?
+
+# Tests
+/service/tbc/.testleveldb/

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,14 @@ cmds = \
 
 all: lint tidy test build install
 
-clean: clean-dist
+clean: clean-dist clean-test
 	rm -rf $(GOBIN) $(GOCACHE) $(GOPKG)
 
 clean-dist:
 	rm -rf $(DIST)
+
+clean-test:
+	rm -rf $(PROJECTPATH)/service/tbc/.testleveldb/
 
 deps: lint-deps vulncheck-deps
 	go mod download

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -18,6 +18,9 @@ const (
 	CmdBtcBlockHeaderByHeightRequest  = "tbcapi-btc-block-header-by-height-request"
 	CmdBtcBlockHeaderByHeightResponse = "tbcapi-btc-block-header-by-height-response"
 
+	CmdBlockHeadersBestRequest  = "tbcapi-block-headers-best-request"
+	CmdBlockHeadersBestResponse = "tbcapi-block-headers-best-response"
+
 	CmdBtcBalanceByAddressRequest  = "tbcapi-btc-balance-by-address-request"
 	CmdBtcBalanceByAddressResponse = "tbcapi-btc-balance-by-address-response"
 )
@@ -67,6 +70,14 @@ type BtcBlockHeaderByHeightResponse struct {
 	BlockHeaders [][]byte        `json:"block_headers"`
 }
 
+type BlockHeadersBestRequest struct{}
+
+type BlockHeadersBestResponse struct {
+	Height       uint64          `json:"height"`
+	BlockHeaders [][]byte        `json:"block_headers"`
+	Error        *protocol.Error `json:"error"`
+}
+
 type BtcAddrBalanceRequest struct {
 	Address string `json:"address"`
 }
@@ -81,6 +92,8 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdPingResponse:                   reflect.TypeOf(PingResponse{}),
 	CmdBtcBlockHeaderByHeightRequest:  reflect.TypeOf(BtcBlockHeaderByHeightRequest{}),
 	CmdBtcBlockHeaderByHeightResponse: reflect.TypeOf(BtcBlockHeaderByHeightResponse{}),
+	CmdBlockHeadersBestRequest:        reflect.TypeOf(BlockHeadersBestRequest{}),
+	CmdBlockHeadersBestResponse:       reflect.TypeOf(BlockHeadersBestResponse{}),
 	CmdBtcBalanceByAddressRequest:     reflect.TypeOf(BtcAddrBalanceRequest{}),
 	CmdBtcBalanceByAddressResponse:    reflect.TypeOf(BtcAddrBalanceResponse{}),
 }

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -66,8 +66,8 @@ type BtcBlockHeaderByHeightRequest struct {
 }
 
 type BtcBlockHeaderByHeightResponse struct {
-	Error        *protocol.Error `json:"error"`
 	BlockHeaders [][]byte        `json:"block_headers"`
+	Error        *protocol.Error `json:"error,omitempty"`
 }
 
 type BlockHeadersBestRequest struct{}
@@ -75,7 +75,7 @@ type BlockHeadersBestRequest struct{}
 type BlockHeadersBestResponse struct {
 	Height       uint64          `json:"height"`
 	BlockHeaders [][]byte        `json:"block_headers"`
-	Error        *protocol.Error `json:"error"`
+	Error        *protocol.Error `json:"error,omitempty"`
 }
 
 type BtcAddrBalanceRequest struct {
@@ -84,7 +84,7 @@ type BtcAddrBalanceRequest struct {
 
 type BtcAddrBalanceResponse struct {
 	Balance uint64          `json:"balance"`
-	Error   *protocol.Error `json:"error"`
+	Error   *protocol.Error `json:"error,omitempty"`
 }
 
 var commands = map[protocol.Command]reflect.Type{

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -54,7 +54,7 @@ func (s *Server) handleBtcBlockHeadersByHeightRequest(ctx context.Context, ws *t
 	// "decode" the input
 	p, ok := payload.(*tbcapi.BtcBlockHeaderByHeightRequest)
 	if !ok {
-		return fmt.Errorf("handleBtcBlockHeadersByHeightRequest invalid payload type: %T", payload)
+		return fmt.Errorf("invalid payload type: %T", payload)
 	}
 
 	blockHeaders, err := s.BlockHeadersByHeight(ctx, uint64(p.Height))
@@ -84,7 +84,7 @@ func (s *Server) handleBlockHeadersBestRequest(ctx context.Context, ws *tbcWs, p
 	defer log.Tracef("handleBlockHeadersBestRequest exit: %v", ws.addr)
 
 	if _, ok := payload.(*tbcapi.BlockHeadersBestRequest); !ok {
-		return fmt.Errorf("handleBlockHeadersBestRequest invalid payload type: %T", payload)
+		return fmt.Errorf("invalid payload type: %T", payload)
 	}
 
 	height, blockHeaders, err := s.BlockHeadersBest(ctx)
@@ -115,7 +115,7 @@ func (s *Server) handleBtcBalanceByAddrRequest(ctx context.Context, ws *tbcWs, p
 
 	p, ok := payload.(*tbcapi.BtcAddrBalanceRequest)
 	if !ok {
-		return fmt.Errorf("handleBtcBlockHeadersByHeightRequest invalid payload type: %T", payload)
+		return fmt.Errorf("invalid payload type: %T", payload)
 	}
 
 	balance, err := s.BalanceByAddress(ctx, p.Address)

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1164,6 +1164,26 @@ func (s *Server) BlockHeadersByHeight(ctx context.Context, height uint64) ([]wir
 	return bhsw, nil
 }
 
+// BlockHeadersBest returns the headers for the best known blocks.
+func (s *Server) BlockHeadersBest(ctx context.Context) (uint64, []wire.BlockHeader, error) {
+	log.Tracef("LastBlockMetadata")
+	defer log.Tracef("LastBlockMetadata exit")
+
+	bhs, err := s.db.BlockHeadersBest(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	bhsw := make([]wire.BlockHeader, 0, len(bhs))
+	for k := range bhs {
+		bhw, err := bytes2Header(bhs[k].Header)
+		if err != nil {
+			return 0, nil, fmt.Errorf("bytes to header: %w", err)
+		}
+		bhsw = append(bhsw, *bhw)
+	}
+	return bhs[0].Height, bhsw, nil
+}
+
 func (s *Server) BalanceByAddress(ctx context.Context, encodedAddress string) (uint64, error) {
 	addr, err := btcutil.DecodeAddress(encodedAddress, s.chainParams)
 	if err != nil {
@@ -1244,7 +1264,7 @@ func (s *Server) FeesAtHeight(ctx context.Context, height, count int64) (uint64,
 	return fees, fmt.Errorf("not yet")
 }
 
-// DBOpen opens the undelying server database. It has been put in its own
+// DBOpen opens the underlying server database. It has been put in its own
 // function to make it available during tests and hemictl.
 func (s *Server) DBOpen(ctx context.Context) error {
 	log.Tracef("DBOpen")
@@ -1256,14 +1276,14 @@ func (s *Server) DBOpen(ctx context.Context) error {
 	case "mainnet":
 	case networkLocalnet: // XXX why is this here?, this breaks the filepath.Join
 	default:
-		return fmt.Errorf("unsuported network: %v", s.cfg.Network)
+		return fmt.Errorf("unsupported network: %v", s.cfg.Network)
 	}
 
 	// Open db.
 	var err error
 	s.db, err = level.New(ctx, filepath.Join(s.cfg.LevelDBHome, s.cfg.Network))
 	if err != nil {
-		return fmt.Errorf("Failed to open level database: %v", err)
+		return fmt.Errorf("open level database: %v", err)
 	}
 
 	return nil

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1173,6 +1173,12 @@ func (s *Server) BlockHeadersBest(ctx context.Context) (uint64, []wire.BlockHead
 	if err != nil {
 		return 0, nil, err
 	}
+
+	var height uint64
+	if len(bhs) > 0 {
+		height = bhs[0].Height
+	}
+
 	bhsw := make([]wire.BlockHeader, 0, len(bhs))
 	for k := range bhs {
 		bhw, err := bytes2Header(bhs[k].Header)
@@ -1181,7 +1187,8 @@ func (s *Server) BlockHeadersBest(ctx context.Context) (uint64, []wire.BlockHead
 		}
 		bhsw = append(bhsw, *bhw)
 	}
-	return bhs[0].Height, bhsw, nil
+
+	return height, bhsw, nil
 }
 
 func (s *Server) BalanceByAddress(ctx context.Context, encodedAddress string) (uint64, error) {

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -59,59 +59,8 @@ func TestBtcBlockHeaderByHeight(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-	bitcoindContainer := createBitcoind(ctx, t)
-	bitcoindHost, err := bitcoindContainer.Host(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	peerPort, err := nat.NewPort("tcp", "18444")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rpcPort, err := nat.NewPort("tcp", "18443")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mappedPeerPort, err := bitcoindContainer.MappedPort(ctx, peerPort)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mappedRpcPort, err := bitcoindContainer.MappedPort(ctx, rpcPort)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("bitcoind host is: %s", bitcoindHost)
-	t.Logf("bitcoind peer port is: %s", mappedPeerPort.Port())
-	t.Logf("bitcoind rpc port is: %s", mappedRpcPort.Port())
-
-	_, _, btcAddress, err := bitcoin.KeysAndAddressFromHexString(
-		privateKey,
-		&chaincfg.RegressionNetParams,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = runBitcoinCommand(
-		ctx,
-		t,
-		bitcoindContainer,
-		[]string{
-			"bitcoin-cli",
-			"-regtest=1",
-			"generatetoaddress",
-			"100",
-			btcAddress.EncodeAddress(),
-		})
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 100)
 	_, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
 
 	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
@@ -184,59 +133,8 @@ func TestBtcBlockHeaderByHeightDoesNotExist(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
-	bitcoindContainer := createBitcoind(ctx, t)
-	bitcoindHost, err := bitcoindContainer.Host(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	peerPort, err := nat.NewPort("tcp", "18444")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rpcPort, err := nat.NewPort("tcp", "18443")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mappedPeerPort, err := bitcoindContainer.MappedPort(ctx, peerPort)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mappedRpcPort, err := bitcoindContainer.MappedPort(ctx, rpcPort)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("bitcoind host is: %s", bitcoindHost)
-	t.Logf("bitcoind peer port is: %s", mappedPeerPort.Port())
-	t.Logf("bitcoind rpc port is: %s", mappedRpcPort.Port())
-
-	_, _, btcAddress, err := bitcoin.KeysAndAddressFromHexString(
-		privateKey,
-		&chaincfg.RegressionNetParams,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = runBitcoinCommand(
-		ctx,
-		t,
-		bitcoindContainer,
-		[]string{
-			"bitcoin-cli",
-			"-regtest=1",
-			"generatetoaddress",
-			"100",
-			btcAddress.EncodeAddress(),
-		})
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	_, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 100)
 	_, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
 
 	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
@@ -292,6 +190,30 @@ func TestBtcBlockHeaderByHeightDoesNotExist(t *testing.T) {
 
 	if response.Error.Message != "error getting block at height 550: db block header by height: not found" {
 		t.Fatalf("unexpected error message: %s", response.Error.Message)
+	}
+}
+
+func TestServer_BlockHeadersBest(t *testing.T) {
+	skipIfNoDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	blocks := uint64(100)
+	_, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, blocks)
+	tbcServer, _ := createTbcServer(ctx, t, mappedPeerPort)
+
+	height, bhs, err := tbcServer.BlockHeadersBest(ctx)
+	if err != nil {
+		t.Errorf("BlockHeadersBest() err = %v, want nil", err)
+	}
+
+	if l := len(bhs); l != 1 {
+		t.Errorf("BlockHeadersBest() block len = %d, want 1", l)
+	}
+
+	if height != blocks {
+		t.Errorf("BlockHeadersBest() height = %d, want %d", height, blocks)
 	}
 }
 
@@ -530,6 +452,65 @@ func TestBalanceByAddress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createBitcoindWithInitialBlocks(ctx context.Context, t *testing.T, blocks uint64) (testcontainers.Container, nat.Port) {
+	t.Helper()
+
+	bitcoindContainer := createBitcoind(ctx, t)
+	bitcoindHost, err := bitcoindContainer.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	peerPort, err := nat.NewPort("tcp", "18444")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rpcPort, err := nat.NewPort("tcp", "18443")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mappedPeerPort, err := bitcoindContainer.MappedPort(ctx, peerPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mappedRpcPort, err := bitcoindContainer.MappedPort(ctx, rpcPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("bitcoind host is: %s", bitcoindHost)
+	t.Logf("bitcoind peer port is: %s", mappedPeerPort.Port())
+	t.Logf("bitcoind rpc port is: %s", mappedRpcPort.Port())
+
+	_, _, btcAddress, err := bitcoin.KeysAndAddressFromHexString(
+		privateKey,
+		&chaincfg.RegressionNetParams,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = runBitcoinCommand(
+		ctx,
+		t,
+		bitcoindContainer,
+		[]string{
+			"bitcoin-cli",
+			"-regtest=1",
+			"generatetoaddress",
+			strconv.FormatUint(blocks, 10),
+			btcAddress.EncodeAddress(),
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return bitcoindContainer, mappedPeerPort
 }
 
 func createBitcoind(ctx context.Context, t *testing.T) testcontainers.Container {

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -193,7 +193,7 @@ func TestBtcBlockHeaderByHeightDoesNotExist(t *testing.T) {
 	}
 }
 
-func TestServer_BlockHeadersBest(t *testing.T) {
+func TestServerBlockHeadersBest(t *testing.T) {
 	skipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)


### PR DESCRIPTION
**Summary**
Add last block metadata API to tbcd
Fixes #39 

**Changes**
 - Add `BlockHeadersBest(ctx)` function to tbc server
 - Add `tbcapi-blockheaders-best-{request,response}` to tbcapi
 - Add tbc temporary test files to the `.gitignore` file and `make clean`
 - Add `omitempty` to errors in responses in tbcapi
 - Remove unnecessary function names from error strings