### PR TITLE
ci: use org DOCKERHUB_TOKEN secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
-          password: "${{ secrets.DOCKERHUB_PASSWORD }}"
+          password: "${{ secrets.DOCKERHUB_TOKEN }}"
 
       - name: "Login to GitHub Container Registry"
         if: github.event_name == 'push' || inputs.release


### PR DESCRIPTION
**Summary**
Use the `hemilabs` organisation-level `DOCKERHUB_TOKEN` secret.
Previously, a repository secret called `DOCKERHUB_PASSWORD` was used.

**Changes**
- Use `DOCKERHUB_TOKEN` secret instead of `DOCKERHUB_PASSWORD`

**Notes**
The existing `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` secrets on this repository should be removed in favour of the organisation-level secrets.