### PR TITLE
e2e: fix issues detected by staticcheck

### DIFF
--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -83,7 +83,7 @@ type bssWs struct { // XXX: use protocol.WSConn directly
 	conn *protocol.WSConn
 }
 
-type bfgWs bssWs // XXX: use protocol.WSConn directly unless
+type bfgWs bssWs // XXX: use protocol.WSConn directly
 
 // Setup some private keys and authenticators
 var (

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -56,7 +56,6 @@ import (
 	"github.com/hemilabs/heminetwork/hemi/pop"
 	"github.com/hemilabs/heminetwork/service/bfg"
 	"github.com/hemilabs/heminetwork/service/bss"
-	"github.com/hemilabs/heminetwork/service/popm"
 )
 
 const (
@@ -280,19 +279,6 @@ func nextPort(ctx context.Context, t *testing.T) int {
 			t.Fatal(err)
 		}
 	}
-}
-
-func createPopm(ctx context.Context, t *testing.T, bfgUrl string, bfgPrivateWsUrl string) (*popm.Miner, error) {
-	m, err := popm.NewMiner(&popm.Config{
-		BFGWSURL:      bfgPrivateWsUrl,
-		BTCChainName:  "testnet3",
-		BTCPrivateKey: "FC4B44FDC798E5D11229B84EC6B21B98EF40B0E4E1D12C6488CB5967F8CE94C6",
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return m, nil
 }
 
 func createBfgServerWithAuth(ctx context.Context, t *testing.T, pgUri string, electrumxAddr string, btcStartHeight uint64, auth bool) (*bfg.Server, string, string, string) {

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -1752,14 +1752,15 @@ func TestProcessBitcoinBlockNewBtcBlock(t *testing.T) {
 	defer _cancel()
 	var _err error
 	var _btcBlockHeader *bfgd.BtcBlock
+loop:
 	for {
 		select {
 		case <-_ctx.Done():
-			break
+			break loop
 		case <-time.After(1 * time.Second):
 			_btcBlockHeader, _err = db.BtcBlockByHash(ctx, [32]byte(btcHeaderHash))
 			if _err == nil {
-				break
+				break loop
 			}
 		}
 
@@ -1832,14 +1833,15 @@ func TestProcessBitcoinBlockNewFullPopBasis(t *testing.T) {
 	defer _cancel()
 	var _err error
 	var popBases []bfgd.PopBasis
+loop:
 	for {
 		select {
 		case <-_ctx.Done():
-			break
+			break loop
 		case <-time.After(1 * time.Second):
 			popBases, _err = db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()), false)
 			if _err == nil && len(popBases) > 0 {
-				break
+				break loop
 			}
 		}
 
@@ -2001,14 +2003,15 @@ func TestBitcoinBroadcastThenUpdate(t *testing.T) {
 	defer _cancel()
 	var _err error
 	var popBases []bfgd.PopBasis
+loop:
 	for {
 		select {
 		case <-_ctx.Done():
-			break
+			break loop
 		case <-time.After(1 * time.Second):
 			popBases, _err = db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()), true)
 			if _err == nil && len(popBases) > 0 {
-				break
+				break loop
 			}
 		}
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -80,13 +80,11 @@ var mockMerkleHashes = []string{
 
 var minerPrivateKeyBytes = []byte{1, 2, 3, 4, 5, 6, 7, 199} // XXX make this a real hardcoded key
 
-type bssWs struct {
-	wg   sync.WaitGroup
-	addr string
+type bssWs struct { // XXX: use protocol.WSConn directly
 	conn *protocol.WSConn
 }
 
-type bfgWs bssWs
+type bfgWs bssWs // XXX: use protocol.WSConn directly unless
 
 // Setup some private keys and authenticators
 var (


### PR DESCRIPTION
**Summary**
Fix issues reported by staticcheck for code in the `e2e` directory.

**Changes**
- Remove unused `wg` and `addr` fields from `bssWs`
- Remove unused `createPopm` function
- Fix ineffective break statements
- Rename variables prefixed with `_`
