### PR TITLE
hemictl: use sort.Strings(...) instead of sort.Sort(sort.StringSlice(...)) (S1032)

### DIFF
--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -824,7 +824,7 @@ func init() {
 	for k := range allCommands {
 		sortedCommands = append(sortedCommands, k)
 	}
-	sort.Sort(sort.StringSlice(sortedCommands))
+	sort.Strings(sortedCommands)
 }
 
 func usage() {


### PR DESCRIPTION
**Summary**
Simplify sorting string slice in hemictl.

**Changes**
- Use `sort.Strings(...)` instead of `sort.Sort(sort.StringSlice(...))` in hemictl package (S1032).
