### PR TITLE
ci: fix bug that makes version type always 'unstable'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
           TYPE=unstable
-          if echo "VERSION" | grep -Eq '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'; then
+          if echo "$VERSION" | grep -Eq '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'; then
             TYPE=stable
           fi
           echo "Detected that $TAG is $TYPE"


### PR DESCRIPTION
**Summary**
Adds a missing `$` character that causes the version type to always be set to 'unstable' in the release workflow.

**Changes**
- Fix version type check in release workflow prepare step
