### PR TITLE
database,e2e: remove use of deprecated `io/ioutil` (SA1019)

### DIFF
--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	mathrand "math/rand/v2"
 	"net/url"
 	"os"
@@ -123,7 +122,7 @@ func applySQLFiles(ctx context.Context, t *testing.T, sdb *sql.DB, path string) 
 	sort.Strings(sqlFiles)
 	for _, sqlFile := range sqlFiles {
 		t.Logf("Applying SQL file %v", filepath.Base(sqlFile))
-		sql, err := ioutil.ReadFile(sqlFile)
+		sql, err := os.ReadFile(sqlFile)
 		if err != nil {
 			t.Fatalf("Failed to read SQL file: %v", err)
 		}

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	mathrand "math/rand/v2"
 	"net"
@@ -159,7 +158,7 @@ func applySQLFiles(ctx context.Context, t *testing.T, sdb *sql.DB, path string) 
 
 	for _, sqlFile := range sqlFiles {
 		t.Logf("Applying SQL file %v", filepath.Base(sqlFile))
-		sql, err := ioutil.ReadFile(sqlFile)
+		sql, err := os.ReadFile(sqlFile)
 		if err != nil {
 			t.Fatalf("Failed to read SQL file: %v", err)
 		}


### PR DESCRIPTION
**Summary**
Remove use of `io/ioutil` package, which is deprecated as of Go 1.16 (SA1019).

**Changes**
- Use `os.ReadFile` instead of `ioutil.ReadFile` in `database/bfgd/database_ext_test.go`
- Use `os.ReadFile` instead of `ioutil.ReadFile` in `e2e/e2e_ext_test.go`
