### PR TITLE
tbcapi: remove remaining "btc" prefixes

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -20,14 +20,14 @@ const (
 	CmdPingRequest  = "tbcapi-ping-request"
 	CmdPingResponse = "tbcapi-ping-response"
 
-	CmdBtcBlockHeadersByHeightRequest  = "tbcapi-btc-block-headers-by-height-request"
-	CmdBtcBlockHeadersByHeightResponse = "tbcapi-btc-block-headers-by-height-response"
+	CmdBlockHeadersByHeightRequest  = "tbcapi-block-headers-by-height-request"
+	CmdBlockHeadersByHeightResponse = "tbcapi-block-headers-by-height-response"
 
 	CmdBlockHeadersBestRequest  = "tbcapi-block-headers-best-request"
 	CmdBlockHeadersBestResponse = "tbcapi-block-headers-best-response"
 
-	CmdBtcBalanceByAddressRequest  = "tbcapi-btc-balance-by-address-request"
-	CmdBtcBalanceByAddressResponse = "tbcapi-btc-balance-by-address-response"
+	CmdBalanceByAddressRequest  = "tbcapi-balance-by-address-request"
+	CmdBalanceByAddressResponse = "tbcapi-balance-by-address-response"
 
 	CmdUtxosByAddressRequest  = "tbcapi-utxos-by-address-request"
 	CmdUtxosByAddressResponse = "tbcapi-utxos-by-address-response"
@@ -49,7 +49,7 @@ type (
 	PingResponse protocol.PingResponse
 )
 
-type BtcHeader struct {
+type Header struct {
 	Version uint32 `json:"version"`
 
 	// hex encoded byte array
@@ -66,17 +66,17 @@ type BtcHeader struct {
 	Nonce uint32 `json:"nonce"`
 }
 
-type BtcBlockHeader struct {
-	Height uint32    `json:"height"`
-	NumTx  uint32    `json:"num_tx"`
-	Header BtcHeader `json:"header"`
+type BlockHeader struct {
+	Height uint32 `json:"height"`
+	NumTx  uint32 `json:"num_tx"`
+	Header Header `json:"header"`
 }
 
-type BtcBlockHeadersByHeightRequest struct {
+type BlockHeadersByHeightRequest struct {
 	Height uint32 `json:"height"`
 }
 
-type BtcBlockHeadersByHeightResponse struct {
+type BlockHeadersByHeightResponse struct {
 	BlockHeaders []api.ByteSlice `json:"block_headers"`
 	Error        *protocol.Error `json:"error,omitempty"`
 }
@@ -89,11 +89,11 @@ type BlockHeadersBestResponse struct {
 	Error        *protocol.Error `json:"error,omitempty"`
 }
 
-type BtcAddrBalanceRequest struct {
+type BalanceByAddressRequest struct {
 	Address string `json:"address"`
 }
 
-type BtcAddrBalanceResponse struct {
+type BalanceByAddressResponse struct {
 	Balance uint64          `json:"balance"`
 	Error   *protocol.Error `json:"error,omitempty"`
 }
@@ -119,18 +119,18 @@ type TxByIdResponse struct {
 }
 
 var commands = map[protocol.Command]reflect.Type{
-	CmdPingRequest:                     reflect.TypeOf(PingRequest{}),
-	CmdPingResponse:                    reflect.TypeOf(PingResponse{}),
-	CmdBtcBlockHeadersByHeightRequest:  reflect.TypeOf(BtcBlockHeadersByHeightRequest{}),
-	CmdBtcBlockHeadersByHeightResponse: reflect.TypeOf(BtcBlockHeadersByHeightResponse{}),
-	CmdBlockHeadersBestRequest:         reflect.TypeOf(BlockHeadersBestRequest{}),
-	CmdBlockHeadersBestResponse:        reflect.TypeOf(BlockHeadersBestResponse{}),
-	CmdBtcBalanceByAddressRequest:      reflect.TypeOf(BtcAddrBalanceRequest{}),
-	CmdBtcBalanceByAddressResponse:     reflect.TypeOf(BtcAddrBalanceResponse{}),
-	CmdUtxosByAddressRequest:           reflect.TypeOf(UtxosByAddressRequest{}),
-	CmdUtxosByAddressResponse:          reflect.TypeOf(UtxosByAddressResponse{}),
-	CmdTxByIdRequest:                   reflect.TypeOf(TxByIdRequest{}),
-	CmdTxByIdResponse:                  reflect.TypeOf(TxByIdResponse{}),
+	CmdPingRequest:                  reflect.TypeOf(PingRequest{}),
+	CmdPingResponse:                 reflect.TypeOf(PingResponse{}),
+	CmdBlockHeadersByHeightRequest:  reflect.TypeOf(BlockHeadersByHeightRequest{}),
+	CmdBlockHeadersByHeightResponse: reflect.TypeOf(BlockHeadersByHeightResponse{}),
+	CmdBlockHeadersBestRequest:      reflect.TypeOf(BlockHeadersBestRequest{}),
+	CmdBlockHeadersBestResponse:     reflect.TypeOf(BlockHeadersBestResponse{}),
+	CmdBalanceByAddressRequest:      reflect.TypeOf(BalanceByAddressRequest{}),
+	CmdBalanceByAddressResponse:     reflect.TypeOf(BalanceByAddressResponse{}),
+	CmdUtxosByAddressRequest:        reflect.TypeOf(UtxosByAddressRequest{}),
+	CmdUtxosByAddressResponse:       reflect.TypeOf(UtxosByAddressResponse{}),
+	CmdTxByIdRequest:                reflect.TypeOf(TxByIdRequest{}),
+	CmdTxByIdResponse:               reflect.TypeOf(TxByIdResponse{}),
 }
 
 type tbcAPI struct{}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -52,19 +52,19 @@ func (s *Server) handlePingRequest(ctx context.Context, ws *tbcWs, payload any, 
 	return nil
 }
 
-func (s *Server) handleBtcBlockHeadersByHeightRequest(ctx context.Context, ws *tbcWs, payload any, id string) error {
+func (s *Server) handleBlockHeadersByHeightRequest(ctx context.Context, ws *tbcWs, payload any, id string) error {
 	log.Tracef("handleBtcBlockHeadersByHeightRequest: %v", ws.addr)
 	defer log.Tracef("handleBtcBlockHeadersByHeightRequest exit: %v", ws.addr)
 
 	// "decode" the input
-	p, ok := payload.(*tbcapi.BtcBlockHeadersByHeightRequest)
+	p, ok := payload.(*tbcapi.BlockHeadersByHeightRequest)
 	if !ok {
 		return fmt.Errorf("invalid payload type: %T", payload)
 	}
 
 	blockHeaders, err := s.BlockHeadersByHeight(ctx, uint64(p.Height))
 	if err != nil {
-		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockHeadersByHeightResponse{
+		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BlockHeadersByHeightResponse{
 			Error: protocol.Errorf("error getting block at height %d: %s", p.Height, err),
 		})
 	}
@@ -79,7 +79,7 @@ func (s *Server) handleBtcBlockHeadersByHeightRequest(ctx context.Context, ws *t
 	}
 
 	// "encode" output and write response
-	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcBlockHeadersByHeightResponse{
+	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BlockHeadersByHeightResponse{
 		BlockHeaders: encodedBlockHeaders,
 	})
 }
@@ -114,23 +114,23 @@ func (s *Server) handleBlockHeadersBestRequest(ctx context.Context, ws *tbcWs, p
 	})
 }
 
-func (s *Server) handleBtcBalanceByAddrRequest(ctx context.Context, ws *tbcWs, payload any, id string) error {
+func (s *Server) handleBalanceByAddrRequest(ctx context.Context, ws *tbcWs, payload any, id string) error {
 	log.Tracef("handleBtcBalanceByAddrRequest: %v", ws.addr)
 	defer log.Tracef("handleBtcBalanceByAddrRequest exit: %v", ws.addr)
 
-	p, ok := payload.(*tbcapi.BtcAddrBalanceRequest)
+	p, ok := payload.(*tbcapi.BalanceByAddressRequest)
 	if !ok {
 		return fmt.Errorf("invalid payload type: %T", payload)
 	}
 
 	balance, err := s.BalanceByAddress(ctx, p.Address)
 	if err != nil {
-		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcAddrBalanceResponse{
+		return tbcapi.Write(ctx, ws.conn, id, tbcapi.BalanceByAddressResponse{
 			Error: protocol.Errorf("error getting balance for address: %s", err),
 		})
 	}
 
-	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BtcAddrBalanceResponse{
+	return tbcapi.Write(ctx, ws.conn, id, tbcapi.BalanceByAddressResponse{
 		Balance: balance,
 	})
 }
@@ -264,12 +264,12 @@ func (s *Server) handleWebsocketRead(ctx context.Context, ws *tbcWs) {
 		switch cmd {
 		case tbcapi.CmdPingRequest:
 			err = s.handlePingRequest(ctx, ws, payload, id)
-		case tbcapi.CmdBtcBlockHeadersByHeightRequest:
-			err = s.handleBtcBlockHeadersByHeightRequest(ctx, ws, payload, id)
+		case tbcapi.CmdBlockHeadersByHeightRequest:
+			err = s.handleBlockHeadersByHeightRequest(ctx, ws, payload, id)
 		case tbcapi.CmdBlockHeadersBestRequest:
 			err = s.handleBlockHeadersBestRequest(ctx, ws, payload, id)
-		case tbcapi.CmdBtcBalanceByAddressRequest:
-			err = s.handleBtcBalanceByAddrRequest(ctx, ws, payload, id)
+		case tbcapi.CmdBalanceByAddressRequest:
+			err = s.handleBalanceByAddrRequest(ctx, ws, payload, id)
 		case tbcapi.CmdUtxosByAddressRequest:
 			err = s.handleUtxosByAddressRequest(ctx, ws, payload, id)
 		case tbcapi.CmdTxByIdRequest:


### PR DESCRIPTION
**Summary**
As tbcd is a bitcoin-only indexer, the decision was made to drop unnecessary "btc" prefixes from the names in `tbcapi`.
Fixes #52 

**Changes**
- Remove remaining `btc` prefixes
- Rename `AddrBalance{Request,Response}` to `BalanceByAddress{Request,Response}` to match command ID