### PR TITLE
bfgd: fix loops unconditionally exited after one interation (SA4004)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,12 @@ lint-deps:
 	GOBIN=$(shell go env GOPATH)/bin go install mvdan.cc/gofumpt@latest
 	GOBIN=$(shell go env GOPATH)/bin go install github.com/google/addlicense@latest
 
+staticcheck:
+	$(shell go env GOPATH)/bin/staticcheck ./...
+
+staticcheck-deps:
+	GOBIN=$(shell go env GOPATH)/bin go install honnef.co/go/tools/cmd/staticcheck@latest
+
 tidy:
 	go mod tidy
 


### PR DESCRIPTION
**Summary**
Add a target to the Makefile to run [Staticcheck](https://staticcheck.io/), a "state of the art linter for the Go programming language" that uses static analysis.

Additionally, fix several issues detected by Staticcheck in the bfgd postgres database.

**Changes**
- Add `staticcheck` and `staticcheck-deps` make tasks.
- Fix several loops that were unconditionally exited after a single interation in `database/bfgd/postgres/postgres.go` (SA4004).
- Fix bug in `AccessPublicKeyDelete` implementation that caused `database.NotFoundError` to be returned even when a key was found and deleted.

**Notes**
It would be nice to add Staticcheck to the `lint` target in the future, however it currently reports a lot of issues, thus doing this would cause builds to fail.

*Passes tests and E2E networktest.*