### PR TITLE
tbcapi: split block-headers-best into raw and serialised

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -26,6 +26,9 @@ const (
 	CmdBlockHeadersByHeightRequest  = "tbcapi-block-headers-by-height-request"
 	CmdBlockHeadersByHeightResponse = "tbcapi-block-headers-by-height-response"
 
+	CmdBlockHeadersBestRawRequest  = "tbcapi-block-headers-best-raw-request"
+	CmdBlockHeadersBestRawResponse = "tbcapi-block-headers-best-raw-response"
+
 	CmdBlockHeadersBestRequest  = "tbcapi-block-headers-best-request"
 	CmdBlockHeadersBestResponse = "tbcapi-block-headers-best-response"
 
@@ -85,11 +88,19 @@ type BlockHeadersByHeightResponse struct {
 	Error        *protocol.Error `json:"error,omitempty"`
 }
 
+type BlockHeadersBestRawRequest struct{}
+
+type BlockHeadersBestRawResponse struct {
+	Height       uint64          `json:"height"`
+	BlockHeaders []api.ByteSlice `json:"block_headers"`
+	Error        *protocol.Error `json:"error,omitempty"`
+}
+
 type BlockHeadersBestRequest struct{}
 
 type BlockHeadersBestResponse struct {
 	Height       uint64          `json:"height"`
-	BlockHeaders []api.ByteSlice `json:"block_headers"`
+	BlockHeaders []*BlockHeader  `json:"block_headers"`
 	Error        *protocol.Error `json:"error,omitempty"`
 }
 
@@ -181,6 +192,8 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdBlockHeadersByHeightRawResponse: reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
 	CmdBlockHeadersByHeightRequest:     reflect.TypeOf(BlockHeadersByHeightRequest{}),
 	CmdBlockHeadersByHeightResponse:    reflect.TypeOf(BlockHeadersByHeightResponse{}),
+	CmdBlockHeadersBestRawRequest:      reflect.TypeOf(BlockHeadersBestRawRequest{}),
+	CmdBlockHeadersBestRawResponse:     reflect.TypeOf(BlockHeadersBestRawResponse{}),
 	CmdBlockHeadersBestRequest:         reflect.TypeOf(BlockHeadersBestRequest{}),
 	CmdBlockHeadersBestResponse:        reflect.TypeOf(BlockHeadersBestResponse{}),
 	CmdBalanceByAddressRequest:         reflect.TypeOf(BalanceByAddressRequest{}),


### PR DESCRIPTION
**Summary**
Rename the existing `tbcapi-block-headers-best` command to `tbcapi-block-headers-best-raw` and add `tbc-block-headers-best` which returns serialised data.

**Changes**
 - Add `Server.RawBlockHeadersBest()` which returns the best block headers as raw bytes
 - Rename previous `tbcapi-block-headers-best` to `tbcapi-block-headers-best-raw`
 - Add `tbcapi-block-headers-best` which returns serialised data
 - Clean up utility functions in `tbc_test.go` to improve readability and maintainability
 - Add `-noonion` and `-listenonion=0` flags to bitcoind in tbc_test, which prevents bitcoind from attempting to connect to the Tor control port
 - Use random hexadecimal encoded bytes as unique identifiers for bitcoind containers, which helps to further prevent container name collisions
 - Clean up some of the `tbc_test.go` code in an attempt improve readability and maintainability
 - Make `io.EOF` errors logged as trace messages in `handleWebsocketRead`