### PR TITLE
tbc: allow seeds to be overwritten

### DIFF
--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -96,7 +96,7 @@ var (
 		"TBC_SEEDS": config.Config{
 			Value:        &cfg.Seeds,
 			DefaultValue: []string{},
-			Help:         "list of tbc seeds, format of <host>:<port>",
+			Help:         "list of seed domains for Bitcoin P2P, in the format '<host>:<port>' (for localnet, must be a single host:port)",
 			Print:        config.PrintAll,
 		},
 	}

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -93,6 +93,12 @@ var (
 			Help:         "address and port tbcd pprof listens on (open <address>/debug/pprof to see available profiles)",
 			Print:        config.PrintAll,
 		},
+		"TBC_SEEDS": config.Config{
+			Value:        &cfg.Seeds,
+			DefaultValue: []string{},
+			Help:         "list of tbc seeds, format of <host>:<port>",
+			Print:        config.PrintAll,
+		},
 	}
 )
 
@@ -139,6 +145,7 @@ func _main() error {
 	if err != nil {
 		return fmt.Errorf("create tbc server: %w", err)
 	}
+
 	// XXX remove, this is an illustration of calling the direct API of server
 	// go func() {
 	//	for {

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 type PrintMode int
@@ -88,6 +89,8 @@ func Parse(c CfgMap) error {
 				}
 
 				reflect.ValueOf(v.Value).Elem().SetBool(val)
+			case reflect.Slice:
+				*(v.Value.(*[]string)) = strings.Split(envValue, ",")
 
 			default:
 				return fmt.Errorf("unsuported type for %v: %v",

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,8 @@ func Parse(c CfgMap) error {
 
 				reflect.ValueOf(v.Value).Elem().SetBool(val)
 			case reflect.Slice:
-				*(v.Value.(*[]string)) = strings.Split(envValue, ",")
+				// we assume that the slice here can be appended to (ex. an empty slice)
+				reflect.AppendSlice(reflect.ValueOf(v.Value), reflect.ValueOf(strings.Split(envValue, ",")))
 
 			default:
 				return fmt.Errorf("unsuported type for %v: %v",

--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,8 @@ func Parse(c CfgMap) error {
 				reflect.ValueOf(v.Value).Elem().SetBool(val)
 			case reflect.Slice:
 				// we assume that the slice here can be appended to (ex. an empty slice)
-				reflect.AppendSlice(reflect.ValueOf(v.Value), reflect.ValueOf(strings.Split(envValue, ",")))
+				value := reflect.ValueOf(v.Value).Elem()
+				value.Set(reflect.AppendSlice(value, reflect.ValueOf(strings.Split(envValue, ","))))
 
 			default:
 				return fmt.Errorf("unsuported type for %v: %v",

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,6 @@ func Parse(c CfgMap) error {
 
 				reflect.ValueOf(v.Value).Elem().SetBool(val)
 			case reflect.Slice:
-				// we assume that the slice here can be appended to (ex. an empty slice)
 				value := reflect.ValueOf(v.Value).Elem()
 				value.Set(reflect.AppendSlice(value, reflect.ValueOf(strings.Split(envValue, ","))))
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -315,7 +315,7 @@ func (s *Server) seed(pctx context.Context, peersWanted int) ([]tbcd.Peer, error
 	for _, v := range s.seeds {
 		host, port, err := net.SplitHostPort(v)
 		if err != nil {
-			log.Errorf("SplitHostPort: %v", err)
+			log.Errorf("Failed to parse host/port: %v", err)
 			errorsSeen++
 			continue
 		}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -313,13 +313,13 @@ func (s *Server) seed(pctx context.Context, peersWanted int) ([]tbcd.Peer, error
 	errorsSeen := 0
 	var moreSeeds []tbcd.Peer
 	for _, v := range s.seeds {
-		_, port, err := net.SplitHostPort(v)
+		host, port, err := net.SplitHostPort(v)
 		if err != nil {
 			log.Errorf("SplitHostPort: %v", err)
 			errorsSeen++
 			continue
 		}
-		ips, err := resolver.LookupIP(ctx, "ip", v)
+		ips, err := resolver.LookupIP(ctx, "ip", host)
 		if err != nil {
 			log.Errorf("lookup: %v", err)
 			errorsSeen++

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -64,7 +64,7 @@ var (
 	zeroHash = new(chainhash.Hash) // used to check if a hash is invalid
 
 	localnetSeeds = []string{
-		"bitcoind:18444",
+		"127.0.0.1:18444",
 	}
 	testnetSeeds = []string{
 		"testnet-seed.bitcoin.jonasschnelli.ch:18333",

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -493,13 +493,7 @@ func (s *Server) localPeerManager(ctx context.Context) error {
 	peersWanted := 1
 	peerC := make(chan string, peersWanted)
 
-	host, port, err := net.SplitHostPort(s.seeds[0])
-	if err != nil {
-		return err
-	}
-
-	address := net.JoinHostPort(host, port)
-	peer, err := NewPeer(s.wireNet, address)
+	peer, err := NewPeer(s.wireNet, s.seeds[0])
 	if err != nil {
 		return fmt.Errorf("new peer: %w", err)
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -48,10 +48,6 @@ const (
 
 	promSubsystem = "tbc_service" // Prometheus
 
-	mainnetPort  = "8333"
-	testnetPort  = "18333"
-	localnetPort = "18444"
-
 	defaultPeersWanted   = 64
 	defaultPendingBlocks = 128 // 128 * ~4MB max memory use
 
@@ -68,21 +64,21 @@ var (
 	zeroHash = new(chainhash.Hash) // used to check if a hash is invalid
 
 	localnetSeeds = []string{
-		fmt.Sprintf("bitcoind:%s", localnetPort),
+		"bitcoind:18444",
 	}
 	testnetSeeds = []string{
-		fmt.Sprintf("testnet-seed.bitcoin.jonasschnelli.ch:%s", testnetPort),
-		fmt.Sprintf("seed.tbtc.petertodd.org:%s", testnetPort),
-		fmt.Sprintf("seed.testnet.bitcoin.sprovoost.nl:%s", testnetPort),
-		fmt.Sprintf("testnet-seed.bluematt.me:%s", testnetPort),
+		"testnet-seed.bitcoin.jonasschnelli.ch:18333",
+		"seed.tbtc.petertodd.org:18333",
+		"seed.testnet.bitcoin.sprovoost.nl:18333",
+		"testnet-seed.bluematt.me:18333",
 	}
 	mainnetSeeds = []string{
-		fmt.Sprintf("seed.bitcoin.sipa.be:%s", mainnetPort),
-		fmt.Sprintf("dnsseed.bluematt.me:%s", mainnetPort),
-		fmt.Sprintf("dnsseed.bitcoin.dashjr.org:%s", mainnetPort),
-		fmt.Sprintf("seed.bitcoinstats.com:%s", mainnetPort),
-		fmt.Sprintf("seed.bitnodes.io:%s", mainnetPort),
-		fmt.Sprintf("seed.bitcoin.jonasschnelli.ch:%s", mainnetPort),
+		"seed.bitcoin.sipa.be:8333",
+		"dnsseed.bluematt.me:8333",
+		"dnsseed.bitcoin.dashjr.org:8333",
+		"seed.bitcoinstats.com:8333",
+		"seed.bitnodes.io:8333",
+		"seed.bitcoin.jonasschnelli.ch:8333",
 	}
 )
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -821,7 +821,7 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 	cfg.LevelDBHome = home
 	cfg.Network = networkLocalnet
 	cfg.ListenAddress = tcbListenAddress
-	cfg.Seeds = []Seed{{Host: "127.0.0.1", Port: localnetPort}}
+	cfg.Seeds = []string{fmt.Sprintf("127.0.0.1:%s", localnetPort)}
 	tbcServer, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -821,7 +821,7 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 	cfg.LevelDBHome = home
 	cfg.Network = networkLocalnet
 	cfg.ListenAddress = tcbListenAddress
-	cfg.Seeds = []string{fmt.Sprintf("127.0.0.1:%s", localnetPort)}
+	cfg.Seeds = []string{"127.0.0.1:18444"}
 	tbcServer, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -1033,5 +1033,5 @@ func createBitcoindWithInitialBlocks(ctx context.Context, t *testing.T, blocks u
 		t.Fatal(err)
 	}
 
-	return bitcoindContainer, nat.Port(localnetPort)
+	return bitcoindContainer, nat.Port("18444")
 }

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -821,7 +821,6 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 	cfg.LevelDBHome = home
 	cfg.Network = networkLocalnet
 	cfg.ListenAddress = tcbListenAddress
-	cfg.Seeds = []string{"127.0.0.1:18444"}
 	tbcServer, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -821,6 +821,7 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 	cfg.LevelDBHome = home
 	cfg.Network = networkLocalnet
 	cfg.ListenAddress = tcbListenAddress
+	cfg.Seeds = []string{"127.0.0.1"}
 	tbcServer, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -821,7 +821,7 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 	cfg.LevelDBHome = home
 	cfg.Network = networkLocalnet
 	cfg.ListenAddress = tcbListenAddress
-	cfg.Seeds = []string{"127.0.0.1"}
+	cfg.Seeds = []Seed{{Host: "127.0.0.1", Port: localnetPort}}
 	tbcServer, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -534,6 +534,7 @@ func TestFork(t *testing.T) {
 		Network:                 networkLocalnet,
 		PeersWanted:             1,
 		PrometheusListenAddress: "",
+		Seeds:                   []string{"127.0.0.1"},
 	}
 	_ = loggo.ConfigureLoggers(cfg.LogLevel)
 	s, err := NewServer(cfg)

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -534,7 +534,7 @@ func TestFork(t *testing.T) {
 		Network:                 networkLocalnet,
 		PeersWanted:             1,
 		PrometheusListenAddress: "",
-		Seeds:                   []Seed{{Host: "127.0.0.1", Port: localnetPort}},
+		Seeds:                   []string{fmt.Sprintf("127.0.0.1:%s", localnetPort)},
 	}
 	_ = loggo.ConfigureLoggers(cfg.LogLevel)
 	s, err := NewServer(cfg)

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -534,7 +534,6 @@ func TestFork(t *testing.T) {
 		Network:                 networkLocalnet,
 		PeersWanted:             1,
 		PrometheusListenAddress: "",
-		Seeds:                   []string{"127.0.0.1:18444"},
 	}
 	_ = loggo.ConfigureLoggers(cfg.LogLevel)
 	s, err := NewServer(cfg)

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -534,7 +534,7 @@ func TestFork(t *testing.T) {
 		Network:                 networkLocalnet,
 		PeersWanted:             1,
 		PrometheusListenAddress: "",
-		Seeds:                   []string{"127.0.0.1"},
+		Seeds:                   []Seed{{Host: "127.0.0.1", Port: localnetPort}},
 	}
 	_ = loggo.ConfigureLoggers(cfg.LogLevel)
 	s, err := NewServer(cfg)

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -534,7 +534,7 @@ func TestFork(t *testing.T) {
 		Network:                 networkLocalnet,
 		PeersWanted:             1,
 		PrometheusListenAddress: "",
-		Seeds:                   []string{fmt.Sprintf("127.0.0.1:%s", localnetPort)},
+		Seeds:                   []string{"127.0.0.1:18444"},
 	}
 	_ = loggo.ConfigureLoggers(cfg.LogLevel)
 	s, err := NewServer(cfg)


### PR DESCRIPTION
**Summary**
allow tbc seeds to be overwritten

**Changes**
if cfg seeds are set, use those, otherwise use the defaults for the network chosen

fixes #157 