### PR TITLE
Add aggressive ping/pong to cull questionable connections.

### DIFF
--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -429,7 +429,7 @@ func (s *Server) peerManager(ctx context.Context) error {
 		return fmt.Errorf("no seeds found")
 	}
 
-	// Add a ticker that times out every 27 seconds regardless of what is
+	// Add a ticker that times out every 13 seconds regardless of what is
 	// going on. This will be nice and jittery and detect bad beers
 	// peridiocally.
 	loopTimeout := 13 * time.Second

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -543,13 +543,13 @@ func (s *Server) pingExpired(key any, value any) {
 	log.Tracef("pingExpired")
 	defer log.Tracef("pingExpired exit")
 
-	v, ok := value.(*peer)
+	p, ok := value.(*peer)
 	if !ok {
 		log.Errorf("invalid ping expired type: %T", value)
 		return
 	}
 	log.Debugf("pingExpired %v", key)
-	if err := v.close(); err != nil {
+	if err := p.close(); err != nil {
 		log.Errorf("ping %v: %v", key, err)
 	}
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -549,8 +549,7 @@ func (s *Server) pingExpired(key any, value any) {
 		return
 	}
 	log.Debugf("pingExpired %v", key)
-	err := v.close()
-	if err != nil {
+	if err := v.close(); err != nil {
 		log.Errorf("ping %v: %v", key, err)
 	}
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hemilabs/heminetwork/database/tbcd"
 	"github.com/hemilabs/heminetwork/database/tbcd/level"
 	"github.com/hemilabs/heminetwork/service/deucalion"
+	"github.com/hemilabs/heminetwork/ttl"
 )
 
 const (
@@ -57,7 +58,8 @@ const (
 
 	networkLocalnet = "localnet" // XXX this needs to be rethought
 
-	defaultCmdTimeout = 4 * time.Second
+	defaultCmdTimeout  = 4 * time.Second
+	defaultPingTimeout = 3 * time.Second
 )
 
 var (
@@ -192,6 +194,7 @@ type Server struct {
 
 	peers  map[string]*peer      // active but not necessarily connected
 	blocks map[string]*blockPeer // outstanding block downloads [hash]when/where
+	pings  *ttl.TTL
 
 	// IBD hints
 	lastBlockHeader tbcd.BlockHeader
@@ -219,12 +222,17 @@ func NewServer(cfg *Config) (*Server, error) {
 	if cfg == nil {
 		cfg = NewDefaultConfig()
 	}
+	pings, err := ttl.New(defaultPeersWanted)
+	if err != nil {
+		return nil, err
+	}
 	defaultRequestTimeout := 10 * time.Second // XXX: make config option?
 	s := &Server{
 		cfg:            cfg,
 		printTime:      time.Now().Add(10 * time.Second),
 		blocks:         make(map[string]*blockPeer, defaultPendingBlocks),
 		peers:          make(map[string]*peer, defaultPeersWanted),
+		pings:          pings,
 		blocksInserted: make(map[string]struct{}, 8192), // stats
 		timeSource:     blockchain.NewMedianTime(),
 		cmdsProcessed: prometheus.NewCounter(prometheus.CounterOpts{
@@ -424,7 +432,7 @@ func (s *Server) peerManager(ctx context.Context) error {
 	// Add a ticker that times out every 27 seconds regardless of what is
 	// going on. This will be nice and jittery and detect bad beers
 	// peridiocally.
-	loopTimeout := 27 * time.Second
+	loopTimeout := 13 * time.Second
 	loopTicker := time.NewTicker(loopTimeout)
 
 	x := 0
@@ -531,6 +539,22 @@ func (s *Server) startPeerManager(ctx context.Context) error {
 	return s.peerManager(ctx)
 }
 
+func (s *Server) pingExpired(key any, value any) {
+	log.Tracef("pingExpired")
+	defer log.Tracef("pingExpired exit")
+
+	v, ok := value.(*peer)
+	if !ok {
+		log.Errorf("invalid ping expired type: %T", value)
+		return
+	}
+	log.Debugf("pingExpired %v", key)
+	err := v.close()
+	if err != nil {
+		log.Errorf("ping %v: %v", key, err)
+	}
+}
+
 func (s *Server) pingAllPeers(ctx context.Context) {
 	log.Tracef("pingAllPeers")
 	defer log.Tracef("pingAllPeers exit")
@@ -549,6 +573,10 @@ func (s *Server) pingAllPeers(ctx context.Context) {
 			continue
 		}
 
+		// Cancel outstanding ping, should not happen
+		peer := p.String()
+		s.pings.Cancel(peer)
+
 		// We don't really care about the response. We just want to
 		// write to the connection to make it fail if the other side
 		// went away.
@@ -557,6 +585,9 @@ func (s *Server) pingAllPeers(ctx context.Context) {
 		if err != nil {
 			log.Errorf("ping %v: %v", p, err)
 		}
+
+		// Record outstanding ping
+		s.pings.Put(ctx, defaultPingTimeout, peer, p, s.pingExpired, nil)
 	}
 }
 
@@ -600,7 +631,7 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 	}
 	defer func() {
 		err := p.close()
-		if err != nil {
+		if err != nil && !errors.Is(err, net.ErrClosed) {
 			log.Errorf("peer disconnect: %v %v", p, err)
 		}
 	}()
@@ -685,6 +716,8 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 
 		case *wire.MsgPing:
 			go s.handlePing(ctx, p, m)
+		case *wire.MsgPong:
+			go s.handlePong(ctx, p, m)
 		default:
 			log.Tracef("unhandled message type %v: %T\n", p, msg)
 		}
@@ -787,6 +820,15 @@ func (s *Server) handlePing(ctx context.Context, p *peer, msg *wire.MsgPing) {
 		return
 	}
 	log.Tracef("handlePing %v: pong %v", p.address, pong.Nonce)
+}
+
+func (s *Server) handlePong(ctx context.Context, p *peer, pong *wire.MsgPong) {
+	log.Tracef("handlePong %v", p.address)
+	defer log.Tracef("handlePong exit %v", p.address)
+
+	s.pings.Cancel(p.String())
+
+	log.Tracef("handlePong %v: pong %v", p.address, pong.Nonce)
 }
 
 func (s *Server) handleInv(ctx context.Context, p *peer, msg *wire.MsgInv) {

--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -1,0 +1,111 @@
+package ttl
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var ErrNotFound = errors.New("not found")
+
+type value struct {
+	value any
+
+	expired func(any, any) // called when expired
+	remove  func(any, any) // called when removed
+
+	// Value context
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+type TTL struct {
+	mtx sync.Mutex
+
+	m map[any]value
+}
+
+func New(capacity int) (*TTL, error) {
+	return &TTL{
+		m: make(map[any]value, capacity),
+	}, nil
+}
+
+func (tm *TTL) ttl(ctx context.Context, key any) {
+	select {
+	case <-ctx.Done():
+		switch ctx.Err() {
+		case nil:
+			// not yet closed
+
+		case context.DeadlineExceeded:
+			// expired
+			tm.mtx.Lock()
+			defer tm.mtx.Unlock()
+			v, ok := tm.m[key]
+			if !ok {
+				return
+			}
+			if v.expired != nil {
+				go v.expired(key, v.value)
+			}
+
+			// For now assume we aways want to remove key
+			delete(tm.m, key)
+
+		case context.Canceled:
+			// This is the caller calling cancel
+			tm.mtx.Lock()
+			defer tm.mtx.Unlock()
+			v, ok := tm.m[key]
+			if !ok {
+				return
+			}
+			if v.remove != nil {
+				go v.remove(key, v.value)
+			}
+
+			// For now assume we aways want to remove key
+			delete(tm.m, key)
+		}
+	}
+}
+
+func (tm *TTL) Put(pctx context.Context, ttl time.Duration, key any, val any, expired func(any, any), remove func(any, any)) {
+	tm.mtx.Lock()
+	defer tm.mtx.Unlock()
+
+	v := value{
+		value:   val,
+		expired: expired,
+		remove:  remove,
+	}
+	v.ctx, v.cancel = context.WithTimeout(pctx, ttl)
+	tm.m[key] = v
+	go tm.ttl(v.ctx, key)
+}
+
+func (tm *TTL) Get(key any) (any, error) {
+	tm.mtx.Lock()
+	defer tm.mtx.Unlock()
+
+	v, ok := tm.m[key]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return v.value, nil
+}
+
+func (tm *TTL) Cancel(key any) error {
+	tm.mtx.Lock()
+	defer tm.mtx.Unlock()
+
+	v, ok := tm.m[key]
+	if !ok {
+		return ErrNotFound
+	}
+	v.cancel()
+
+	return nil
+}

--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2024 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
 package ttl
 
 import (

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -1,0 +1,98 @@
+package ttl
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+var (
+	tt *testing.T // ugly but serves a purpose
+	wg sync.WaitGroup
+)
+
+func callback(key any, value any) {
+	v, ok := value.(*sync.WaitGroup)
+	if !ok {
+		panic(fmt.Sprintf("invalid value type: %T", value))
+	}
+	tt.Logf("%v", spew.Sdump(key))
+	v.Done()
+}
+
+func callbackPanic(key any, value any) {
+	panic(fmt.Sprintf("unexpected callback: %v", spew.Sdump(key)))
+}
+
+func TestTTLExpire(t *testing.T) {
+	tt = t
+
+	count := 10
+	tm, err := New(count)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		tm.Put(ctx, time.Second, strconv.Itoa(i), &wg, callback, nil)
+	}
+	for i := 0; i < count; i++ {
+		key := strconv.Itoa(i)
+		_, err := tm.Get(key)
+		if err != nil {
+			t.Fatalf("%v: %v", key, err)
+		}
+	}
+
+	t.Logf("waiting for timeouts")
+	wg.Wait()
+
+	if len(tm.m) != 0 {
+		t.Fatalf("map not empty: %v", len(tm.m))
+	}
+}
+
+func TestTTLCancel(t *testing.T) {
+	tt = t
+
+	count := 10
+	tm, err := New(count)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		tm.Put(ctx, time.Second, strconv.Itoa(i), &wg, callbackPanic, callback)
+	}
+	for i := 0; i < count; i++ {
+		key := strconv.Itoa(i)
+		_, err := tm.Get(key)
+		if err != nil {
+			t.Fatalf("%v: %v", key, err)
+		}
+		err = tm.Cancel(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Logf("waiting for cancels")
+	wg.Wait()
+
+	if len(tm.m) != 0 {
+		t.Fatalf("map not empty: %v", len(tm.m))
+	}
+}

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2024 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
 package ttl
 
 import (

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -76,8 +76,7 @@ func TestTTLCancel(t *testing.T) {
 	}
 	for i := 0; i < count; i++ {
 		key := strconv.Itoa(i)
-		_, err := tm.Get(key)
-		if err != nil {
+		if _, err := tm.Get(key); err != nil {
 			t.Fatalf("%v: %v", key, err)
 		}
 		err = tm.Cancel(key)

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -44,8 +44,7 @@ func TestTTLExpire(t *testing.T) {
 	}
 	for i := 0; i < count; i++ {
 		key := strconv.Itoa(i)
-		_, err := tm.Get(key)
-		if err != nil {
+		if _, err := tm.Get(key); err != nil {
 			t.Fatalf("%v: %v", key, err)
 		}
 	}

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -79,8 +79,7 @@ func TestTTLCancel(t *testing.T) {
 		if _, err := tm.Get(key); err != nil {
 			t.Fatalf("%v: %v", key, err)
 		}
-		err = tm.Cancel(key)
-		if err != nil {
+		if err = tm.Cancel(key); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
The ttl package can be used to conveniently timeout events. Essentially it is a map that has an expiration per key.

**Summary**
`tbc` needs to schedule events in the future such as ping responses. This pr adds a convenient package to timeout or cancel events. The pings are needed to more aggressively kill misbehaving connections.

**Changes**
<!-- A list of changes made by this pull request. -->
