### PR TITLE
electrumx: fix unhandled error in NewJSONRPCRequest

### DIFF
--- a/hemi/electrumx/conn.go
+++ b/hemi/electrumx/conn.go
@@ -53,8 +53,11 @@ func (c *clientConn) call(ctx context.Context, method string, params, result any
 	defer c.mx.Unlock()
 	c.requestID++
 
-	req := NewJSONRPCRequest(c.requestID, method, params)
-	if err := writeRequest(ctx, c.conn, req); err != nil {
+	req, err := NewJSONRPCRequest(c.requestID, method, params)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if err = writeRequest(ctx, c.conn, req); err != nil {
 		return fmt.Errorf("write request: %w", err)
 	}
 

--- a/hemi/electrumx/conn_test.go
+++ b/hemi/electrumx/conn_test.go
@@ -80,12 +80,12 @@ func TestWriteRequest(t *testing.T) {
 	}{
 		{
 			name: "simple",
-			req:  NewJSONRPCRequest(1, "test", nil),
+			req:  mustNewJSONRPCRequest(1, "test", nil),
 			want: "{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"id\":1}\n",
 		},
 		{
 			name: "with params",
-			req: NewJSONRPCRequest(2, "test", map[string]any{
+			req: mustNewJSONRPCRequest(2, "test", map[string]any{
 				"test": true,
 			}),
 			want: "{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{\"test\":true},\"id\":2}\n",
@@ -302,4 +302,12 @@ func createAddress() string {
 		panic(fmt.Errorf("find free port: %w", err))
 	}
 	return fmt.Sprintf("localhost:%d", port)
+}
+
+func mustNewJSONRPCRequest(id uint64, method string, params any) *JSONRPCRequest {
+	req, err := NewJSONRPCRequest(id, method, params)
+	if err != nil {
+		panic(fmt.Errorf("create JSON RPC request: %w", err))
+	}
+	return req
 }

--- a/hemi/electrumx/electrumx.go
+++ b/hemi/electrumx/electrumx.go
@@ -36,7 +36,7 @@ type JSONRPCRequest struct {
 }
 
 // NewJSONRPCRequest creates a new JSONRPCRequest.
-func NewJSONRPCRequest(id uint64, method string, params any) *JSONRPCRequest {
+func NewJSONRPCRequest(id uint64, method string, params any) (*JSONRPCRequest, error) {
 	req := &JSONRPCRequest{
 		JSONRPC: "2.0",
 		Method:  method,
@@ -45,10 +45,11 @@ func NewJSONRPCRequest(id uint64, method string, params any) *JSONRPCRequest {
 	if params != nil {
 		b, err := json.Marshal(params)
 		if err != nil {
+			return nil, fmt.Errorf("marshal params: %w", err)
 		}
 		req.Params = b
 	}
-	return req
+	return req, nil
 }
 
 type JSONRPCResponse struct {


### PR DESCRIPTION
**Summary**
Fix unhandled error from `json.Marshal` in `NewJSONRPCRequest` function.

**Changes**
- Add error return value to `NewJSONRPCRequest`
- Return error from `json.Marshal` error in `NewJSONRPCRequest`
- Handle errors from `NewJSONRPCRequest`
