### PR TITLE
popm/wasm: add 'parseKey' method

### DIFF
--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -9,7 +9,7 @@ import type {
   BitcoinBalanceResult,
   BitcoinInfoResult,
   BitcoinUTXOsResult,
-  GenerateKeyResult,
+  KeyResult,
   L2KeystonesResult,
   PingResult,
   VersionResult,
@@ -31,7 +31,15 @@ export const generateKey: typeof types.generateKey = ({ network }) => {
   return dispatch({
     method: 'generateKey',
     network: network,
-  }) as Promise<GenerateKeyResult>;
+  }) as Promise<KeyResult>;
+};
+
+export const parseKey: typeof types.parseKey = ({ network, privateKey }) => {
+  return dispatch({
+    method: 'parseKey',
+    network: network,
+    privateKey: privateKey,
+  }) as Promise<KeyResult>;
 };
 
 export const startPoPMiner: typeof types.startPoPMiner = (args) => {

--- a/web/packages/pop-miner/src/browser/wasm.ts
+++ b/web/packages/pop-miner/src/browser/wasm.ts
@@ -15,6 +15,7 @@ export type Method =
   | 'version'
   | 'wasmPing'
   | 'generateKey'
+  | 'parseKey'
   | 'startPoPMiner'
   | 'stopPoPMiner'
   | 'ping'

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -98,12 +98,12 @@ export type VersionResult = {
   /**
    * The version of the WASM PoP Miner.
    */
-  version: string;
+  readonly version: string;
 
   /**
    * The SHA-1 hash of the Git commit the WASM binary was built from.
    */
-  gitCommit: string;
+  readonly gitCommit: string;
 };
 
 /**
@@ -121,30 +121,37 @@ export type GenerateKeyArgs = {
   network: 'testnet3' | 'mainnet';
 };
 
-export type GenerateKeyResult = {
+/**
+ * Contains a secp256k1 key pair and its corresponding Bitcoin address and
+ * public key hash, and Ethereum address.
+ *
+ * @see generateKey
+ * @see parseKey
+ */
+export type KeyResult = {
   /**
-   * The Ethereum address for the generated key.
+   * The Ethereum address for the key.
    */
   readonly ethereumAddress: string;
 
   /**
-   * The network for which the key was generated.
+   * The network the addresses were created for.
    */
   readonly network: 'testnet3' | 'mainnet';
 
   /**
-   * The generated secpk256k1 private key, encoded as a hexadecimal string.
+   * The secp256k1 private key, encoded as a hexadecimal string.
    */
   readonly privateKey: string;
 
   /**
-   * The secpk256k1 public key for the generated key, in the 33-byte compressed
-   * format, encoded as a hexadecimal string.
+   * The secp256k1 public key, in the 33-byte compressed format, encoded as a
+   * hexadecimal string.
    */
   readonly publicKey: string;
 
   /**
-   * The Bitcoin pay-to-pubkey-hash address for the generated key.
+   * The Bitcoin pay-to-pubkey-hash address for the key.
    */
   readonly publicKeyHash: string;
 };
@@ -155,9 +162,31 @@ export type GenerateKeyResult = {
  *
  * @param args Key generation parameters.
  */
-export declare function generateKey(
-  args: GenerateKeyArgs,
-): Promise<GenerateKeyResult>;
+export declare function generateKey(args: GenerateKeyArgs): Promise<KeyResult>;
+
+/**
+ * @see parseKey
+ */
+export type ParseKeyArgs = {
+  /**
+   * Determines which network the public key will be created for.
+   */
+  network: 'testnet3' | 'mainnet';
+
+  /**
+   * The private key to parse and return the corresponding public key and
+   * addresses for, encoded as a hexadecimal string.
+   */
+  privateKey: string;
+};
+
+/**
+ * Parses the given private key and returns its corresponding public key and
+ * addresses.
+ *
+ * @param args Key parse parameters.
+ */
+export declare function parseKey(args: ParseKeyArgs): Promise<KeyResult>;
 
 /**
  * @see startPoPMiner
@@ -169,7 +198,7 @@ export type MinerStartArgs = {
   network: 'testnet' | 'devnet' | 'mainnet';
 
   /**
-   * The secpk256k1 private key for the PoP Miner.
+   * The secp256k1 private key for the PoP Miner.
    */
   privateKey: string;
 

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -15,6 +15,7 @@ const (
 	// The following can be dispatched at any time.
 	MethodVersion       Method = "version"       // Retrieve WASM version information
 	MethodGenerateKey   Method = "generateKey"   // Generate secp256k1 key pair
+	MethodParseKey      Method = "parseKey"      // Parses a secp256k1 private and returns key information
 	MethodStartPoPMiner Method = "startPoPMiner" // Start PoP Miner
 	MethodStopPoPMiner  Method = "stopPoPMiner"  // Stop PoP Miner
 
@@ -90,25 +91,25 @@ type VersionResult struct {
 	GitCommit string `json:"gitCommit"`
 }
 
-// GenerateKeyResult contains the generated key information.
-// Returned by MethodGenerateKey.
-type GenerateKeyResult struct {
-	// EthereumAddress is the Ethereum address for the generated key.
+// KeyResult contains a secp256k1 key pair and its corresponding Bitcoin
+// address and public key hash, and Ethereum address.
+//
+// Returned by MethodGenerateKey and MethodParseKey.
+type KeyResult struct {
+	// EthereumAddress is the Ethereum address for the key.
 	EthereumAddress string `json:"ethereumAddress"`
 
-	// Network is the network for which the key was generated.
+	// Network is the network the addresses were created for.
 	Network string `json:"network"`
 
-	// PrivateKey is the generated secpk256k1 private key, encoded as a
-	// hexadecimal string.
+	// PrivateKey is the secp256k1 private key, encoded as a hexadecimal string.
 	PrivateKey string `json:"privateKey"`
 
-	// PublicKey is the generated secp256k1 public key, in the 33-byte
-	// compressed format, encoded as a hexadecimal string.
+	// PublicKey is the secp256k1 public key, in the 33-byte compressed format,
+	// encoded as a hexadecimal string.
 	PublicKey string `json:"publicKey"`
 
-	// PublicKeyHash is the Bitcoin pay-to-pubkey-hash address for the generated
-	// key.
+	// PublicKeyHash is the Bitcoin pay-to-pubkey-hash address for the key.
 	PublicKeyHash string `json:"publicKeyHash"`
 }
 

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -27,6 +27,18 @@
     </div>
 
     <div>
+      <input id="ParseKeyNetworkInput" value="testnet3">
+      <label for="ParseKeyNetworkInput">bitcoin network</label>
+      <br>
+      <input id="ParseKeyPrivateKeyInput" type="password">
+      <label for="ParseKeyPrivateKeyInput">secp256k1 private key (hexadecimal string, 32 bytes)</label>
+      <br>
+
+      <button id="ParseKeyButton">parse key</button>
+      <pre class="ParseKeyShow"></pre>
+    </div>
+
+    <div>
       <input id="StartPopMinerLogLevelInput" value="hemiwasm=INFO:popm=INFO:protocol=INFO">
       <label for="StartPopMinerLogLevelInput">log level</label>
       <br>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -57,6 +57,26 @@ GenerateKeyButton.addEventListener('click', () => {
   GenerateKey();
 });
 
+const ParseKeyShow = document.querySelector('.ParseKeyShow');
+
+async function ParseKey() {
+  try {
+    const result = await dispatch({
+      method: 'parseKey',
+      network: ParseKeyNetworkInput.value,
+      privateKey: ParseKeyPrivateKeyInput.value,
+    });
+    ParseKeyShow.innerText = JSON.stringify(result, null, 2);
+  } catch (err) {
+    ParseKeyShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
+    console.error('Caught exception', err);
+  }
+}
+
+ParseKeyButton.addEventListener('click', () => {
+  ParseKey();
+});
+
 // start pop miner
 const StartPopMinerShow = document.querySelector('.StartPopMinerShow');
 


### PR DESCRIPTION
**Summary**
Add a `parseKey` method to the WebAssembly PoP Miner and `@hemilabs/pop-miner` package that takes a network type and secp256k1 private key and returns the public key, Bitcoin address and public key hash, and the Ethereum address.

**Changes**
 - Add `parseKey` method to the WebAssembly PoP Miner.
 - Rename `GenerateKeyResult` to `KeyResult` in pop-miner package.
 - Fix typo `secpk256k1` -> `secp256k1`.