### PR TITLE
tbcapi: use api.ByteSlice to encode bytes as hex

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 )
 
-// HexDecode decodes a string that may be prefixed with " and/or 0x. Thus,
+// hexDecode decodes a string that may be prefixed with " and/or 0x. Thus,
 // "0x00" and 0x00 or 00 are all valid hex encodings. If length is provided the
 // decoded size must exactly match. The length parameter will be ignored if it
 // is less than 0.
-func HexDecode(data []byte, length int) ([]byte, error) {
+func hexDecode(data []byte, length int) ([]byte, error) {
 	x, _ := strings.CutPrefix(strings.Trim(string(data), "\""), "0x")
 	s, err := hex.DecodeString(x)
 	if err != nil {
@@ -38,7 +38,7 @@ func (bs *ByteSlice) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" || string(data) == `""` {
 		return nil
 	}
-	s, err := HexDecode(data, -1)
+	s, err := hexDecode(data, -1)
 	if err != nil {
 		return err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 )
 
-// hexDecode decodes a string that may be prefixed with " and/or 0x. Thus
+// HexDecode decodes a string that may be prefixed with " and/or 0x. Thus,
 // "0x00" and 0x00 or 00 are all valid hex encodings. If length is provided the
 // decoded size must exactly match. The length parameter will be ignored if it
 // is less than 0.
-func hexDecode(data []byte, length int) ([]byte, error) {
+func HexDecode(data []byte, length int) ([]byte, error) {
 	x, _ := strings.CutPrefix(strings.Trim(string(data), "\""), "0x")
 	s, err := hex.DecodeString(x)
 	if err != nil {
@@ -38,7 +38,7 @@ func (bs *ByteSlice) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" || string(data) == `""` {
 		return nil
 	}
-	s, err := hexDecode(data, -1)
+	s, err := HexDecode(data, -1)
 	if err != nil {
 		return err
 	}

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -6,8 +6,6 @@ package tbcapi
 
 import (
 	"context"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
@@ -111,26 +109,8 @@ type UtxosByAddressResponse struct {
 	Error *protocol.Error `json:"error"`
 }
 
-type TxId [32]byte
-
-func (tx TxId) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hex.EncodeToString(tx[:]))
-}
-
-func (tx *TxId) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-	s, err := api.HexDecode(data, 32)
-	if err != nil {
-		return err
-	}
-	*tx = [32]byte(s)
-	return nil
-}
-
 type TxByIdRequest struct {
-	TxId TxId `json:"tx_id"`
+	TxId api.ByteSlice `json:"tx_id"`
 }
 
 type TxByIdResponse struct {

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -6,10 +6,13 @@ package tbcapi
 
 import (
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
 
+	"github.com/hemilabs/heminetwork/api"
 	"github.com/hemilabs/heminetwork/api/protocol"
 )
 
@@ -76,7 +79,7 @@ type BtcBlockHeadersByHeightRequest struct {
 }
 
 type BtcBlockHeadersByHeightResponse struct {
-	BlockHeaders [][]byte        `json:"block_headers"`
+	BlockHeaders []api.ByteSlice `json:"block_headers"`
 	Error        *protocol.Error `json:"error,omitempty"`
 }
 
@@ -84,7 +87,7 @@ type BlockHeadersBestRequest struct{}
 
 type BlockHeadersBestResponse struct {
 	Height       uint64          `json:"height"`
-	BlockHeaders [][]byte        `json:"block_headers"`
+	BlockHeaders []api.ByteSlice `json:"block_headers"`
 	Error        *protocol.Error `json:"error,omitempty"`
 }
 
@@ -104,16 +107,34 @@ type UtxosByAddressRequest struct {
 }
 
 type UtxosByAddressResponse struct {
-	Utxos [][]byte        `json:"utxos"`
+	Utxos []api.ByteSlice `json:"utxos"`
 	Error *protocol.Error `json:"error"`
 }
 
+type TxId [32]byte
+
+func (tx TxId) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(tx[:]))
+}
+
+func (tx *TxId) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" || string(data) == `""` {
+		return nil
+	}
+	s, err := api.HexDecode(data, 32)
+	if err != nil {
+		return err
+	}
+	*tx = [32]byte(s)
+	return nil
+}
+
 type TxByIdRequest struct {
-	TxId [32]byte `json:"tx_id"`
+	TxId TxId `json:"tx_id"`
 }
 
 type TxByIdResponse struct {
-	Tx    []byte          `json:"tx"`
+	Tx    api.ByteSlice   `json:"tx"`
 	Error *protocol.Error `json:"error"`
 }
 

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -170,6 +170,12 @@ func (s *Server) handleTxByIdRequest(ctx context.Context, ws *tbcWs, payload any
 		return fmt.Errorf("handleTxByIdRequest invalid payload type: %T", payload)
 	}
 
