### PR TITLE
popmd: remove unused 'handle' func and return err in connectBFG

### DIFF
--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -799,7 +799,7 @@ func (m *Miner) connectBFG(pctx context.Context) error {
 	log.Debugf("Connected to BFG: %s", m.cfg.BFGWSURL)
 	m.bfgWg.Wait()
 
-	return nil
+	return err
 }
 
 func (m *Miner) bfg(ctx context.Context) error {

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/http"
 	"slices"
 	"strings"
 	"sync"
@@ -661,11 +660,6 @@ func (m *Miner) promRunning() float64 {
 		return 1
 	}
 	return 0
-}
-
-func handle(service string, mux *http.ServeMux, pattern string, handler func(http.ResponseWriter, *http.Request)) {
-	mux.HandleFunc(pattern, handler)
-	log.Infof("handle (%v): %v", service, pattern)
 }
 
 func (m *Miner) handleBFGCallCompletion(parrentCtx context.Context, conn *protocol.Conn, bc bfgCmd) {


### PR DESCRIPTION
**Summary**
Remove unused `handle` function and return previously unused err in `connectBFG`.

**Changes**
- Remove unused `handle` function
- Return previously unused `err` in `connectBFG` function (bug)
