### PR TITLE
Use hemilabs/websocket fork of nhooyr.io/websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/hemilabs/heminetwork
 
 go 1.22.2
 
+toolchain go1.22.3
+
+replace nhooyr.io/websocket v1.8.11 => github.com/hemilabs/websocket v0.0.0-20240620132401-b5109a38f904
+
 require (
 	github.com/btcsuite/btcd v0.24.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
@@ -23,7 +27,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/testcontainers/testcontainers-go v0.28.0
 	golang.org/x/sys v0.17.0
-	nhooyr.io/websocket v1.8.10
+	nhooyr.io/websocket v1.8.11
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
+github.com/hemilabs/websocket v0.0.0-20240620132401-b5109a38f904 h1:6kt/B7B5cQNpR0fiCPr53MU5sgao8Tj5NokLddTM3kU=
+github.com/hemilabs/websocket v0.0.0-20240620132401-b5109a38f904/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=
 github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o=
 github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -341,5 +343,3 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
 gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
-nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
-nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=


### PR DESCRIPTION
**Summary**
Use https://github.com/hemilabs/websocket fork of `nhooyr.io/websocket` library

The WASM implementation of the WebSocket connection in `nhooyr.io/websocket` contains a bug that causes `net.ErrClosed` to always be returned when the connection is closed, causing the underlying `websocket.CloseError` to never be returned. This fork contains a fix that returns the close error correctly. This patch will hopefully be upstreamed at a later date, once we are able to confirm that this fix is working correctly and doesn't change anything else.

Tested by running the `web/integrationtest` and providing a private key that is not authorised on the BFG server.
The exit behaviour now matches the `popmd` daemon.

**Changes**
 - Use `github.com/hemilabs/websocket` instead of `nhooyr.io/websocket` (likely temporarily)