+	if len(p.TxId) != 32 {
+		return tbcapi.Write(ctx, ws.conn, id, tbcapi.TxByIdResponse{
+			Error: protocol.Errorf("invalid tx id"),
+		})
+	}
+
 	tx, err := s.TxById(ctx, [32]byte(p.TxId))
 	if err != nil {
 		return tbcapi.Write(ctx, ws.conn, id, tbcapi.TxByIdResponse{

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"nhooyr.io/websocket"
 
+	"github.com/hemilabs/heminetwork/api"
 	"github.com/hemilabs/heminetwork/api/protocol"
 	"github.com/hemilabs/heminetwork/api/tbcapi"
 )
@@ -68,7 +69,7 @@ func (s *Server) handleBtcBlockHeadersByHeightRequest(ctx context.Context, ws *t
 		})
 	}
 
-	encodedBlockHeaders := [][]byte{}
+	var encodedBlockHeaders []api.ByteSlice
 	for _, bh := range blockHeaders {
 		bytes, err := header2Bytes(&bh)
 		if err != nil {
@@ -98,7 +99,7 @@ func (s *Server) handleBlockHeadersBestRequest(ctx context.Context, ws *tbcWs, p
 		})
 	}
 
-	var encodedBlockHeaders [][]byte
+	var encodedBlockHeaders []api.ByteSlice
 	for _, bh := range blockHeaders {
 		bytes, err := header2Bytes(&bh)
 		if err != nil {
@@ -150,7 +151,7 @@ func (s *Server) handleUtxosByAddressRequest(ctx context.Context, ws *tbcWs, pay
 		})
 	}
 
-	responseUtxos := [][]byte{}
+	var responseUtxos []api.ByteSlice
 	for _, utxo := range utxos {
 		responseUtxos = append(responseUtxos, utxo[:])
 	}
@@ -169,7 +170,7 @@ func (s *Server) handleTxByIdRequest(ctx context.Context, ws *tbcWs, payload any
 		return fmt.Errorf("handleTxByIdRequest invalid payload type: %T", payload)
 	}
 
-	tx, err := s.TxById(ctx, p.TxId)
+	tx, err := s.TxById(ctx, [32]byte(p.TxId))
 	if err != nil {
 		return tbcapi.Write(ctx, ws.conn, id, tbcapi.TxByIdResponse{
 			Error: protocol.Errorf("error getting tx by id: %s", err),

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -804,7 +804,7 @@ func TestTxById(t *testing.T) {
 		slices.Reverse(txIdBytes)
 
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-			TxId: [32]byte(txIdBytes),
+			TxId: txIdBytes,
 		})
 		if err != nil {
 			lastErr = err

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -30,6 +30,7 @@ import (
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 
+	"github.com/hemilabs/heminetwork/api"
 	"github.com/hemilabs/heminetwork/api/protocol"
 	"github.com/hemilabs/heminetwork/api/tbcapi"
 	"github.com/hemilabs/heminetwork/bitcoin"
@@ -1094,7 +1095,7 @@ func cliBlockToResponse(btcCliBlockHeader BtcCliBlockHeader, t *testing.T) tbcap
 		t.Fatal(err)
 	}
 	return tbcapi.BtcBlockHeadersByHeightResponse{
-		BlockHeaders: [][]byte{bytes},
+		BlockHeaders: []api.ByteSlice{bytes},
 	}
 }
 


### PR DESCRIPTION
**Summary**
Use `api.ByteSlice` instead of raw byte slices in `tbcapi` to encode bytes as hexadecimal strings.

**Changes**
 - Use `api.ByteSlice` instead of `[]byte` in `tbcapi` package