### PR TITLE
bfgd: drop btc_blocks_can refresh triggers for l2_keystones/pop_basis

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	bfgdVersion = 6
+	bfgdVersion = 7
 
 	logLevel = "INFO"
 	verbose  = false

--- a/database/bfgd/scripts/0007.sql
+++ b/database/bfgd/scripts/0007.sql
@@ -8,4 +8,6 @@ UPDATE version SET version = 7;
 
 DROP TRIGGER btc_blocks_canonical_refresh_l2_keystones ON l2_keystones;
 
+DROP TRIGGER btc_blocks_canonical_refresh_pop_basis ON pop_basis;
+
 COMMIT;

--- a/database/bfgd/scripts/0007.sql
+++ b/database/bfgd/scripts/0007.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 7;
+
+DROP TRIGGER btc_blocks_canonical_refresh_l2_keystones ON l2_keystones;
+
+COMMIT;


### PR DESCRIPTION
**Summary**
prior, we were refreshing a materialized view on each l2_keystones insert/update.  this isn't needed as the materialized view doesn't use that table. 

**Changes**
 remove that trigger.
