### PR TITLE
Replace os.Kill with syscall.SIGTERM in signal.Notify calls

### DIFF
--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/juju/loggo"
 
@@ -85,8 +86,7 @@ var (
 
 func HandleSignals(ctx context.Context, cancel context.CancelFunc, callback func(os.Signal)) {
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
-	signal.Notify(signalChan, os.Kill)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 	defer func() {
 		signal.Stop(signalChan)
 		cancel()

--- a/cmd/bssd/bssd.go
+++ b/cmd/bssd/bssd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/juju/loggo"
 
@@ -60,8 +61,7 @@ var (
 
 func HandleSignals(ctx context.Context, cancel context.CancelFunc, callback func(os.Signal)) {
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
-	signal.Notify(signalChan, os.Kill)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 	defer func() {
 		signal.Stop(signalChan)
 		cancel()

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/juju/loggo"
 
@@ -71,8 +72,7 @@ var (
 
 func handleSignals(ctx context.Context, cancel context.CancelFunc, callback func(os.Signal)) {
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
-	signal.Notify(signalChan, os.Kill)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 	defer func() {
 		signal.Stop(signalChan)
 		cancel()

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/juju/loggo"
 
@@ -85,8 +86,7 @@ var (
 
 func HandleSignals(ctx context.Context, cancel context.CancelFunc, callback func(os.Signal)) {
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
-	signal.Notify(signalChan, os.Kill)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 	defer func() {
 		signal.Stop(signalChan)
 		cancel()


### PR DESCRIPTION
**Summary**
Replace `os.Kill` with `syscall.SIGTERM` in `signal.Notify` calls.

[`os.Kill` is equal to `syscall.SIGKILL`](https://pkg.go.dev/os#pkg-constants:~:text=Kill%20%20%20%20%20%20Signal%20%3D%20syscall.SIGKILL)

SIGKILL cannot be caught on Unix-like systems.
SIGTERM is often used to request that an application terminate gracefully.

https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html
https://man.openbsd.org/signal

**Changes**
 - Replace `os.Kill` (syscall.SIGKILL) with `syscall.SIGTERM` in signal handlers