### PR TITLE
ci: improve runtime of high usage CI workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,10 +51,10 @@ jobs:
 
       - name: "Download and verify dependencies"
         id: deps
-        run: make deps
+        run: make GOCACHE="$(go env GOCACHE)" deps
 
       - name: "make race"
-        run: make race
+        run: make GOCACHE="$(go env GOCACHE)" race
 
       - name: "make"
         if: (success() || failure()) && steps.deps.outcome == 'success'
@@ -62,7 +62,7 @@ jobs:
           PGTESTURI: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
           HEMI_DOCKER_TESTS: "1"
         run: |
-          make
+          make GOCACHE="$(go env GOCACHE)"
           git diff --exit-code
 
       - name: "make web popm"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,6 +49,20 @@ jobs:
           cache: true
           check-latest: true
 
+      - name: "Retrieve GOPATH"
+        id: retrieve
+        run: echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_OUTPUT"
+
+      - name: "Setup GOPATH/bin cache"
+        uses: actions/cache@v4
+        with:
+          path: "${{ steps.retrieve.outputs.GOPATH }}/bin/"
+          key: "${{ runner.os }}-${{ runner.arch }}-gobin-go${{ env.GO_VERSION }}-${{ hashFiles('**/Makefile') }}"
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-gobin-go${{ env.GO_VERSION }}-${{ hashFiles('**/Makefile') }}
+            ${{ runner.os }}-${{ runner.arch }}-gobin-go${{ env.GO_VERSION }}-
+            ${{ runner.os }}-${{ runner.arch }}-gobin-
+
       - name: "Download and verify dependencies"
         id: deps
         run: make GOCACHE="$(go env GOCACHE)" deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           check-latest: true
 
       - name: "Download and verify dependencies"
-        run: make deps
+        run: make GOCACHE="$(go env GOCACHE)" deps
 
       - name: "Create binary archive for ${{ matrix.goos }}/${{ matrix.goarch }}"
         env:
@@ -105,7 +105,7 @@ jobs:
           GOARCH: "${{ matrix.goarch }}"
           CGO_ENABLED: 0 # Disable CGO.
           GOGC: off # Disable GC during build, faster but uses more RAM.
-        run: make archive
+        run: make GOCACHE="$(go env GOCACHE)" archive
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           check-latest: true
 
       - name: "Download and verify dependencies"
-        run: make GOCACHE="$(go env GOCACHE)" deps
+        run: make GOCACHE="$(go env GOCACHE)" go-deps
 
       - name: "Create binary archive for ${{ matrix.goos }}/${{ matrix.goarch }}"
         env:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ cmds = \
 	popmd	\
 	tbcd
 
-.PHONY: all clean clean-dist deps $(cmds) build install lint lint-deps tidy race test vulncheck \
+.PHONY: all clean clean-dist deps go-deps $(cmds) build install lint lint-deps tidy race test vulncheck \
 	vulncheck-deps dist archive sources checksums
 
 all: lint tidy test build install
@@ -42,7 +42,9 @@ clean-dist:
 clean-test:
 	rm -rf $(PROJECTPATH)/service/tbc/.testleveldb/
 
-deps: lint-deps vulncheck-deps
+deps: lint-deps vulncheck-deps go-deps
+
+go-deps:
 	go mod download
 	go mod verify
 


### PR DESCRIPTION
**Summary**
This pull request aims to improve the runtime of "high usage CI workflows" (i.e. `go.yml` and parts of `release.yml`).
These CI workflows are rather slow, partially due to the amount of time certain tests are currently taking, but also due to the lack of correctly configured caching in some workflows.

The average runtime of the `go.yml` workflow is currently **365.9 seconds (6~ minutes)**.

The repository root `Makefile` changes the `GOCACHE` environment variable, resulting in Go writing the build cache to a directory stored within the repository (not in git), allowing for easy clean up with `make clean`.

This has some benefits, however none of them apply to CI environments. The `actions/setup-go` action has built-in support for caching installed Go mod dependencies, as well as build cache.

We are currently using the Go mod dependency cache, however due to the `GOCACHE` environment variable being changed, nothing is being stored in the directory in which the action expects the build cache to be stored. By overriding `GOCACHE` and setting it to the default (`go env GOCACHE`), Go will store the build cache in the expected directory, allowing the `actions/setup-go` action to cache its contents.

We also download and build (`go install`) a collection of CLIs that we use for linting, formatting, license compliance and more: 
https://github.com/hemilabs/heminetwork/blob/main/Makefile#L64-L67
https://github.com/hemilabs/heminetwork/blob/main/Makefile#L73
https://github.com/hemilabs/heminetwork/blob/main/Makefile#L88

We can use the `actions/cache` action to cache these as well, making it less likely that Go will need to download, build and install each binary. (Go will still check for the latest version, due to the `@latest` tag).

**Changes**
  - Add `GOCACHE=$(go env GOCACHE)` to `make` commands in CI to override the non-default cache path used in the Makefile.
  - Use `actions/cache@v4` to cache contents of `$GOPATH/bin/`
  - Add `go-deps` target to `Makefile` which only installs Go mod dependencies, and use it in `release.yml`

**Future improvements**
This pull request does not speed up anything other than build times (by a tiny amount) and the time it takes to install the binaries used for linting/vulncheck/etc.

The runtime could further be improved by improving a lot of the Docker tests, which are currently slow due to having to create, interact with, and stop docker containers. Other tests could possibly be run on a scheduled workflow, instead of needing to be run for every pull request.