### PR TITLE
e2e: fix op-proposer op-node dependency condition (fixes #98)

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -268,7 +268,7 @@ services:
       op-geth-l2:
         condition: "service_healthy"
       op-node:
-        condition: "service_healthy"
+        condition: "service_started"
     command:
       - "op-proposer/bin/op-proposer"
       - "--poll-interval=1s"


### PR DESCRIPTION
**Summary**
Fix `e2e/docker-compose.yml` failing with `container e2e-op-node-1 has no healthcheck configured`.

op-proposer previously depended on op-node being in the condition "service_healthy", which will never be reached because op-node does not have any healthchecks configured.

Fixes #98 

**Changes**
 - Replace op-node dependency condition in op-proposer with `service_started`
