### PR TITLE
Add initial CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# This file exists to designate certain reviewers for certain areas of the
+# repository. This allows us to enhance security measures, streamline reviews
+# and help automate review requests.
+#
+# Most owners are people who have a lot of experience in a certain area of the
+# codebase, and as such are most suited to review changes to that area.
+#
+# Hemi Labs team members: If you feel you have a lot of experience in an area
+#  within the codebase, please add yourself as a code owner.
+
+# This is the default owner for all files in this repository.
+# Core Engineering is responsible for all source code in this repository.
+* @hemilabs/dev
+
+# GitHub Actions Workflows
+/.github/workflows/ @hemilabs/dev @joshuasing
+
+# Docker images
+/docker/ @hemilabs/dev @ClaytonNorthey92 @joshuasing
+
+# End-to-End testing
+/e2e/ @hemilabs/dev @ClaytonNorthey92
+
+# Pprof service
+/service/pprof/ @hemilabs/dev @joshuasing
+
+# Tiny Bitcoin Daemon (TBC)
+/api/tbcapi/    @hemilabs/dev @marcopeereboom @joshuasing
+/cmd/tbcd/      @hemilabs/dev @marcopeereboom
+/database/tbcd/ @hemilabs/dev @marcopeereboom
+/service/tbc/   @hemilabs/dev @marcopeereboom
+
+# WASM PoP Miner (popmd/wasm)
+/web/ @hemilabs/dev @joshuasing


### PR DESCRIPTION
**Summary**
Add initial `.github/CODEOWNERS` file ([GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)).

This file is useful for both security, as well as efficiency/automation.
People with experience in certain areas of the codebase will be automatically requested to review incoming changes, giving the right people a chance to review the pull request before it is merged.

In the future, branch protection rules could be used to enforce that at least one code owner "signs off" on the changes, however this has not been done yet.

**Changes**
 - Add `.github/CODEOWNERS`
