### PR TITLE
Added configurable fee-per-vB to PoP Miner

### DIFF
--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -66,6 +66,12 @@ var (
 			Help:         "the number of L2 Keystones behind the latest seen that we are willing to remine, this is handy for re-orgs",
 			Print:        config.PrintAll,
 		},
+		"POPM_STATIC_FEE": config.Config{
+			Value:        &cfg.StaticFee,
+			DefaultValue: uint(1),
+			Help:         "specify the number of sats/vB the PoP Miner will pay for fees",
+			Print:        config.PrintAll,
+		},
 	}
 )
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -73,6 +73,8 @@ type Config struct {
 	PrometheusListenAddress string
 
 	RetryMineThreshold uint
+
+	StaticFee uint
 }
 
 func NewDefaultConfig() *Config {
@@ -309,7 +311,7 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 
 	// Estimate BTC fees.
 	txLen := 285 // XXX for now all transactions are the same size
-	feePerKB := 1024
+	feePerKB := 1024 * m.cfg.StaticFee
 	feeAmount := (int64(txLen) * int64(feePerKB)) / 1024
 
 	// Check balance.


### PR DESCRIPTION
This adds the environment variable POPM_STATIC_FEE which can be used to configure a specific fee level for the PoP Miner to use.

Longer-term, BFG needs an RPC method for getting current network fee levels.