### PR TITLE
utxos-by-address raw vs cooked + tx-by-id cleanup

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -112,7 +112,7 @@ type UtxosByAddressRawRequest struct {
 
 type UtxosByAddressRawResponse struct {
 	Utxos []api.ByteSlice `json:"utxos"`
-	Error *protocol.Error `json:"error"`
+	Error *protocol.Error `json:"error,omitempty"`
 }
 
 type UtxosByAddressRequest struct {
@@ -129,7 +129,7 @@ type Utxo struct {
 
 type UtxosByAddressResponse struct {
 	Utxos []Utxo          `json:"utxos"`
-	Error *protocol.Error `json:"error"`
+	Error *protocol.Error `json:"error,omitempty"`
 }
 
 type TxByIdRawRequest struct {
@@ -138,7 +138,7 @@ type TxByIdRawRequest struct {
 
 type TxByIdRawResponse struct {
 	Tx    api.ByteSlice   `json:"tx"`
-	Error *protocol.Error `json:"error"`
+	Error *protocol.Error `json:"error,omitempty"`
 }
 
 type TxByIdRequest struct {
@@ -147,7 +147,7 @@ type TxByIdRequest struct {
 
 type TxByIdResponse struct {
 	Tx    Tx              `json:"tx"`
-	Error *protocol.Error `json:"error"`
+	Error *protocol.Error `json:"error,omitempty"`
 }
 
 type OutPoint struct {

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -29,6 +29,9 @@ const (
 	CmdBalanceByAddressRequest  = "tbcapi-balance-by-address-request"
 	CmdBalanceByAddressResponse = "tbcapi-balance-by-address-response"
 
+	CmdUtxosByAddressRawRequest  = "tbcapi-utxos-by-address-raw-request"
+	CmdUtxosByAddressRawResponse = "tbcapi-utxos-by-address-raw-response"
+
 	CmdUtxosByAddressRequest  = "tbcapi-utxos-by-address-request"
 	CmdUtxosByAddressResponse = "tbcapi-utxos-by-address-response"
 
@@ -101,14 +104,31 @@ type BalanceByAddressResponse struct {
 	Error   *protocol.Error `json:"error,omitempty"`
 }
 
+type UtxosByAddressRawRequest struct {
+	Address string `json:"address"`
+	Start   uint   `json:"start"`
+	Count   uint   `json:"count"`
+}
+
+type UtxosByAddressRawResponse struct {
+	Utxos []api.ByteSlice `json:"utxos"`
+	Error *protocol.Error `json:"error"`
+}
+
 type UtxosByAddressRequest struct {
 	Address string `json:"address"`
 	Start   uint   `json:"start"`
 	Count   uint   `json:"count"`
 }
 
+type Utxo struct {
+	TxId     api.ByteSlice `json:"tx_id"`
+	Value    uint64        `json:"value"`
+	OutIndex uint32        `json:"out_index"`
+}
+
 type UtxosByAddressResponse struct {
-	Utxos []api.ByteSlice `json:"utxos"`
+	Utxos []Utxo          `json:"utxos"`
 	Error *protocol.Error `json:"error"`
 }
 
@@ -165,6 +185,8 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdBlockHeadersBestResponse:     reflect.TypeOf(BlockHeadersBestResponse{}),
 	CmdBalanceByAddressRequest:      reflect.TypeOf(BalanceByAddressRequest{}),
 	CmdBalanceByAddressResponse:     reflect.TypeOf(BalanceByAddressResponse{}),
+	CmdUtxosByAddressRawRequest:     reflect.TypeOf(UtxosByAddressRawRequest{}),
+	CmdUtxosByAddressRawResponse:    reflect.TypeOf(UtxosByAddressRawResponse{}),
 	CmdUtxosByAddressRequest:        reflect.TypeOf(UtxosByAddressRequest{}),
 	CmdUtxosByAddressResponse:       reflect.TypeOf(UtxosByAddressResponse{}),
 	CmdTxByIdRawRequest:             reflect.TypeOf(TxByIdRawRequest{}),

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -271,7 +271,7 @@ func (s *Server) handleUtxosByAddressRawRequest(ctx context.Context, req *tbcapi
 
 		return &tbcapi.UtxosByAddressRawResponse{
 			Error: protocol.RequestErrorf("error getting utxos for address: %s", req.Address),
-		}, err
+		}, nil
 	}
 
 	var responseUtxos []api.ByteSlice
@@ -294,12 +294,12 @@ func (s *Server) handleUtxosByAddressRequest(ctx context.Context, req *tbcapi.Ut
 			e := protocol.NewInternalError(err)
 			return &tbcapi.UtxosByAddressResponse{
 				Error: e.ProtocolError(),
-			}, err
+			}, e
 		}
 
 		return &tbcapi.UtxosByAddressResponse{
 			Error: protocol.RequestErrorf("error getting utxos for address: %s", req.Address),
-		}, err
+		}, nil
 	}
 
 	var responseUtxos []tbcapi.Utxo
@@ -324,16 +324,16 @@ func (s *Server) handleTxByIdRawRequest(ctx context.Context, req *tbcapi.TxByIdR
 		responseErr := protocol.RequestErrorf("invalid tx id")
 		return &tbcapi.TxByIdRawResponse{
 			Error: responseErr,
-		}, responseErr
+		}, nil
 	}
 
 	tx, err := s.TxById(ctx, [32]byte(req.TxId))
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
-			responseErr := protocol.RequestErrorf("not found: %s", hex.EncodeToString(req.TxId))
+			responseErr := protocol.RequestErrorf("tx not found: %s", hex.EncodeToString(req.TxId))
 			return &tbcapi.TxByIdRawResponse{
 				Error: responseErr,
-			}, responseErr
+			}, nil
 		}
 
 		responseErr := protocol.NewInternalError(err)
@@ -363,7 +363,7 @@ func (s *Server) handleTxByIdRequest(ctx context.Context, req *tbcapi.TxByIdRequ
 		responseErr := protocol.RequestErrorf("invalid tx id")
 		return &tbcapi.TxByIdResponse{
 			Error: responseErr,
-		}, responseErr
+		}, nil
 	}
 
 	tx, err := s.TxById(ctx, [32]byte(req.TxId))
@@ -372,7 +372,7 @@ func (s *Server) handleTxByIdRequest(ctx context.Context, req *tbcapi.TxByIdRequ
 			responseErr := protocol.RequestErrorf("not found: %s", hex.EncodeToString(req.TxId))
 			return &tbcapi.TxByIdResponse{
 				Error: responseErr,
-			}, responseErr
+			}, nil
 		}
 
 		responseErr := protocol.NewInternalError(err)

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -76,6 +76,13 @@ func (s *Server) handleWebsocketRead(ctx context.Context, ws *tbcWs) {
 			}
 
 			go s.handleRequest(ctx, ws, id, cmd, handler)
