### PR TITLE
remove bug (and ineffiency) from MATERIALIZED VIEW

### DIFF
--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1445,16 +1445,6 @@ func TestBtcBlockGetCanonicalChainWithForks(t *testing.T) {
 			chainPattern:       []int{2, 1, 1},
 			unconfirmedIndices: []bool{false, false, false, false},
 		},
-		{
-			name:               "fork in beginning with break",
-			chainPattern:       []int{2, 1, 1, 1},
-			unconfirmedIndices: []bool{false, false, true, false},
-		},
-		{
-			name:               "fork in beginning with multiple breaks",
-			chainPattern:       []int{2, 1, 1, 1, 1},
-			unconfirmedIndices: []bool{false, true, false, true, false},
-		},
 	}
 
 	for _, tti := range testTable {
@@ -1522,11 +1512,6 @@ func TestPublications(t *testing.T) {
 			name:            "height in order",
 			heightPattern:   []int{1, 2, 3, 4},
 			expectedHeights: []int{4, 3, 2, 1},
-		},
-		{
-			name:            "height in order unconfirmed",
-			heightPattern:   []int{1, 2, -1, 4}, // use -1 to indicate unconfirmed
-			expectedHeights: []int{4, -1, 2, 1},
 		},
 	}
 

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	bfgdVersion = 7
+	bfgdVersion = 8
 
 	logLevel = "INFO"
 	verbose  = false

--- a/database/bfgd/scripts/0008.sql
+++ b/database/bfgd/scripts/0008.sql
@@ -1,0 +1,43 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 8;
+
+DROP MATERIALIZED VIEW btc_blocks_can;
+
+-- this materialized view represents the canonical btc_blocks as we know it
+CREATE MATERIALIZED VIEW btc_blocks_can AS 
+
+WITH RECURSIVE bb AS (
+			SELECT hash, header, height FROM btc_blocks
+			WHERE height = (
+				SELECT MAX(height) as height
+				FROM __highest
+				WHERE c = 1
+			)
+		
+			UNION 
+		
+			SELECT 
+				btc_blocks.hash, 
+				btc_blocks.header,
+				btc_blocks.height
+			FROM btc_blocks, bb
+			WHERE 
+
+            -- try to find the parent block via header -> parent hash
+			(
+				substr(bb.header, 5, 32) = btc_blocks.hash 
+				AND bb.height > btc_blocks.height
+			)
+		), __highest AS (
+			SELECT height, count(*) AS c
+			FROM btc_blocks
+			GROUP BY height
+		)
+SELECT * FROM bb;
+
+COMMIT;


### PR DESCRIPTION
**Summary**
previously, in our canonical chain MATERIALIZED VIEW, we would fall back to height if we couldn't find a previous block by hash

**Changes**
the aforementioned is incorrect (and inefficient), so remove it
