### PR TITLE
ci: add registry-url to setup-node in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,7 @@ jobs:
           check-latest: true
           cache: "pnpm"
           cache-dependency-path: "web/**/pnpm-lock.yaml"
+          registry-url: "https://registry.npmjs.org"
 
       - name: "Install dependencies"
         working-directory: "web/"


### PR DESCRIPTION
**Summary**
Add `registry-url` to `actions/setup-node` in release workflow.
This should fix the error that caused the last NPM release job to fail.

**Changes**
 - Set `registry-url: "https://registry.npmjs.org"` when running `actions/setup-node` in the `.github/workflows/release.yml` workflow.
