### PR TITLE
popm/wasm: add error codes

### DIFF
--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -24,23 +24,35 @@ const (
 	MethodBitcoinUTXOs   Method = "bitcoinUTXOs"   // Retrieve bitcoin UTXOs
 )
 
-// ErrorCode is a unique identifier used to differentiate between error types.
-type ErrorCode string
+// ErrorCode is used to differentiate between error types.
+type ErrorCode uint32
 
 const (
 	// ErrorCodeInternal is used when the error is internal, either due to an
 	// invalid dispatch or a panic.
-	ErrorCodeInternal ErrorCode = "internal"
+	ErrorCodeInternal ErrorCode = 0
 
 	// ErrorCodeInvalidValue is used when an invalid value was provided for
 	// a dispatch argument.
-	ErrorCodeInvalidValue ErrorCode = "invalid-value"
+	ErrorCodeInvalidValue ErrorCode = 1000
 )
+
+// String returns a string value representing the error code.
+func (e ErrorCode) String() string {
+	switch e {
+	case ErrorCodeInternal:
+		return "internal error"
+	case ErrorCodeInvalidValue:
+		return "invalid value"
+	default:
+		return "unknown"
+	}
+}
 
 // Error represents an error that has occurred within the WASM PoP Miner.
 type Error struct {
 	// Code is a unique identifier used to differentiate between error types.
-	Code ErrorCode `json:"code,omitempty"`
+	Code ErrorCode `json:"code"`
 
 	// Message is the error message.
 	Message string `json:"message"`

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -30,11 +30,11 @@ type ErrorCode uint32
 const (
 	// ErrorCodeInternal is used when the error is internal, either due to an
 	// invalid dispatch or a panic.
-	ErrorCodeInternal ErrorCode = 0
+	ErrorCodeInternal ErrorCode = 1000
 
 	// ErrorCodeInvalidValue is used when an invalid value was provided for
 	// a dispatch argument.
-	ErrorCodeInvalidValue ErrorCode = 1000
+	ErrorCodeInvalidValue ErrorCode = 1001
 )
 
 // String returns a string value representing the error code.

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -24,8 +24,24 @@ const (
 	MethodBitcoinUTXOs   Method = "bitcoinUTXOs"   // Retrieve bitcoin UTXOs
 )
 
+// ErrorCode is a unique identifier used to differentiate between error types.
+type ErrorCode string
+
+const (
+	// ErrorCodeInternal is used when the error is internal, either due to an
+	// invalid dispatch or a panic.
+	ErrorCodeInternal ErrorCode = "internal"
+
+	// ErrorCodeInvalidValue is used when an invalid value was provided for
+	// a dispatch argument.
+	ErrorCodeInvalidValue ErrorCode = "invalid-value"
+)
+
 // Error represents an error that has occurred within the WASM PoP Miner.
 type Error struct {
+	// Code is a unique identifier used to differentiate between error types.
+	Code ErrorCode `json:"code,omitempty"`
+
 	// Message is the error message.
 	Message string `json:"message"`
 

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -34,7 +34,7 @@ const (
 
 	// ErrorCodeInvalidValue is used when an invalid value was provided for
 	// a dispatch argument.
-	ErrorCodeInvalidValue ErrorCode = 1001
+	ErrorCodeInvalidValue ErrorCode = 2000
 )
 
 // String returns a string value representing the error code.

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -30,6 +30,10 @@ const (
 type ErrorCode uint32
 
 const (
+	// errorCodeInvalid is the zero value of ErrorCode.
+	// This should not be used for anything.
+	errorCodeInvalid ErrorCode = 0
+
 	// ErrorCodeInternal is used when the error is internal, either due to an
 	// invalid dispatch or a panic.
 	ErrorCodeInternal ErrorCode = 1000
@@ -42,6 +46,8 @@ const (
 // String returns a string value representing the error code.
 func (e ErrorCode) String() string {
 	switch e {
+	case errorCodeInvalid:
+		return "invalid error code"
 	case ErrorCodeInternal:
 		return "internal error"
 	case ErrorCodeInvalidValue:

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -6,6 +6,8 @@
 
 package main
 
+import "syscall/js"
+
 // Method represents a method that can be dispatched.
 type Method string
 
@@ -47,6 +49,10 @@ func (e ErrorCode) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+func (e ErrorCode) JSValue() js.Value {
+	return jsValueSafe(uint32(e))
 }
 
 // Error represents an error that has occurred within the WASM PoP Miner.

--- a/web/popminer/util.go
+++ b/web/popminer/util.go
@@ -21,6 +21,10 @@ var (
 	arrayConstructor   = js.Global().Get("Array")
 )
 
+type JSValuer interface {
+	JSValue() js.Value
+}
+
 // jsValueOf returns x as a JavaScript value.
 //
 //	| Go                     | JavaScript             |
@@ -43,7 +47,7 @@ func jsValueOf(x any) js.Value {
 		return t
 	case js.Func:
 		return t.Value
-	case interface{ JSValue() js.Value }:
+	case JSValuer:
 		return t.JSValue()
 	case bool,
 		int, int8, int16, int32, int64,
@@ -189,7 +193,7 @@ func jsValueSafe(v any) (jsv js.Value) {
 
 	// Special handling
 	switch x := v.(type) {
-	case interface{ JSValue() js.Value }:
+	case JSValuer:
 		return x.JSValue()
 	}
 

--- a/web/popminer/util.go
+++ b/web/popminer/util.go
@@ -43,6 +43,8 @@ func jsValueOf(x any) js.Value {
 		return t
 	case js.Func:
 		return t.Value
+	case interface{ JSValue() js.Value }:
+		return t.JSValue()
 	case bool,
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64, uintptr,
@@ -187,8 +189,8 @@ func jsValueSafe(v any) (jsv js.Value) {
 
 	// Special handling
 	switch x := v.(type) {
-	case ErrorCode:
-		return js.ValueOf(uint32(x))
+	case interface{ JSValue() js.Value }:
+		return x.JSValue()
 	}
 
 	return js.ValueOf(v)

--- a/web/popminer/util.go
+++ b/web/popminer/util.go
@@ -188,7 +188,7 @@ func jsValueSafe(v any) (jsv js.Value) {
 	// Special handling
 	switch x := v.(type) {
 	case ErrorCode:
-		return js.ValueOf(string(x))
+		return js.ValueOf(uint32(x))
 	}
 
 	return js.ValueOf(v)

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -8,27 +8,25 @@
   <head>
     <meta charset="UTF-8" />
     <title>PoP miner integration tests</title>
-  </head>
-
-  <body>
     <script src="wasm_exec.js"></script>
     <script src="popminer.js"></script>
-
-    <p>
+  </head>
+  <body>
+    <div>
       <button id="VersionButton">version</button>
-      <span class="VersionShow"></span>
-    </p>
+      <pre class="VersionShow"></pre>
+    </div>
 
-    <p>
+    <div>
       <input id="GenerateKeyNetworkInput" value="testnet3">
       <label for="GenerateKeyNetworkInput">bitcoin network</label>
       <br>
 
       <button id="GenerateKeyButton">generate key</button>
-      <span class="GenerateKeyShow"></span>
-    </p>
+      <pre class="GenerateKeyShow"></pre>
+    </div>
 
-    <p>
+    <div>
       <input id="StartPopMinerLogLevelInput" value="hemiwasm=INFO:popm=INFO:protocol=INFO">
       <label for="StartPopMinerLogLevelInput">log level</label>
       <br>
@@ -45,55 +43,55 @@
       <br>
 
       <button id="StartPopMinerButton">Run PoP Miner</button>
-      <span class="StartPopMinerShow"></span>
-    </p>
+      <pre class="StartPopMinerShow"></pre>
+    </div>
 
-    <p>
+    <div>
       <button id="StopPopMinerButton">Stop PoP Miner</button>
-      <span class="StopPopMinerShow"></span>
-    </p>
+      <pre class="StopPopMinerShow"></pre>
+    </div>
 
     <!-- connected commands go here, run after StartPopMinerButton -->
     <hr>
-    <div>The following commands require a live connection (after StartPopMinerButton)</div>
+    <p>The following commands require a live connection (after StartPopMinerButton)</p>
     <br>
 
-    <p>
+    <div>
       <button id="PingButton">ping</button>
-      <span class="PingShow"></span>
-    </p>
+      <pre class="PingShow"></pre>
+    </div>
 
-    <p>
+    <div>
       <input id="L2KeystonesNumL2KeystonesInput" value="2" type="number">
       <label for="L2KeystonesNumL2KeystonesInput">num l2 keystones</label>
       <br>
 
       <button id="L2KeystonesButton">l2 keystones</button>
-      <span class="L2KeystonesShow"></span>
-    </p>
+      <pre class="L2KeystonesShow"></pre>
+    </div>
 
-    <p>
+    <div>
       <input id="BitcoinBalanceScriptHashInput" value="xxx">
       <label for="BitcoinBalanceScriptHashInput">script hash</label>
       <br>
 
       <button id="BitcoinBalanceButton">bitcoin balance</button>
-      <span class="BitcoinBalanceShow"></span>
-    </p>
+      <pre class="BitcoinBalanceShow"></pre>
+    </div>
 
-    <p>
+    <div>
       <button id="BitcoinInfoButton">bitcoin info</button>
-      <span class="BitcoinInfoShow"></span>
-    </p>
+      <pre class="BitcoinInfoShow"></pre>
+    </div>
 
-    <p>
+    <div>
       <input id="BitcoinUTXOsScriptHashInput" value="xxx">
       <label for="BitcoinUTXOsScriptHashInput">script hash</label>
       <br>
 
       <button id="BitcoinUTXOsButton">bitcoin utxos</button>
-      <span class="BitcoinUTXOsShow"></span>
-    </p>
+      <pre class="BitcoinUTXOsShow"></pre>
+    </div>
 
     <script src="index.js" defer></script>
   </body>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -26,9 +26,9 @@ async function Version() {
     const result = await dispatch({
       method: 'version',
     });
-    VersionShow.innerText = JSON.stringify(result);
+    VersionShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    VersionShow.innerText = 'error: ' + JSON.stringify(err);
+    VersionShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -46,9 +46,9 @@ async function GenerateKey() {
       method: 'generateKey',
       network: GenerateKeyNetworkInput.value,
     });
-    GenerateKeyShow.innerText = JSON.stringify(result);
+    GenerateKeyShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    GenerateKeyShow.innerText = 'error: ' + JSON.stringify(err);
+    GenerateKeyShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -69,9 +69,9 @@ async function StartPopMiner() {
       privateKey: StartPopMinerPrivateKeyInput.value,
       staticFee: Number(StartPopMinerStaticFeeInput.value),
     });
-    StartPopMinerShow.innerText = JSON.stringify(result);
+    StartPopMinerShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    StartPopMinerShow.innerText = 'error: ' + JSON.stringify(err);
+    StartPopMinerShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -88,9 +88,9 @@ async function StopPopMiner() {
     const result = await dispatch({
       method: 'stopPoPMiner',
     });
-    StopPopMinerShow.innerText = JSON.stringify(result);
+    StopPopMinerShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    StopPopMinerShow.innerText = 'error: ' + JSON.stringify(err);
+    StopPopMinerShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -107,9 +107,9 @@ async function Ping() {
     const result = await dispatch({
       method: 'ping', // Timestamp is handled by Go.
     });
-    PingShow.innerText = JSON.stringify(result);
+    PingShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    PingShow.innerText = 'error: ' + JSON.stringify(err);
+    PingShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -127,9 +127,9 @@ async function L2Keystones() {
       method: 'l2Keystones',
       numL2Keystones: Number(L2KeystonesNumL2KeystonesInput.value),
     });
-    L2KeystonesShow.innerText = JSON.stringify(result);
+    L2KeystonesShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    L2KeystonesShow.innerText = 'error: ' + JSON.stringify(err);
+    L2KeystonesShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -147,9 +147,9 @@ async function BitcoinBalance() {
       method: 'bitcoinBalance',
       scriptHash: BitcoinBalanceScriptHashInput.value,
     });
-    BitcoinBalanceShow.innerText = JSON.stringify(result);
+    BitcoinBalanceShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    BitcoinBalanceShow.innerText = 'error: ' + JSON.stringify(err);
+    BitcoinBalanceShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -166,9 +166,9 @@ async function BitcoinInfo() {
     const result = await dispatch({
       method: 'bitcoinInfo',
     });
-    BitcoinInfoShow.innerText = JSON.stringify(result);
+    BitcoinInfoShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    BitcoinInfoShow.innerText = 'error: ' + JSON.stringify(err);
+    BitcoinInfoShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }
@@ -186,9 +186,9 @@ async function BitcoinUTXOs() {
       method: 'bitcoinUTXOs',
       scriptHash: BitcoinUTXOsScriptHashInput.value,
     });
-    BitcoinUTXOsShow.innerText = JSON.stringify(result);
+    BitcoinUTXOsShow.innerText = JSON.stringify(result, null, 2);
   } catch (err) {
-    BitcoinUTXOsShow.innerText = 'error: ' + JSON.stringify(err);
+    BitcoinUTXOsShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
     console.error('Caught exception', err);
   }
 }


### PR DESCRIPTION
**Summary**
Add error codes to the WebAssembly PoP Miner.
These error codes will be used to programatically handle errors and display useful information to users.

The default error code is ErrorCodeInternal ("internal").

**Changes**
 - Add `ErrorCode` type and add `Code` field to the existing `Error` type
 - Add `ErrorCodeInternal` for use with internal errors (and is the default error code)
 - Add `ErrorCodeInvalidValue` for use when an invalid value is provided for an argument, currently only used in `generateKey`
 - Refactor how some elements are displayed in integration test web page to help with testing
 - Add `codedError` type, used to include an error code in an error that is extracted when creating an `Error` that will be converted to a JavaScript Object

More error codes will be added as needed in future pull requests.
