### PR TITLE
tbcapi: use reverse byte order for hashes in serialised, tidy up

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -30,8 +30,13 @@ func hexDecode(data []byte, length int) ([]byte, error) {
 // ByteSlice is used to hex encode addresses in JSON structs.
 type ByteSlice []byte
 
+// String returns the bytes as a hexadecimal string.
+func (bs ByteSlice) String() string {
+	return hex.EncodeToString(bs)
+}
+
 func (bs ByteSlice) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hex.EncodeToString(bs))
+	return json.Marshal(bs.String())
 }
 
 func (bs *ByteSlice) UnmarshalJSON(data []byte) error {

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -62,12 +62,12 @@ type (
 )
 
 type BlockHeader struct {
-	Version    int32  `json:"version"`
-	PrevHash   string `json:"prev_hash"`
-	MerkleRoot string `json:"merkle_root"`
-	Timestamp  int64  `json:"timestamp"`
-	Bits       string `json:"bits"`
-	Nonce      uint32 `json:"nonce"`
+	Version    int32         `json:"version"`
+	PrevHash   api.ByteSlice `json:"prev_hash"`   // reverse order
+	MerkleRoot api.ByteSlice `json:"merkle_root"` // reverse order
+	Timestamp  int64         `json:"timestamp"`
+	Bits       string        `json:"bits"`
+	Nonce      uint32        `json:"nonce"`
 }
 
 type BlockHeadersByHeightRawRequest struct {
@@ -131,7 +131,7 @@ type UtxosByAddressRequest struct {
 }
 
 type Utxo struct {
-	TxId     api.ByteSlice `json:"tx_id"`
+	TxId     api.ByteSlice `json:"tx_id"` // reverse order
 	Value    uint64        `json:"value"`
 	OutIndex uint32        `json:"out_index"`
 }
@@ -142,7 +142,7 @@ type UtxosByAddressResponse struct {
 }
 
 type TxByIdRawRequest struct {
-	TxId api.ByteSlice `json:"tx_id"`
+	TxId api.ByteSlice `json:"tx_id"` // natural order
 }
 
 type TxByIdRawResponse struct {
@@ -151,7 +151,7 @@ type TxByIdRawResponse struct {
 }
 
 type TxByIdRequest struct {
-	TxId api.ByteSlice `json:"tx_id"`
+	TxId api.ByteSlice `json:"tx_id"` // reverse order
 }
 
 type TxByIdResponse struct {
@@ -160,7 +160,7 @@ type TxByIdResponse struct {
 }
 
 type OutPoint struct {
-	Hash  api.ByteSlice `json:"hash"`
+	Hash  api.ByteSlice `json:"hash"` // reverse order
 	Index uint32        `json:"index"`
 }
 

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -137,7 +137,7 @@ type Utxo struct {
 }
 
 type UtxosByAddressResponse struct {
-	Utxos []Utxo          `json:"utxos"`
+	Utxos []*Utxo         `json:"utxos"`
 	Error *protocol.Error `json:"error,omitempty"`
 }
 
@@ -155,7 +155,7 @@ type TxByIdRequest struct {
 }
 
 type TxByIdResponse struct {
-	Tx    Tx              `json:"tx"`
+	Tx    *Tx             `json:"tx"`
 	Error *protocol.Error `json:"error,omitempty"`
 }
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1536,7 +1536,7 @@ func TestTxById(t *testing.T) {
 				t.Fatal(response.Error.Message)
 			}
 
-			tx, err := tbcServer.TxById(ctx, tbcd.TxId(txIdBytes))
+			tx, err := tbcServer.TxById(ctx, tbcd.TxId(reverseBytes(txIdBytes)))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1196,7 +1196,7 @@ func TestTxByIdRaw(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		slices.Reverse(txIdBytes)
+		slices.Reverse(txIdBytes) // convert to natural order
 
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 			TxId: txIdBytes,
@@ -1302,7 +1302,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 
 		txIdBytes[0]++
 
-		slices.Reverse(txIdBytes)
+		slices.Reverse(txIdBytes) // convert to natural order
 
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 			TxId: txIdBytes,
@@ -1415,7 +1415,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 
 		txIdBytes = append(txIdBytes, 8)
 
-		slices.Reverse(txIdBytes)
+		slices.Reverse(txIdBytes) // convert to natural order
 
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 			TxId: txIdBytes,
@@ -1511,8 +1511,6 @@ func TestTxById(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		slices.Reverse(txIdBytes)
 
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 			TxId: txIdBytes,
@@ -1614,8 +1612,6 @@ func TestTxByIdInvalid(t *testing.T) {
 		}
 
 		txIdBytes[0]++
-
-		slices.Reverse(txIdBytes)
 
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 			TxId: txIdBytes,
@@ -1727,8 +1723,6 @@ func TestTxByIdNotFound(t *testing.T) {
 		}
 
 		txIdBytes = append(txIdBytes, 8)
-
-		slices.Reverse(txIdBytes)
 
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 			TxId: txIdBytes,

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1543,7 +1543,7 @@ func TestTxById(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			w := wireTxToTbcapiTx(tx)
+			w := wireTxToTBC(tx)
 
 			if diff := deep.Equal(w, &response.Tx); len(diff) > 0 {
 				t.Fatal(diff)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1543,7 +1543,7 @@ func TestTxById(t *testing.T) {
 
 			w := wireTxToTBC(tx)
 
-			if diff := deep.Equal(w, &response.Tx); len(diff) > 0 {
+			if diff := deep.Equal(w, response.Tx); len(diff) > 0 {
 				t.Fatal(diff)
 			}
 


### PR DESCRIPTION
**Summary**
Use reverse byte order for hashes (tx ids, block ids and merkle root) serialised tbcapi request/responses.

Additionally, change `tbcapi` to consistently use pointers to structs for data in responses, preventing unwanted allocations and causes `null` to be returned instead of an empty object.

**Changes**
- Use reverse byte order for hashes in `tbcapi`
- Tidy up `wire.MsgTx` to `tbcapi.Tx` conversion function
- Consistently use pointers for data structs in `tbcapi` responses
