### PR TITLE
Fix typo 'keytone' -> 'keystone'

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ bssd has a few crucial requirements to run:
 Prerequisites: `docker`
 
 To run the full network locally, you can run the following.  Note that this will create
-L2Keytones and BTC Blocks at a high rate.  
+L2Keystones and BTC Blocks at a high rate.  
 
 note: the `--build` flag is optional if you want to rebuild your code
 

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -245,9 +245,9 @@ func (s *Server) handlePopPayoutsRequest(ctx context.Context, msg *bssapi.PopPay
 	}, nil
 }
 
-func (s *Server) handleL2KeytoneRequest(ctx context.Context, msg *bssapi.L2KeystoneRequest) (*bssapi.L2KeystoneResponse, error) {
-	log.Tracef("handleL2KeytoneRequest")
-	defer log.Tracef("handleL2KeytoneRequest exit")
+func (s *Server) handleL2KeystoneRequest(ctx context.Context, msg *bssapi.L2KeystoneRequest) (*bssapi.L2KeystoneResponse, error) {
+	log.Tracef("handleL2KeystoneRequest")
+	defer log.Tracef("handleL2KeystoneRequest exit")
 
 	_, err := s.callBFG(ctx, &bfgapi.NewL2KeystonesRequest{
 		L2Keystones: []hemi.L2Keystone{msg.L2Keystone},
@@ -343,7 +343,7 @@ func (s *Server) handleWebsocketRead(ctx context.Context, bws *bssWs) {
 		case bssapi.CmdL2KeystoneRequest:
 			handler := func(c context.Context) (any, error) {
 				msg := payload.(*bssapi.L2KeystoneRequest)
-				return s.handleL2KeytoneRequest(c, msg)
+				return s.handleL2KeystoneRequest(c, msg)
 			}
 
 			go s.handleRequest(ctx, bws, id, "handle l2 keystone request", handler)


### PR DESCRIPTION
**Summary**
Fix typo `keytone` -> `keystone`
Fixes #34

**Changes**
- Fix typo "keytone" -> "keystone"
