### PR TITLE
tbc: remove use of math/rand from rpc.go

### DIFF
--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -6,10 +6,10 @@ package tbc
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"sync"
 	"time"


### PR DESCRIPTION
**Summary**
Remove use of `math/rand` package in `service/tbc/rpc.go`.

I believe the original code in `service/tbc/rpc.go` used `crypto/rand`, however it appears to have been changed in #46 and committed as bd5f7bc5bdd3fb475ae291f0cc10c34984dd2d76.

The `math/rand` package is deterministic and should never be used where security matters.

Go 1.22 introduced [`math/rand/v2`](https://pkg.go.dev/math/rand/v2), which aims to improve the current `math/rand` package. I think it would be nice if we could update the required version in `go.mod` to Go 1.22 so that we can use this package instead of `math/rand`.

**Changes**
- Use `crypto/rand` instead of `math/rand` package in `service/tbc/rpc.go`.
