### PR TITLE
Rename block-header-by-height to block-headers-by-height

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -19,8 +19,8 @@ const (
 	CmdPingRequest  = "tbcapi-ping-request"
 	CmdPingResponse = "tbcapi-ping-response"
 
-	CmdBtcBlockHeaderByHeightRequest  = "tbcapi-btc-block-header-by-height-request"
-	CmdBtcBlockHeaderByHeightResponse = "tbcapi-btc-block-header-by-height-response"
+	CmdBtcBlockHeadersByHeightRequest  = "tbcapi-btc-block-headers-by-height-request"
+	CmdBtcBlockHeadersByHeightResponse = "tbcapi-btc-block-headers-by-height-response"
 
 	CmdBlockHeadersBestRequest  = "tbcapi-block-headers-best-request"
 	CmdBlockHeadersBestResponse = "tbcapi-block-headers-best-response"
@@ -71,11 +71,11 @@ type BtcBlockHeader struct {
 	Header BtcHeader `json:"header"`
 }
 
-type BtcBlockHeaderByHeightRequest struct {
+type BtcBlockHeadersByHeightRequest struct {
 	Height uint32 `json:"height"`
 }
 
-type BtcBlockHeaderByHeightResponse struct {
+type BtcBlockHeadersByHeightResponse struct {
 	BlockHeaders [][]byte        `json:"block_headers"`
 	Error        *protocol.Error `json:"error,omitempty"`
 }
@@ -118,18 +118,18 @@ type TxByIdResponse struct {
 }
 
 var commands = map[protocol.Command]reflect.Type{
-	CmdPingRequest:                    reflect.TypeOf(PingRequest{}),
-	CmdPingResponse:                   reflect.TypeOf(PingResponse{}),
-	CmdBtcBlockHeaderByHeightRequest:  reflect.TypeOf(BtcBlockHeaderByHeightRequest{}),
-	CmdBtcBlockHeaderByHeightResponse: reflect.TypeOf(BtcBlockHeaderByHeightResponse{}),
-	CmdBlockHeadersBestRequest:        reflect.TypeOf(BlockHeadersBestRequest{}),
-	CmdBlockHeadersBestResponse:       reflect.TypeOf(BlockHeadersBestResponse{}),
-	CmdBtcBalanceByAddressRequest:     reflect.TypeOf(BtcAddrBalanceRequest{}),
-	CmdBtcBalanceByAddressResponse:    reflect.TypeOf(BtcAddrBalanceResponse{}),
-	CmdUtxosByAddressRequest:          reflect.TypeOf(UtxosByAddressRequest{}),
-	CmdUtxosByAddressResponse:         reflect.TypeOf(UtxosByAddressResponse{}),
-	CmdTxByIdRequest:                  reflect.TypeOf(TxByIdRequest{}),
-	CmdTxByIdResponse:                 reflect.TypeOf(TxByIdResponse{}),
+	CmdPingRequest:                     reflect.TypeOf(PingRequest{}),
+	CmdPingResponse:                    reflect.TypeOf(PingResponse{}),
+	CmdBtcBlockHeadersByHeightRequest:  reflect.TypeOf(BtcBlockHeadersByHeightRequest{}),
+	CmdBtcBlockHeadersByHeightResponse: reflect.TypeOf(BtcBlockHeadersByHeightResponse{}),
+	CmdBlockHeadersBestRequest:         reflect.TypeOf(BlockHeadersBestRequest{}),
+	CmdBlockHeadersBestResponse:        reflect.TypeOf(BlockHeadersBestResponse{}),
+	CmdBtcBalanceByAddressRequest:      reflect.TypeOf(BtcAddrBalanceRequest{}),
+	CmdBtcBalanceByAddressResponse:     reflect.TypeOf(BtcAddrBalanceResponse{}),
+	CmdUtxosByAddressRequest:           reflect.TypeOf(UtxosByAddressRequest{}),
+	CmdUtxosByAddressResponse:          reflect.TypeOf(UtxosByAddressResponse{}),
+	CmdTxByIdRequest:                   reflect.TypeOf(TxByIdRequest{}),
+	CmdTxByIdResponse:                  reflect.TypeOf(TxByIdResponse{}),
 }
 
 type tbcAPI struct{}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -56,14 +56,14 @@ func (s *Server) handleBtcBlockHeadersByHeightRequest(ctx context.Context, ws *t
 	defer log.Tracef("handleBtcBlockHeadersByHeightRequest exit: %v", ws.addr)
 
 	// "decode" the input
-	p, ok := payload.(*tbcapi.BtcBlockHeaderByHeightRequest)
+	p, ok := payload.(*tbcapi.BtcBlockHeadersByHeightRequest)
 	if !ok {
 		return fmt.Errorf("invalid payload type: %T", payload)
 	}
 
 	blockHeaders, err := s.BlockHeadersByHeight(ctx, uint64(p.Height))
 	if err != nil {
-		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockHeaderByHeightResponse{
+		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockHeadersByHeightResponse{
 			Error: protocol.Errorf("error getting block at height %d: %s", p.Height, err),
 		})
 	}
@@ -78,7 +78,7 @@ func (s *Server) handleBtcBlockHeadersByHeightRequest(ctx context.Context, ws *t
 	}
 
 	// "encode" output and write response
-	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockHeaderByHeightResponse{
+	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockHeadersByHeightResponse{
 		BlockHeaders: encodedBlockHeaders,
 	})
 }
@@ -257,7 +257,7 @@ func (s *Server) handleWebsocketRead(ctx context.Context, ws *tbcWs) {
 		switch cmd {
 		case tbcapi.CmdPingRequest:
 			err = s.handlePingRequest(ctx, ws, payload, id)
-		case tbcapi.CmdBtcBlockHeaderByHeightRequest:
+		case tbcapi.CmdBtcBlockHeadersByHeightRequest:
 			err = s.handleBtcBlockHeadersByHeightRequest(ctx, ws, payload, id)
 		case tbcapi.CmdBlockHeadersBestRequest:
 			err = s.handleBlockHeadersBestRequest(ctx, ws, payload, id)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -60,7 +60,7 @@ func skipIfNoDocker(t *testing.T) {
 	}
 }
 
-func TestBtcBlockHeaderByHeight(t *testing.T) {
+func TestBtcBlockHeadersByHeight(t *testing.T) {
 	skipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
@@ -82,7 +82,7 @@ func TestBtcBlockHeaderByHeight(t *testing.T) {
 	}
 
 	var lastErr error
-	var response tbcapi.BtcBlockHeaderByHeightResponse
+	var response tbcapi.BtcBlockHeadersByHeightResponse
 	for {
 		select {
 		case <-time.After(1 * time.Second):
@@ -90,7 +90,7 @@ func TestBtcBlockHeaderByHeight(t *testing.T) {
 			t.Fatal(ctx.Err())
 		}
 		lastErr = nil
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BtcBlockHeaderByHeightRequest{
+		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BtcBlockHeadersByHeightRequest{
 			Height: 55,
 		})
 		if err != nil {
@@ -105,7 +105,7 @@ func TestBtcBlockHeaderByHeight(t *testing.T) {
 			continue
 		}
 
-		if v.Header.Command == tbcapi.CmdBtcBlockHeaderByHeightResponse {
+		if v.Header.Command == tbcapi.CmdBtcBlockHeadersByHeightResponse {
 			if err := json.Unmarshal(v.Payload, &response); err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func TestBtcBlockHeaderByHeight(t *testing.T) {
 	}
 }
 
-func TestBtcBlockHeaderByHeightDoesNotExist(t *testing.T) {
+func TestBtcBlockHeadersByHeightDoesNotExist(t *testing.T) {
 	skipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
@@ -156,7 +156,7 @@ func TestBtcBlockHeaderByHeightDoesNotExist(t *testing.T) {
 	}
 
 	var lastErr error
-	var response tbcapi.BtcBlockHeaderByHeightResponse
+	var response tbcapi.BtcBlockHeadersByHeightResponse
 	for {
 		select {
 		case <-time.After(1 * time.Second):
@@ -164,7 +164,7 @@ func TestBtcBlockHeaderByHeightDoesNotExist(t *testing.T) {
 			t.Fatal(ctx.Err())
 		}
 		lastErr = nil
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BtcBlockHeaderByHeightRequest{
+		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BtcBlockHeadersByHeightRequest{
 			Height: 550,
 		})
 		if err != nil {
@@ -179,7 +179,7 @@ func TestBtcBlockHeaderByHeightDoesNotExist(t *testing.T) {
 			continue
 		}
 
-		if v.Header.Command == tbcapi.CmdBtcBlockHeaderByHeightResponse {
+		if v.Header.Command == tbcapi.CmdBtcBlockHeadersByHeightResponse {
 			if err := json.Unmarshal(v.Payload, &response); err != nil {
 				t.Fatal(err)
 			}
@@ -1073,7 +1073,7 @@ type BtcCliBlockHeader struct {
 	NextBlockHash     string  `json:"nextblockhash"`
 }
 
-func cliBlockToResponse(btcCliBlockHeader BtcCliBlockHeader, t *testing.T) tbcapi.BtcBlockHeaderByHeightResponse {
+func cliBlockToResponse(btcCliBlockHeader BtcCliBlockHeader, t *testing.T) tbcapi.BtcBlockHeadersByHeightResponse {
 	prevBlockHash, err := chainhash.NewHashFromStr(btcCliBlockHeader.PreviousBlockHash)
 	if err != nil {
 		t.Fatal(err)
@@ -1093,7 +1093,7 @@ func cliBlockToResponse(btcCliBlockHeader BtcCliBlockHeader, t *testing.T) tbcap
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tbcapi.BtcBlockHeaderByHeightResponse{
+	return tbcapi.BtcBlockHeadersByHeightResponse{
 		BlockHeaders: [][]byte{bytes},
 	}
 }


### PR DESCRIPTION
**Summary**
Rename block-header-by-height to block-headers-by-height
Fixes #53 

**Changes**
 - Rename `tbcapi-btc-block-header-by-height-{request,response}` to `tbcapi-btc-block-headers-by-height-{request,response}`
 - Rename `BtcBlockHeaderByHeight{Request,Response}` to `BtcBlockheadersByHeight{Request,Response}`