+		case tbcapi.CmdUtxosByAddressRawRequest:
+			handler := func(ctx context.Context) (any, error) {
+				req := payload.(*tbcapi.UtxosByAddressRawRequest)
+				return s.handleUtxosByAddressRawRequest(ctx, req)
+			}
+
+			go s.handleRequest(ctx, ws, id, cmd, handler)
 		case tbcapi.CmdUtxosByAddressRequest:
 			handler := func(ctx context.Context) (any, error) {
 				req := payload.(*tbcapi.UtxosByAddressRequest)
@@ -249,6 +256,34 @@ func (s *Server) handleBalanceByAddressRequest(ctx context.Context, req *tbcapi.
 	}, nil
 }
 
+func (s *Server) handleUtxosByAddressRawRequest(ctx context.Context, req *tbcapi.UtxosByAddressRawRequest) (any, error) {
+	log.Tracef("handleUtxosByAddressRawRequest")
+	defer log.Tracef("handleUtxosByAddressRawRequest exit")
+
+	utxos, err := s.UtxosByAddress(ctx, req.Address, uint64(req.Start), uint64(req.Count))
+	if err != nil {
+		if errors.Is(err, level.ErrIterator) {
+			e := protocol.NewInternalError(err)
+			return &tbcapi.UtxosByAddressRawResponse{
+				Error: e.ProtocolError(),
+			}, err
+		}
+
+		return &tbcapi.UtxosByAddressRawResponse{
+			Error: protocol.RequestErrorf("error getting utxos for address: %s", req.Address),
+		}, err
+	}
+
+	var responseUtxos []api.ByteSlice
+	for _, utxo := range utxos {
+		responseUtxos = append(responseUtxos, utxo[:])
+	}
+
+	return &tbcapi.UtxosByAddressRawResponse{
+		Utxos: responseUtxos,
+	}, nil
+}
+
 func (s *Server) handleUtxosByAddressRequest(ctx context.Context, req *tbcapi.UtxosByAddressRequest) (any, error) {
 	log.Tracef("handleUtxosByAddressRequest")
 	defer log.Tracef("handleUtxosByAddressRequest exit")
@@ -259,18 +294,21 @@ func (s *Server) handleUtxosByAddressRequest(ctx context.Context, req *tbcapi.Ut
 			e := protocol.NewInternalError(err)
 			return &tbcapi.UtxosByAddressResponse{
 				Error: e.ProtocolError(),
-			}, e
+			}, err
 		}
 
