### PR TITLE
Stopgap to re-fetch blocks with no children

### DIFF
--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -26,6 +26,7 @@ type Database interface {
 	BtcBlockInsert(ctx context.Context, bb *BtcBlock) error
 	BtcBlockByHash(ctx context.Context, hash [32]byte) (*BtcBlock, error)
 	BtcBlockHeightByHash(ctx context.Context, hash [32]byte) (uint64, error)
+	BtcBlocksHeightsWithNoChildren(ctx context.Context) ([]uint64, error)
 
 	// Pop data
 	PopBasisByL2KeystoneAbrevHash(ctx context.Context, aHash [32]byte, excludeUnconfirmed bool) ([]PopBasis, error)

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1687,6 +1687,7 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 
 	createBlocksWithNoChildren := func(ctx context.Context, count int, db bfgd.Database) []int64 {
 		heights := make([]int64, count)
+		var prevHash []byte
 		for i := range count {
 			height := mathrand.Int64()
 			hash := make([]byte, 32)
@@ -1694,8 +1695,14 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 				t.Fatal(err)
 			}
 			header := make([]byte, 80)
-			if _, err := rand.Read(header); err != nil {
-				t.Fatal(err)
+			for {
+				if _, err := rand.Read(header); err != nil {
+					t.Fatal(err)
+				}
+
+				if !slices.Equal(prevHash, header[5:37]) {
+					break
+				}
 			}
 
 			btcBlock := bfgd.BtcBlock{
@@ -1709,6 +1716,7 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 			}
 
 			heights[i] = height
+			prevHash = hash
 		}
 
 		return heights
@@ -1736,16 +1744,9 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 			if _, err := rand.Read(hash); err != nil {
 				t.Fatal(err)
 			}
-
 			header := make([]byte, 80)
-			for {
-				if _, err := rand.Read(header); err != nil {
-					t.Fatal(err)
-				}
-
-				if !slices.Equal(prevHash, header[5:37]) {
-					break
-				}
+			if _, err := rand.Read(header); err != nil {
+				t.Fatal(err)
 			}
 
 			if len(prevHash) > 0 {
@@ -1810,7 +1811,7 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 			slices.Sort(heights)
 			slices.Sort(toCmp)
 
-			// we return a nil slice if empty, change that here for deep.Equal
+			// we return a nil slice if emtpy, change that here for deep.Equal
 			if len(heights) == 0 {
 				heights = []uint64{}
 			}

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1743,7 +1743,7 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				if !slices.Equal(hash, header[5:37]) {
+				if !slices.Equal(prevHash, header[5:37]) {
 					break
 				}
 			}

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1715,7 +1715,7 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 	}
 
 	createBlocksWithChildren := func(ctx context.Context, count int, db bfgd.Database, avoidHeights []int64, overlapHeights []int64) []int64 {
-		prevHash := []byte{}
+		var prevHash []byte
 		overlapHeightI := 0
 		heights := make([]int64, count)
 		for i := range count {

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1687,7 +1687,6 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 
 	createBlocksWithNoChildren := func(ctx context.Context, count int, db bfgd.Database) []int64 {
 		heights := make([]int64, count)
-		var prevHash []byte
 		for i := range count {
 			height := mathrand.Int64()
 			hash := make([]byte, 32)
@@ -1695,14 +1694,8 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 				t.Fatal(err)
 			}
 			header := make([]byte, 80)
-			for {
-				if _, err := rand.Read(header); err != nil {
-					t.Fatal(err)
-				}
-
-				if !slices.Equal(prevHash, header[5:37]) {
-					break
-				}
+			if _, err := rand.Read(header); err != nil {
+				t.Fatal(err)
 			}
 
 			btcBlock := bfgd.BtcBlock{
@@ -1716,7 +1709,6 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 			}
 
 			heights[i] = height
-			prevHash = hash
 		}
 
 		return heights

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1736,9 +1736,16 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 			if _, err := rand.Read(hash); err != nil {
 				t.Fatal(err)
 			}
+
 			header := make([]byte, 80)
-			if _, err := rand.Read(header); err != nil {
-				t.Fatal(err)
+			for {
+				if _, err := rand.Read(header); err != nil {
+					t.Fatal(err)
+				}
+
+				if !slices.Equal(hash, header[5:37]) {
+					break
+				}
 			}
 
 			if len(prevHash) > 0 {

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1803,7 +1803,7 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 			slices.Sort(heights)
 			slices.Sort(toCmp)
 
-			// we return a nil slice if emtpy, change that here for deep.Equal
+			// we return a nil slice if empty, change that here for deep.Equal
 			if len(heights) == 0 {
 				heights = []uint64{}
 			}

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	bfgdVersion = 7
+	bfgdVersion = 8
 
 	logLevel = "INFO"
 	verbose  = false

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -977,12 +977,10 @@ func (p *pgdb) BtcBlocksHeightsWithNoChildren(ctx context.Context) ([]uint64, er
 	// Excludes the tip because it will not have any children.
 	const q = `
 		SELECT height FROM btc_blocks bb1
-
-		WHERE NOT EXISTS (SELECT * FROM btc_blocks bb2 WHERE SUBSTR(bb2.header, 5, 32) = bb1.hash)
-		
+		WHERE NOT EXISTS (SELECT * FROM btc_blocks bb2 WHERE substr(bb2.header, 5, 32) = bb1.hash)
 		AND NOT EXISTS (
 			SELECT * FROM btc_blocks bb3 WHERE bb1.height = bb3.height 
-			AND EXISTS(
+			AND EXISTS (
 				SELECT * FROM btc_blocks bb4 WHERE substr(bb4.header, 5, 32) = bb3.hash
 			)
 		)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -965,9 +965,9 @@ func (p *pgdb) AccessPublicKeyDelete(ctx context.Context, publicKey *bfgd.Access
 	return nil
 }
 
-// BtcBlocksHeightsWithNoChildren returns the heights of blocks that have no
-// child blocks in our database, these represent possible forks that we have
-// not handled yet
+// BtcBlocksHeightsWithNoChildren returns the heights of blocks stored in the
+// database that do not have any children, these represent possible forks that
+// have not been handled yet.
 func (p *pgdb) BtcBlocksHeightsWithNoChildren(ctx context.Context) ([]uint64, error) {
 	log.Tracef("BtcBlocksHeightsWithNoChildren")
 	defer log.Tracef("BtcBlocksHeightsWithNoChildren exit")

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -972,12 +972,9 @@ func (p *pgdb) BtcBlocksHeightsWithNoChildren(ctx context.Context) ([]uint64, er
 	log.Tracef("BtcBlocksHeightsWithNoChildren")
 	defer log.Tracef("BtcBlocksHeightsWithNoChildren exit")
 
-	/*
-		give me all heights for btc blocks
-		where there does not exist a child of this block
-		and there are no other blocks at this height with children
-		exclude the tip because it won't have children by definition
-	*/
+	// Query all heights from btc_blocks where the block does not have any
+	// children and there are no other blocks at the same height with children.
+	// Excludes the tip because it will not have any children.
 	const q = `
 		SELECT height FROM btc_blocks bb1
 

--- a/database/bfgd/scripts/0008.sql
+++ b/database/bfgd/scripts/0008.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 8;
+
+CREATE INDEX btc_blocks_header_prev_hash_idx ON btc_blocks (substr(header, 5, 32));
+
+COMMIT;

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -191,7 +191,6 @@ func (s *Server) invalidBlockChecker(ctx context.Context) {
 					log.Errorf("error processing bitcoin block: %s", err)
 				}
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
**Summary**
in BFG, we only increment block height to get each block in the chain; if there is a fork, we don't handle for it.  

**Changes**
this introduces a check for blocks with no children, it will then "re-process" the block at that height from electrumx

fixes #130 