### PR TITLE
ignore ulimits in tbc when on localnet

### DIFF
--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1662,7 +1662,7 @@ func (s *Server) Run(pctx context.Context) error {
 
 	// We need a lot of open files and memory for the indexes. Best effort
 	// to echo to the user what the ulimits are.
-	if s.ignoreUlimit {
+	if s.ignoreUlimit || s.cfg.Network == networkLocalnet {
 		log.Warningf("ignoring ulimit requirements")
 	} else if ulimitSupported {
 		if err := verifyUlimits(); err != nil {


### PR DESCRIPTION


**Summary**
localnet is small, and is easy for tbc to crawl and index.  with localnet, we often run it in CI environments where we have limited or no control over ulimits.  there is no need for this in localnet, so let's ignore it if we're on localnet.

**Changes**
if network set to localnet, ignore ulimits
