### PR TITLE
drop all triggers materialized view triggers, move refreshing materialized view to queue/consumer paradigm

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -91,6 +91,7 @@ func (p *pgdb) materializedViewRefresher(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			return
 		case <-p.refreshMaterializedViewCh:
 			if err := p.refreshBTCBlocksCanonical(ctx); err != nil {
 				log.Errorf("error refreshing btc blocks canonical materialized view %s", err)

--- a/database/bfgd/scripts/0007.sql
+++ b/database/bfgd/scripts/0007.sql
@@ -1,0 +1,17 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 7;
+
+DROP TRIGGER btc_blocks_canonical_refresh_btc_blocks ON btc_blocks;
+
+DROP TRIGGER btc_blocks_canonical_refresh_l2_keystones ON l2_keystones;
+
+DROP TRIGGER btc_blocks_canonical_refresh_pop_basis ON pop_basis;
+
+DROP FUNCTION refresh_btc_blocks_can;
+
+COMMIT;


### PR DESCRIPTION
**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->

**Changes**
dropped all triggers that refresh our canonical chain materialized view.  now doing so in a "consumer" go routine to make this async
