### PR TITLE
separate tx-by-id endpoint in raw vs cooked

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -32,6 +32,9 @@ const (
 	CmdUtxosByAddressRequest  = "tbcapi-utxos-by-address-request"
 	CmdUtxosByAddressResponse = "tbcapi-utxos-by-address-response"
 
+	CmdTxByIdRawRequest  = "tbcapi-tx-by-id-raw-request"
+	CmdTxByIdRawResponse = "tbcapi-tx-by-id-raw-response"
+
 	CmdTxByIdRequest  = "tbcapi-tx-by-id-request"
 	CmdTxByIdResponse = "tbcapi-tx-by-id-response"
 )
@@ -109,13 +112,48 @@ type UtxosByAddressResponse struct {
 	Error *protocol.Error `json:"error"`
 }
 
+type TxByIdRawRequest struct {
+	TxId api.ByteSlice `json:"tx_id"`
+}
+
+type TxByIdRawResponse struct {
+	Tx    api.ByteSlice   `json:"tx"`
+	Error *protocol.Error `json:"error"`
+}
+
 type TxByIdRequest struct {
 	TxId api.ByteSlice `json:"tx_id"`
 }
 
 type TxByIdResponse struct {
-	Tx    api.ByteSlice   `json:"tx"`
+	Tx    Tx              `json:"tx"`
 	Error *protocol.Error `json:"error"`
+}
+
+type OutPoint struct {
+	Hash  api.ByteSlice `json:"hash"`
+	Index uint32        `json:"index"`
+}
+
+type TxWitness []api.ByteSlice
+
+type TxIn struct {
+	PreviousOutPoint OutPoint      `json:"outpoint"`
+	SignatureScript  api.ByteSlice `json:"signature_script"`
+	Witness          TxWitness     `json:"tx_witness"`
+	Sequence         uint32        `json:"sequence"`
+}
+
+type TxOut struct {
+	Value    int64         `json:"value"`
+	PkScript api.ByteSlice `json:"pk_script"`
+}
+
+type Tx struct {
+	Version  int32    `json:"version"`
+	LockTime uint32   `json:"lock_time"`
+	TxIn     []*TxIn  `json:"tx_in"`
+	TxOut    []*TxOut `json:"tx_out"`
 }
 
 var commands = map[protocol.Command]reflect.Type{
@@ -129,6 +167,8 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdBalanceByAddressResponse:     reflect.TypeOf(BalanceByAddressResponse{}),
 	CmdUtxosByAddressRequest:        reflect.TypeOf(UtxosByAddressRequest{}),
 	CmdUtxosByAddressResponse:       reflect.TypeOf(UtxosByAddressResponse{}),
+	CmdTxByIdRawRequest:             reflect.TypeOf(TxByIdRawRequest{}),
+	CmdTxByIdRawResponse:            reflect.TypeOf(TxByIdRawResponse{}),
 	CmdTxByIdRequest:                reflect.TypeOf(TxByIdRequest{}),
 	CmdTxByIdResponse:               reflect.TypeOf(TxByIdResponse{}),
 }

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -322,40 +322,6 @@ func (s *Server) txById(ctx context.Context, txId api.ByteSlice) (*wire.MsgTx, *
 	return tx, nil
 }
 
-func wireTxToTbcapiTx(w *wire.MsgTx) *tbcapi.Tx {
-	a := &tbcapi.Tx{
-		Version:  w.Version,
-		LockTime: w.LockTime,
-		TxIn:     []*tbcapi.TxIn{},
-		TxOut:    []*tbcapi.TxOut{},
-	}
-
-	for _, v := range w.TxIn {
-		a.TxIn = append(a.TxIn, &tbcapi.TxIn{
-			Sequence:        v.Sequence,
-			SignatureScript: api.ByteSlice(v.SignatureScript),
-			PreviousOutPoint: tbcapi.OutPoint{
-				Hash:  api.ByteSlice(v.PreviousOutPoint.Hash[:]),
-				Index: v.PreviousOutPoint.Index,
-			},
-		})
-
-		for _, b := range v.Witness {
-			a.TxIn[len(a.TxIn)-1].Witness = append(a.TxIn[len(a.TxIn)-1].Witness,
-				api.ByteSlice(b))
-		}
-	}
-
-	for _, v := range w.TxOut {
-		a.TxOut = append(a.TxOut, &tbcapi.TxOut{
-			Value:    v.Value,
-			PkScript: api.ByteSlice(v.PkScript),
-		})
-	}
-
-	return a
-}
-
 func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleWebsocket: %v", r.RemoteAddr)
 	defer log.Tracef("handleWebsocket exit: %v", r.RemoteAddr)
@@ -436,4 +402,38 @@ func (s *Server) deleteSession(id string) {
 	if !ok {
 		log.Errorf("id not found in sessions %s", id)
 	}
+}
+
+func wireTxToTbcapiTx(w *wire.MsgTx) *tbcapi.Tx {
+	a := &tbcapi.Tx{
+		Version:  w.Version,
+		LockTime: w.LockTime,
+		TxIn:     []*tbcapi.TxIn{},
+		TxOut:    []*tbcapi.TxOut{},
+	}
+
+	for _, v := range w.TxIn {
+		a.TxIn = append(a.TxIn, &tbcapi.TxIn{
+			Sequence:        v.Sequence,
+			SignatureScript: api.ByteSlice(v.SignatureScript),
+			PreviousOutPoint: tbcapi.OutPoint{
+				Hash:  api.ByteSlice(v.PreviousOutPoint.Hash[:]),
+				Index: v.PreviousOutPoint.Index,
+			},
+		})
+
+		for _, b := range v.Witness {
+			a.TxIn[len(a.TxIn)-1].Witness = append(a.TxIn[len(a.TxIn)-1].Witness,
+				api.ByteSlice(b))
+		}
+	}
+
+	for _, v := range w.TxOut {
+		a.TxOut = append(a.TxOut, &tbcapi.TxOut{
+			Value:    v.Value,
+			PkScript: api.ByteSlice(v.PkScript),
+		})
+	}
+
+	return a
 }


### PR DESCRIPTION
**Summary**
separate tx-by-id endpoint in raw vs cooked

**Changes**
separated tx-by-id endpoint into two version: raw returning bytes, cooked returning wire.MsgTx

fixes #56 