### PR TITLE
ignore l2 keystones notifications in tests

### DIFF
--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -870,11 +870,11 @@ func TestL2Keystone(t *testing.T) {
 			continue
 		}
 
-		if command == bfgapi.CmdL2KeystonesResponse {
-			break
-		} else {
+		if command != bfgapi.CmdL2KeystonesResponse {
 			t.Fatalf("unexpected command %s", command)
 		}
+
+		break
 	}
 
 	l2KeystonesResponse := response.(*bfgapi.L2KeystonesResponse)


### PR DESCRIPTION
**Summary**
when we broadcast notifications for new l2 keystones, there is no guarantee when those broadcasts will be sent out since it is async.  we had a test that would create new keystones, then write an api rpc request, then wait for a response.  occasionally, the response would be the notifications for new l2 keystones that were created earlier in the tests.  

**Changes**
we can safely ignore those in this test.

fixes #110 
