### PR TITLE
Track pending blocks with ttl package

### DIFF
--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1060,7 +1060,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 		if err != nil {
 			// This can happen during startup or when the network
 			// is starved.
-			// Probably too loud, remove later.
+			// XXX: Probably too loud, remove later.
 			log.Errorf("random peer %v: %v", hashS, err)
 			return
 		}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1068,6 +1068,11 @@ func (s *Server) syncBlocks(ctx context.Context) {
 			s.blockExpired, nil)
 		go s.downloadBlock(ctx, rp, hash)
 	}
+
+	if len(bm) == 0 {
+		// if we are complete we need to kick off utxo sync
+		go s.utxoIndexer(ctx)
+	}
 }
 
 func (s *Server) handleHeaders(ctx context.Context, p *peer, msg *wire.MsgHeaders) {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1027,7 +1027,7 @@ func (s *Server) randomPeer(ctx context.Context) (*peer, error) {
 		}
 		return p, nil
 	}
-	return nil, fmt.Errorf("no peers")
+	return nil, errors.New("no peers")
 }
 
 func (s *Server) syncBlocks(ctx context.Context) {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1034,7 +1034,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 	log.Tracef("syncBlocks")
 	defer log.Tracef("syncBlocks exit")
 
-	// Don't let want race. If we do the cache capacity will be overshot.
+	// Prevent race condition with 'want', which may cause the cache capacity to be exceeded.
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1922,7 +1922,6 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 	cfg := NewDefaultConfig()
 	cfg.LevelDBHome = home
 	cfg.Network = networkLocalnet
-	cfg.RegtestPort = mappedPeerPort.Port()
 	cfg.ListenAddress = tcbListenAddress
 	tbcServer, err := NewServer(cfg)
 	if err != nil {

--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -28,8 +28,8 @@ type value struct {
 }
 
 // TTL is an opaque structure that stores key/values in an internal map. These
-// values have a time-to-live callback functioned associated with them.
-// Depending on configuration eiher these values are automatically deleted from
+// values have a time-to-live callback functions associated with them.
+// Depending on configuration either these values are automatically deleted from
 // the map on expiration.
 type TTL struct {
 	mtx sync.Mutex

--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -27,7 +27,10 @@ type value struct {
 	cancel context.CancelFunc
 }
 
-// TTL is an opaque structure that wraps the TTL key/value map.
+// TTL is an opaque structure that stores key/values in an internal map. These
+// values have a time-to-live callback functioned associated with them.
+// Depending on configuration eiher these values are automatically deleted from
+// the map on expiration.
 type TTL struct {
 	mtx sync.Mutex
 

--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -13,8 +13,7 @@ import (
 
 var ErrNotFound = errors.New("not found")
 
-// value is an opaque structure that wraps a value that is store in the TTL
-// key/value map.
+// value wraps a value stored in the TTL map and includes additional metadata.
 type value struct {
 	value any
 


### PR DESCRIPTION
**Summary**
The pending block cache is scanned in various locations. Instead of scanning this makes the block expire using the ttl package and thus the code is more even driven and it locks less.

**Changes**
- Cope with the new ttl package for pings.
- Replace blockPeer map with ttl.

Fixes #84 