-		// TODO(joshuasing): do not include raw err in errors sent to client
 		return &tbcapi.UtxosByAddressResponse{
-			Error: protocol.RequestErrorf("error getting utxos for address: %s", err),
-		}, nil
+			Error: protocol.RequestErrorf("error getting utxos for address: %s", req.Address),
+		}, err
 	}
 
-	var responseUtxos []api.ByteSlice
+	var responseUtxos []tbcapi.Utxo
 	for _, utxo := range utxos {
-		responseUtxos = append(responseUtxos, utxo[:])
+		responseUtxos = append(responseUtxos, tbcapi.Utxo{
+			TxId:     api.ByteSlice(utxo.ScriptHashSlice()),
+			Value:    utxo.Value(),
+			OutIndex: utxo.OutputIndex(),
+		})
 	}
 
 	return &tbcapi.UtxosByAddressResponse{
@@ -282,10 +320,25 @@ func (s *Server) handleTxByIdRawRequest(ctx context.Context, req *tbcapi.TxByIdR
 	log.Tracef("handleTxByIdRawRequest")
 	defer log.Tracef("handleTxByIdRawRequest exit")
 
-	tx, responseErr := s.txById(ctx, req.TxId)
-	if responseErr != nil {
+	if len(req.TxId) != 32 {
+		responseErr := protocol.RequestErrorf("invalid tx id")
 		return &tbcapi.TxByIdRawResponse{
 			Error: responseErr,
+		}, responseErr
+	}
+
+	tx, err := s.TxById(ctx, [32]byte(req.TxId))
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			responseErr := protocol.RequestErrorf("not found: %s", hex.EncodeToString(req.TxId))
+			return &tbcapi.TxByIdRawResponse{
+				Error: responseErr,
+			}, responseErr
+		}
+
+		responseErr := protocol.NewInternalError(err)
+		return &tbcapi.TxByIdRawResponse{
+			Error: responseErr.ProtocolError(),
 		}, responseErr
 	}
 
@@ -306,34 +359,31 @@ func (s *Server) handleTxByIdRequest(ctx context.Context, req *tbcapi.TxByIdRequ
 	log.Tracef("handleTxByIdRequest")
 	defer log.Tracef("handleTxByIdRequest exit")
 
-	tx, responseErr := s.txById(ctx, req.TxId)
-	if responseErr != nil {
+	if len(req.TxId) != 32 {
+		responseErr := protocol.RequestErrorf("invalid tx id")
 		return &tbcapi.TxByIdResponse{
 			Error: responseErr,
+		}, responseErr
+	}
+
+	tx, err := s.TxById(ctx, [32]byte(req.TxId))
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			responseErr := protocol.RequestErrorf("not found: %s", hex.EncodeToString(req.TxId))
+			return &tbcapi.TxByIdResponse{
+				Error: responseErr,
+			}, responseErr
+		}
+
+		responseErr := protocol.NewInternalError(err)
+		return &tbcapi.TxByIdResponse{
+			Error: responseErr.ProtocolError(),
 		}, responseErr
 	}
 
 	return &tbcapi.TxByIdResponse{
 		Tx: *wireTxToTbcapiTx(tx),
 	}, nil
-}
-
-func (s *Server) txById(ctx context.Context, txId api.ByteSlice) (*wire.MsgTx, *protocol.Error) {
-	if len(txId) != 32 {
-		return nil, protocol.RequestErrorf("invalid tx id")
-	}
-
-	tx, err := s.TxById(ctx, [32]byte(txId))
-	if err != nil {
-		// TODO(joshuasing): do not include raw err in errors sent to client
-		if errors.Is(err, database.ErrNotFound) {
-			return nil, protocol.RequestErrorf("not found: %s", err)
-		}
-
-		return nil, protocol.NewInternalError(err).ProtocolError()
-	}
-
-	return tx, nil
 }
 
 func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->
utxos-by-address raw vs cooked + tx-by-id cleanup

**Changes**
<!-- A list of changes made by this pull request. -->
this commit addresses two things:
* splitting up utxos-by-address into raw-vs-cooked
* fixing tx-by-id to return the error that will also be in the response; this allows us to print the error when responding

fixes #60 