### PR TITLE
ci: add labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,76 @@
+# Bitcoin Finality Governor (BFG)
+'area: bfg':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/bfgapi/**"
+          - "cmd/bfgd/**"
+          - "database/bfgd/**"
+          - "docker/bfgd/**"
+          - "service/bfg/**"
+
+# Bitcoin Secure Sequencer (BSS)
+'area: bss':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/bssapi/**"
+          - "cmd/bssd/**"
+          - "docker/bssd/**"
+          - "service/bss/**"
+
+# GitHub Actions workflows (CI)
+'area: ci':
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+# Deucalion (Prometheus service)
+'area: deucalion':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "service/deucalion/**"
+
+# Docker images
+'area: docker':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docker/**"
+
+# hemictl
+'area: hemictl':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "cmd/hemictl/**"
+
+# @hemilabs/pop-miner NPM package
+'area: @hemilabs/pop-miner':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "web/packages/pop-miner/**"
+
+# Makefiles
+'area: make':
+  - changed-files:
+      - any-glob-to-any-file: "**/Makefile"
+
+# WebAssembly PoP Miner
+'area: popm/wasm':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "web/popminer/**"
+
+# PoP Miner
+'area: popm':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "cmd/popmd/**"
+          - "docker/popmd/**"
+          - "service/popm/**"
+
+# Tiny Bitcoin Daemon (TBC)
+'area: tbc':
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/tbcapi/**"
+          - "cmd/tbcd/**"
+          - "database/tbcd/**"
+          - "service/tbc/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
 # Bitcoin Finality Governor (BFG)
 'area: bfg':
   - changed-files:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+# GitHub Actions workflow to automatically label pull requests.
+name: "Label"
+on: [ "pull_request_target" ]
+
+jobs:
+  labeler:
+    name: "Pull Request"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: "Label pull requests"
+        uses: actions/labeler@v5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
 # GitHub Actions workflow to automatically label pull requests.
 name: "Label"
 on: [ "pull_request_target" ]


### PR DESCRIPTION
**Summary**
Add a GitHub Actions workflow that will automatically label pull requests based on the files modified by the pull request.
This should allow pull requests to be labeled more accurately, while reducing the amount of time required to update labels.

Uses https://github.com/actions/labeler. At a later date, it might be worth considering a third-party action that supports adding labels by age, size, etc.

**Changes**
 - Add labeler workflow: `.github/workflows/labeler.yml`
 - Add labeler config: `.github/labeler.yml`
