### PR TITLE
tbcapi: split block-headers-by-height into raw and serialised

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -20,6 +20,9 @@ const (
 	CmdPingRequest  = "tbcapi-ping-request"
 	CmdPingResponse = "tbcapi-ping-response"
 
+	CmdBlockHeadersByHeightRawRequest  = "tbcapi-block-headers-by-height-raw-request"
+	CmdBlockHeadersByHeightRawResponse = "tbcapi-block-headers-by-height-raw-response"
+
 	CmdBlockHeadersByHeightRequest  = "tbcapi-block-headers-by-height-request"
 	CmdBlockHeadersByHeightResponse = "tbcapi-block-headers-by-height-response"
 
@@ -55,27 +58,22 @@ type (
 	PingResponse protocol.PingResponse
 )
 
-type Header struct {
-	Version uint32 `json:"version"`
-
-	// hex encoded byte array
-	PrevHash string `json:"prev_hash"`
-
-	// hex encoded byte array
+type BlockHeader struct {
+	Version    int32  `json:"version"`
+	PrevHash   string `json:"prev_hash"`
 	MerkleRoot string `json:"merkle_root"`
-
-	Timestamp uint64 `json:"timestamp"`
-
-	// hex encoded int
-	Bits string `json:"bits"`
-
-	Nonce uint32 `json:"nonce"`
+	Timestamp  int64  `json:"timestamp"`
+	Bits       string `json:"bits"`
+	Nonce      uint32 `json:"nonce"`
 }
 
-type BlockHeader struct {
+type BlockHeadersByHeightRawRequest struct {
 	Height uint32 `json:"height"`
-	NumTx  uint32 `json:"num_tx"`
-	Header Header `json:"header"`
+}
+
+type BlockHeadersByHeightRawResponse struct {
+	BlockHeaders []api.ByteSlice `json:"block_headers"`
+	Error        *protocol.Error `json:"error,omitempty"`
 }
 
 type BlockHeadersByHeightRequest struct {
@@ -83,7 +81,7 @@ type BlockHeadersByHeightRequest struct {
 }
 
 type BlockHeadersByHeightResponse struct {
-	BlockHeaders []api.ByteSlice `json:"block_headers"`
+	BlockHeaders []*BlockHeader  `json:"block_headers"`
 	Error        *protocol.Error `json:"error,omitempty"`
 }
 
@@ -177,22 +175,24 @@ type Tx struct {
 }
 
 var commands = map[protocol.Command]reflect.Type{
-	CmdPingRequest:                  reflect.TypeOf(PingRequest{}),
-	CmdPingResponse:                 reflect.TypeOf(PingResponse{}),
-	CmdBlockHeadersByHeightRequest:  reflect.TypeOf(BlockHeadersByHeightRequest{}),
-	CmdBlockHeadersByHeightResponse: reflect.TypeOf(BlockHeadersByHeightResponse{}),
-	CmdBlockHeadersBestRequest:      reflect.TypeOf(BlockHeadersBestRequest{}),
-	CmdBlockHeadersBestResponse:     reflect.TypeOf(BlockHeadersBestResponse{}),
-	CmdBalanceByAddressRequest:      reflect.TypeOf(BalanceByAddressRequest{}),
-	CmdBalanceByAddressResponse:     reflect.TypeOf(BalanceByAddressResponse{}),
-	CmdUtxosByAddressRawRequest:     reflect.TypeOf(UtxosByAddressRawRequest{}),
-	CmdUtxosByAddressRawResponse:    reflect.TypeOf(UtxosByAddressRawResponse{}),
-	CmdUtxosByAddressRequest:        reflect.TypeOf(UtxosByAddressRequest{}),
-	CmdUtxosByAddressResponse:       reflect.TypeOf(UtxosByAddressResponse{}),
-	CmdTxByIdRawRequest:             reflect.TypeOf(TxByIdRawRequest{}),
-	CmdTxByIdRawResponse:            reflect.TypeOf(TxByIdRawResponse{}),
-	CmdTxByIdRequest:                reflect.TypeOf(TxByIdRequest{}),
-	CmdTxByIdResponse:               reflect.TypeOf(TxByIdResponse{}),
+	CmdPingRequest:                     reflect.TypeOf(PingRequest{}),
+	CmdPingResponse:                    reflect.TypeOf(PingResponse{}),
+	CmdBlockHeadersByHeightRawRequest:  reflect.TypeOf(BlockHeadersByHeightRawRequest{}),
+	CmdBlockHeadersByHeightRawResponse: reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
+	CmdBlockHeadersByHeightRequest:     reflect.TypeOf(BlockHeadersByHeightRequest{}),
+	CmdBlockHeadersByHeightResponse:    reflect.TypeOf(BlockHeadersByHeightResponse{}),
+	CmdBlockHeadersBestRequest:         reflect.TypeOf(BlockHeadersBestRequest{}),
+	CmdBlockHeadersBestResponse:        reflect.TypeOf(BlockHeadersBestResponse{}),
+	CmdBalanceByAddressRequest:         reflect.TypeOf(BalanceByAddressRequest{}),
+	CmdBalanceByAddressResponse:        reflect.TypeOf(BalanceByAddressResponse{}),
+	CmdUtxosByAddressRawRequest:        reflect.TypeOf(UtxosByAddressRawRequest{}),
+	CmdUtxosByAddressRawResponse:       reflect.TypeOf(UtxosByAddressRawResponse{}),
+	CmdUtxosByAddressRequest:           reflect.TypeOf(UtxosByAddressRequest{}),
+	CmdUtxosByAddressResponse:          reflect.TypeOf(UtxosByAddressResponse{}),
+	CmdTxByIdRawRequest:                reflect.TypeOf(TxByIdRawRequest{}),
+	CmdTxByIdRawResponse:               reflect.TypeOf(TxByIdRawResponse{}),
+	CmdTxByIdRequest:                   reflect.TypeOf(TxByIdRequest{}),
+	CmdTxByIdResponse:                  reflect.TypeOf(TxByIdResponse{}),
 }
 
 type tbcAPI struct{}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -199,16 +199,8 @@ func (s *Server) handleBlockHeadersByHeightRequest(ctx context.Context, req *tbc
 		}, e
 	}
 
-	blockHeaders, err := wireBlockHeaderToTBC(wireBlockHeaders)
-	if err != nil {
-		e := protocol.NewInternalError(err)
-		return &tbcapi.BlockHeadersByHeightResponse{
-			Error: e.ProtocolError(),
-		}, e
-	}
-
 	return &tbcapi.BlockHeadersByHeightResponse{
-		BlockHeaders: blockHeaders,
+		BlockHeaders: wireBlockHeaderToTBC(wireBlockHeaders),
 	}, nil
 }
 
@@ -494,19 +486,19 @@ func (s *Server) deleteSession(id string) {
 	}
 }
 
-func wireBlockHeaderToTBC(w []*wire.BlockHeader) ([]*tbcapi.BlockHeader, error) {
-	var blockHeaders []*tbcapi.BlockHeader
-	for _, bh := range w {
-		blockHeaders = append(blockHeaders, &tbcapi.BlockHeader{
+func wireBlockHeaderToTBC(w []*wire.BlockHeader) []*tbcapi.BlockHeader {
+	blockHeaders := make([]*tbcapi.BlockHeader, len(w))
+	for i, bh := range w {
+		blockHeaders[i] = &tbcapi.BlockHeader{
 			Version:    bh.Version,
 			PrevHash:   bh.PrevBlock.String(),
 			MerkleRoot: bh.MerkleRoot.String(),
 			Timestamp:  bh.Timestamp.Unix(),
 			Bits:       fmt.Sprintf("%x", bh.Bits),
 			Nonce:      bh.Nonce,
-		})
+		}
 	}
-	return blockHeaders, nil
+	return blockHeaders
 }
 
 func wireTxToTbcapiTx(w *wire.MsgTx) *tbcapi.Tx {

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -200,7 +200,7 @@ func (s *Server) handleBlockHeadersByHeightRequest(ctx context.Context, req *tbc
 	}
 
 	return &tbcapi.BlockHeadersByHeightResponse{
-		BlockHeaders: wireBlockHeaderToTBC(wireBlockHeaders),
+		BlockHeaders: wireBlockHeadersToTBC(wireBlockHeaders),
 	}, nil
 }
 
@@ -486,7 +486,7 @@ func (s *Server) deleteSession(id string) {
 	}
 }
 
-func wireBlockHeaderToTBC(w []*wire.BlockHeader) []*tbcapi.BlockHeader {
+func wireBlockHeadersToTBC(w []*wire.BlockHeader) []*tbcapi.BlockHeader {
 	blockHeaders := make([]*tbcapi.BlockHeader, len(w))
 	for i, bh := range w {
 		blockHeaders[i] = &tbcapi.BlockHeader{

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -62,6 +62,13 @@ func (s *Server) handleWebsocketRead(ctx context.Context, ws *tbcWs) {
 			}
 
 			go s.handleRequest(ctx, ws, id, cmd, handler)
+		case tbcapi.CmdBlockHeadersByHeightRawRequest:
+			handler := func(ctx context.Context) (any, error) {
+				req := payload.(*tbcapi.BlockHeadersByHeightRawRequest)
+				return s.handleBlockHeadersByHeightRawRequest(ctx, req)
+			}
+
+			go s.handleRequest(ctx, ws, id, cmd, handler)
 		case tbcapi.CmdBlockHeadersBestRequest:
 			handler := func(ctx context.Context) (any, error) {
 				req := payload.(*tbcapi.BlockHeadersBestRequest)
@@ -178,7 +185,7 @@ func (s *Server) handleBlockHeadersByHeightRequest(ctx context.Context, req *tbc
 	log.Tracef("handleBtcBlockHeadersByHeightRequest")
 	defer log.Tracef("handleBtcBlockHeadersByHeightRequest exit")
 
-	blockHeaders, err := s.BlockHeadersByHeight(ctx, uint64(req.Height))
+	wireBlockHeaders, err := s.BlockHeadersByHeight(ctx, uint64(req.Height))
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return &tbcapi.BlockHeadersByHeightResponse{
@@ -192,20 +199,39 @@ func (s *Server) handleBlockHeadersByHeightRequest(ctx context.Context, req *tbc
 		}, e
 	}
 
-	var encodedBlockHeaders []api.ByteSlice
-	for _, bh := range blockHeaders {
-		bytes, err := header2Bytes(&bh)
-		if err != nil {
-			e := protocol.NewInternalError(err)
-			return &tbcapi.BlockHeadersByHeightResponse{
-				Error: e.ProtocolError(),
-			}, e
-		}
-		encodedBlockHeaders = append(encodedBlockHeaders, bytes)
+	blockHeaders, err := wireBlockHeaderToTBC(wireBlockHeaders)
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockHeadersByHeightResponse{
+			Error: e.ProtocolError(),
+		}, e
 	}
 
-	return tbcapi.BlockHeadersByHeightResponse{
-		BlockHeaders: encodedBlockHeaders,
+	return &tbcapi.BlockHeadersByHeightResponse{
+		BlockHeaders: blockHeaders,
+	}, nil
+}
+
+func (s *Server) handleBlockHeadersByHeightRawRequest(ctx context.Context, req *tbcapi.BlockHeadersByHeightRawRequest) (any, error) {
+	log.Tracef("handleBtcBlockHeadersByHeightRawRequest")
+	defer log.Tracef("handleBtcBlockHeadersByHeightRawRequest exit")
+
+	rawBlockHeaders, err := s.RawBlockHeadersByHeight(ctx, uint64(req.Height))
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return &tbcapi.BlockHeadersByHeightRawResponse{
+				Error: protocol.RequestErrorf("block headers not found at height %d", req.Height),
+			}, nil
+		}
+
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockHeadersByHeightRawResponse{
+			Error: e.ProtocolError(),
+		}, e
+	}
+
+	return &tbcapi.BlockHeadersByHeightRawResponse{
+		BlockHeaders: rawBlockHeaders,
 	}, nil
 }
 
@@ -466,6 +492,21 @@ func (s *Server) deleteSession(id string) {
 	if !ok {
 		log.Errorf("id not found in sessions %s", id)
 	}
+}
+
+func wireBlockHeaderToTBC(w []*wire.BlockHeader) ([]*tbcapi.BlockHeader, error) {
+	var blockHeaders []*tbcapi.BlockHeader
+	for _, bh := range w {
+		blockHeaders = append(blockHeaders, &tbcapi.BlockHeader{
+			Version:    bh.Version,
+			PrevHash:   bh.PrevBlock.String(),
+			MerkleRoot: bh.MerkleRoot.String(),
+			Timestamp:  bh.Timestamp.Unix(),
+			Bits:       fmt.Sprintf("%x", bh.Bits),
+			Nonce:      bh.Nonce,
+		})
+	}
+	return blockHeaders, nil
 }
 
 func wireTxToTbcapiTx(w *wire.MsgTx) *tbcapi.Tx {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/syndtr/goleveldb/leveldb"
 
+	"github.com/hemilabs/heminetwork/api"
 	"github.com/hemilabs/heminetwork/api/tbcapi"
 	"github.com/hemilabs/heminetwork/database"
 	"github.com/hemilabs/heminetwork/database/tbcd"
@@ -1322,24 +1323,41 @@ func (s *Server) blockHeadersByHeight(ctx context.Context, height uint64) ([]tbc
 	return bhs, nil
 }
 
-func (s *Server) BlockHeadersByHeight(ctx context.Context, height uint64) ([]wire.BlockHeader, error) {
-	log.Tracef("BlockHeadersByHeight")
-	defer log.Tracef("BlockHeadersByHeight exit")
+func (s *Server) RawBlockHeadersByHeight(ctx context.Context, height uint64) ([]api.ByteSlice, error) {
+	log.Tracef("RawBlockHeadersByHeight")
+	defer log.Tracef("RawBlockHeadersByHeight exit")
 
 	bhs, err := s.blockHeadersByHeight(ctx, height)
 	if err != nil {
 		return nil, err
 	}
 
-	bhsw := make([]wire.BlockHeader, 0, len(bhs))
-	for k := range bhs {
-		bhw, err := bytes2Header(bhs[k].Header)
-		if err != nil {
-			return nil, fmt.Errorf("bytes to header: %w", err)
-		}
-		bhsw = append(bhsw, *bhw)
+	var headers []api.ByteSlice
+	for _, bh := range bhs {
+		headers = append(headers, []byte(bh.Header))
 	}
-	return bhsw, nil
+
+	return headers, nil
+}
+
+func (s *Server) BlockHeadersByHeight(ctx context.Context, height uint64) ([]*wire.BlockHeader, error) {
+	log.Tracef("BlockHeadersByHeight")
+	defer log.Tracef("BlockHeadersByHeight exit")
+
+	blockHeaders, err := s.blockHeadersByHeight(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
+	wireBlockHeaders := make([]*wire.BlockHeader, 0, len(blockHeaders))
+	for _, bh := range blockHeaders {
+		w, err := bh.Wire()
+		if err != nil {
+			return nil, err
+		}
+		wireBlockHeaders = append(wireBlockHeaders, w)
+	}
+	return wireBlockHeaders, nil
 }
 
 // BlockHeadersBest returns the headers for the best known blocks.

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1804,7 +1804,7 @@ func cliBlockToResponse(btcCliBlockHeader BtcCliBlockHeader, t *testing.T) tbcap
 	bh.Timestamp = time.Unix(int64(btcCliBlockHeader.Time), 0)
 	t.Logf(spew.Sdump(bh))
 	return tbcapi.BlockHeadersByHeightResponse{
-		BlockHeaders: wireBlockHeaderToTBC([]*wire.BlockHeader{bh}),
+		BlockHeaders: wireBlockHeadersToTBC([]*wire.BlockHeader{bh}),
 	}
 }
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -181,7 +181,7 @@ func TestBtcBlockHeadersByHeight(t *testing.T) {
 			continue
 		}
 
-		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightRawResponse {
+		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightResponse {
 			if err := json.Unmarshal(v.Payload, &response); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
**Summary**
Add `tbcapi-block-headers-by-height-raw-{request,response}` and convert existing command to respond with serialised data.

**Changes**
 - Add `tbcapi-block-headers-by-height-raw-{request,response}`
 - Convert existing `tbcapi-block-headers-by-height-response` to contain serialised data
