### PR TITLE
Remove height as the terminal condition for indexers.

### DIFF
--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -114,6 +114,19 @@ func (bh BlockHeader) Wire() (*wire.BlockHeader, error) {
 	return &wbh, nil
 }
 
+func (bh BlockHeader) BlockHash() *chainhash.Hash {
+	ch, _ := chainhash.NewHash(bh.Hash)
+	return ch
+}
+
+func (bh BlockHeader) ParentHash() *chainhash.Hash {
+	wh, err := bh.Wire()
+	if err != nil {
+		panic(err)
+	}
+	return &wh.PrevBlock
+}
+
 // Block contains a raw bitcoin block and its corresponding hash.
 type Block struct {
 	Hash  database.ByteArray
@@ -396,4 +409,34 @@ func NewTxMapping(txId, blockHash *chainhash.Hash) (txKey TxKey) {
 	copy(txKey[33:], blockHash[:])
 
 	return txKey
+}
+
+// Helper functions
+
+// B2H converts a raw bloc header to a wire block header structure.
+func B2H(header []byte) (*wire.BlockHeader, error) {
+	var bh wire.BlockHeader
+	if err := bh.Deserialize(bytes.NewReader(header)); err != nil {
+		return nil, fmt.Errorf("deserialize block header: %w", err)
+	}
+	return &bh, nil
+}
+
+// HeaderHash return the block hash from a raw block header.
+func HeaderHash(header []byte) *chainhash.Hash {
+	h, err := B2H(header)
+	if err != nil {
+		panic(err)
+	}
+	hash := h.BlockHash()
+	return &hash
+}
+
+// HeaderHash return the parent block hash from a raw block header.
+func HeaderParentHash(header []byte) *chainhash.Hash {
+	h, err := B2H(header)
+	if err != nil {
+		panic(err)
+	}
+	return &h.PrevBlock
 }

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/juju/loggo"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -57,31 +56,6 @@ var ErrIterator = IteratorError(errors.New("iteration error"))
 
 func init() {
 	loggo.ConfigureLoggers(logLevel)
-}
-
-func b2h(header []byte) (*wire.BlockHeader, error) {
-	var bh wire.BlockHeader
-	if err := bh.Deserialize(bytes.NewReader(header)); err != nil {
-		return nil, fmt.Errorf("deserialize block header: %w", err)
-	}
-	return &bh, nil
-}
-
-func headerHash(header []byte) *chainhash.Hash {
-	h, err := b2h(header)
-	if err != nil {
-		panic(err)
-	}
-	hash := h.BlockHash()
-	return &hash
-}
-
-func headerParentHash(header []byte) *chainhash.Hash {
-	h, err := b2h(header)
-	if err != nil {
-		panic(err)
-	}
-	return &h.PrevBlock
 }
 
 type ldb struct {
@@ -283,7 +257,7 @@ func decodeBlockHeader(ebh []byte) *tbcd.BlockHeader {
 	)
 	copy(header[:], ebh[8:88])
 	bh := &tbcd.BlockHeader{
-		Hash:   headerHash(header[:])[:],
+		Hash:   tbcd.HeaderHash(header[:])[:],
 		Height: binary.BigEndian.Uint64(ebh[0:8]),
 		Header: header[:],
 	}
@@ -295,7 +269,7 @@ func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, bh [80]byte) error {
 	log.Tracef("BlockHeaderGenesisInsert")
 	defer log.Tracef("BlockHeaderGenesisInsert exit")
 
-	wbh, err := b2h(bh[:])
+	wbh, err := tbcd.B2H(bh[:])
 	if err != nil {
 		return fmt.Errorf("block header insert b2h: %w", err)
 	}
@@ -399,7 +373,7 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs [][80]byte) (tbcd.Inse
 	// Ensure we can connect these blockheaders prior to starting database
 	// transaction. This also obtains the starting cumulative difficulty
 	// and  height.
-	wbh, err := b2h(bhs[0][:])
+	wbh, err := tbcd.B2H(bhs[0][:])
 	if err != nil {
 		return tbcd.ITInvalid, nil, nil,
 			fmt.Errorf("block headers insert b2h: %w", err)
@@ -483,7 +457,7 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs [][80]byte) (tbcd.Inse
 	for k, bh := range bhs {
 		// The first element is skipped, as it is pre-decoded.
 		if k != 0 {
-			wbh, err = b2h(bh[:])
+			wbh, err = tbcd.B2H(bh[:])
 			if err != nil {
 				return tbcd.ITInvalid, nil, nil,
 					fmt.Errorf("block headers insert b2h: %w", err)

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -66,6 +65,8 @@ const (
 )
 
 var (
+	zeroHash = &chainhash.Hash{} // used to validate invalid hashes
+
 	testnetSeeds = []string{
 		"testnet-seed.bitcoin.jonasschnelli.ch",
 		"seed.tbtc.petertodd.org",
@@ -883,7 +884,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 		// We can avoid quiescing by verifying if we are already done
 		// indexing.
 		if si := s.synced(ctx); si.Synced {
-			log.Tracef("already synced at %v", si.BlockHeaderHeight)
+			log.Tracef("already synced at %v", si.BlockHeader)
 			return
 		}
 
@@ -901,11 +902,12 @@ func (s *Server) syncBlocks(ctx context.Context) {
 		go func() {
 			// we really want to push the indexing reentrancy into this call
 			log.Infof("quiescing p2p and indexing to: %v", bhb.Height)
+			panic("quiescing p2p")
 			// XXX make hash
-			if err = s.SyncIndexersToHeight(ctx, bhb.Height+1); err != nil {
-				log.Errorf("sync blocks: %v", err)
-				return
-			}
+			//if err = s.SyncIndexersToHeight(ctx, bhb.Height+1); err != nil {
+			//	log.Errorf("sync blocks: %v", err)
+			//	return
+			//}
 		}()
 		return
 	}
@@ -1456,37 +1458,56 @@ func (s *Server) FeesAtHeight(ctx context.Context, height, count int64) (uint64,
 }
 
 type SyncInfo struct {
-	Synced            bool   // True when all indexing is caught up
-	BlockHeaderHeight uint64 // last block header height
-	UtxoHeight        uint64 // last indexed utxo block height
-	TxHeight          uint64 // last indexed tx block height
+	Synced      bool // True when all indexing is caught up
+	BlockHeader HashHeight
+	Utxo        HashHeight
+	Tx          HashHeight
+	// BlockHeaderHeight uint64 // last block header height
+	// UtxoHeight        uint64 // last indexed utxo block height
+	// TxHeight          uint64 // last indexed tx block height
 }
 
 func (s *Server) synced(ctx context.Context) (si SyncInfo) {
-	bhb, err := s.db.BlockHeaderBest(ctx)
-	if err != nil {
-		// This should never happen.
-		panic(err)
-	}
-	si.BlockHeaderHeight = bhb.Height
-
 	// These values are cached in leveldb so it is ok to call with mutex
 	// held.
 	//
 	// Note that index heights are start indexing values thus they are off
 	// by one from the last block height seen.
-	uh, err := s.db.MetadataGet(ctx, UtxoIndexHeightKey)
-	if err == nil {
-		si.UtxoHeight = binary.BigEndian.Uint64(uh) - 1
+	bhb, err := s.db.BlockHeaderBest(ctx)
+	if err != nil {
+		panic(err)
 	}
-	th, err := s.db.MetadataGet(ctx, TxIndexHeightKey)
-	if err == nil {
-		si.TxHeight = binary.BigEndian.Uint64(th) - 1
+	bhHash, err := chainhash.NewHash(bhb.Hash)
+	if err != nil {
+		panic(err)
 	}
-	if si.UtxoHeight == si.TxHeight && si.UtxoHeight == si.BlockHeaderHeight &&
+	// Ensure we have genesis or the Synced flag will be true if metadata
+	// does not exist.
+	if zeroHash.IsEqual(bhHash) {
+		panic("no genesis")
+	}
+	si.BlockHeader.Hash = *bhHash
+	si.BlockHeader.Height = bhb.Height
+
+	// utxo index
+	utxoHH, err := s.UtxoIndexHash(ctx)
+	if err != nil {
+		utxoHH = &HashHeight{}
+	}
+	si.Utxo = *utxoHH
+
+	// tx index
+	txHH, err := s.txIndexHash(ctx)
+	if err != nil {
+		txHH = &HashHeight{}
+	}
+	si.Tx = *txHH
+
+	if utxoHH.Hash.IsEqual(bhHash) && txHH.Hash.IsEqual(bhHash) &&
 		!s.blksMissing(ctx) {
 		si.Synced = true
 	}
+	log.Infof("=== synced %v", spew.Sdump(si))
 	return
 }
 
@@ -1500,6 +1521,7 @@ func (s *Server) Synced(ctx context.Context) SyncInfo {
 
 // DBOpen opens the underlying server database. It has been put in its own
 // function to make it available during tests and hemictl.
+// It would be good if it can be deleted.
 func (s *Server) DBOpen(ctx context.Context) error {
 	log.Tracef("DBOpen")
 	defer log.Tracef("DBOpen exit")

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -171,10 +171,13 @@ func TestForksWithGen(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				err = tbcServer.SyncIndexersToHeight(ctx, 201)
-				if err != nil {
-					t.Fatal(err)
+				if true {
+					panic("replace tbcServer.SyncIndexersToHeight with tbcServer.SyncIndexersToHash")
 				}
+				//err = tbcServer.SyncIndexersToHeight(ctx, 201)
+				//if err != nil {
+				//	t.Fatal(err)
+				//}
 
 				balance, err := tbcServer.BalanceByAddress(ctx, otherAddress.String())
 				if err != nil {
@@ -383,10 +386,13 @@ func TestForksWithGen(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				err = tbcServer.SyncIndexersToHeight(ctx, 201)
-				if err != nil {
-					t.Fatal(err)
+				if true {
+					panic("replace tbcServer.SyncIndexersToHeight with tbcServer.SyncIndexersToHash")
 				}
+				//err = tbcServer.SyncIndexersToHeight(ctx, 201)
+				//if err != nil {
+				//	t.Fatal(err)
+				//}
 
 				balance, err := tbcServer.BalanceByAddress(ctx, otherAddress.String())
 				if err != nil {
@@ -446,10 +452,11 @@ func TestForksWithGen(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				err = tbcServer.SyncIndexersToHeight(ctx, 310)
-				if err != nil {
-					t.Fatal(err)
-				}
+				panic("replace tbcServer.SyncIndexersToHeight with tbcServer.SyncIndexersToHash")
+				//err = tbcServer.SyncIndexersToHeight(ctx, 310)
+				//if err != nil {
+				//	t.Fatal(err)
+				//}
 			},
 		},
 		{
@@ -487,10 +494,13 @@ func TestForksWithGen(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				err = tbcServer.SyncIndexersToHeight(ctx, 201)
-				if err != nil {
-					t.Fatal(err)
+				if true {
+					panic("replace tbcServer.SyncIndexersToHeight with tbcServer.SyncIndexersToHash")
 				}
+				//err = tbcServer.SyncIndexersToHeight(ctx, 201)
+				//if err != nil {
+				//	t.Fatal(err)
+				//}
 
 				balance, err := tbcServer.BalanceByAddress(ctx, otherAddress.String())
 				if err != nil {
@@ -550,10 +560,11 @@ func TestForksWithGen(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				err = tbcServer.SyncIndexersToHeight(ctx, 310)
-				if err != nil {
-					t.Fatal(err)
-				}
+				panic("replace tbcServer.SyncIndexersToHeight with tbcServer.SyncIndexersToHash")
+				//err = tbcServer.SyncIndexersToHeight(ctx, 310)
+				//if err != nil {
+				//	t.Fatal(err)
+				//}
 			},
 		},
 	}

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -122,8 +122,8 @@ func (b *btcNode) handleGetData(m *wire.MsgGetData) (*wire.MsgBlock, error) {
 }
 
 func (b *btcNode) handleRPC(ctx context.Context, conn net.Conn) {
-	b.t.Logf("got conn %v", conn.RemoteAddr())
-	defer b.t.Logf("exit conn %v", conn.RemoteAddr())
+	b.t.Logf("handleRPC %v", conn.RemoteAddr())
+	defer b.t.Logf("handleRPC exit %v", conn.RemoteAddr())
 
 	p := &peer{
 		conn:            conn,


### PR DESCRIPTION
**Summary**
Currently height is being used as the terminal condition for indexers. This cannot be the case since this breaks during forks.

**Changes**
This PR adds a hash as the terminal condition for the indexers and catches potential forks.

Fixes #141 