### PR TITLE
popm/wasm: add 'bitcoinAddressToScriptHash' method

### DIFF
--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -42,6 +42,15 @@ export const parseKey: typeof types.parseKey = ({ network, privateKey }) => {
   }) as Promise<KeyResult>;
 };
 
+export const bitcoinAddressToScriptHash: typeof types.bitcoinAddressToScriptHash =
+  ({ network, address }) => {
+    return dispatch({
+      method: 'bitcoinAddressToScriptHash',
+      network: network,
+      address: address,
+    }) as Promise<BitcoinAddressToScriptHashResult>;
+  };
+
 export const startPoPMiner: typeof types.startPoPMiner = (args) => {
   return dispatchVoid({
     method: 'startPoPMiner',

--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -6,6 +6,7 @@
 
 import * as types from '../types';
 import type {
+  BitcoinAddressToScriptHashResult,
   BitcoinBalanceResult,
   BitcoinInfoResult,
   BitcoinUTXOsResult,

--- a/web/packages/pop-miner/src/browser/wasm.ts
+++ b/web/packages/pop-miner/src/browser/wasm.ts
@@ -16,6 +16,7 @@ export type Method =
   | 'wasmPing'
   | 'generateKey'
   | 'parseKey'
+  | 'bitcoinAddressToScriptHash'
   | 'startPoPMiner'
   | 'stopPoPMiner'
   | 'ping'

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -189,6 +189,50 @@ export type ParseKeyArgs = {
 export declare function parseKey(args: ParseKeyArgs): Promise<KeyResult>;
 
 /**
+ * @see bitcoinAddressToScriptHash
+ */
+export type BitcoinAddressToScriptHashArgs = {
+  /**
+   * Determines the network the key will be parsed for.
+   */
+  network: 'testnet3' | 'mainnet';
+
+  /**
+   * The Bitcoin address to return the script hash of.
+   */
+  address: string;
+};
+
+/**
+ * @see bitcoinAddressToScriptHash
+ */
+export type BitcoinAddressToScriptHashResult = {
+  /**
+   * The network the address is for.
+   */
+  network: 'testnet3' | 'mainnet';
+
+  /**
+   * The address the script hash is for.
+   */
+  address: string;
+
+  /**
+   * The script hash for the address.
+   */
+  scriptHash: string;
+};
+
+/**
+ * Returns the script hash of the given Bitcoin address.
+ *
+ * @param args Bitcoin to script hash arguments.
+ */
+export declare function bitcoinAddressToScriptHash(
+  args: BitcoinAddressToScriptHashArgs,
+): Promise<BitcoinAddressToScriptHashResult>;
+
+/**
  * @see startPoPMiner
  */
 export type MinerStartArgs = {

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -13,11 +13,12 @@ type Method string
 
 const (
 	// The following can be dispatched at any time.
-	MethodVersion       Method = "version"       // Retrieve WASM version information
-	MethodGenerateKey   Method = "generateKey"   // Generate secp256k1 key pair
-	MethodParseKey      Method = "parseKey"      // Parses a secp256k1 private and returns key information
-	MethodStartPoPMiner Method = "startPoPMiner" // Start PoP Miner
-	MethodStopPoPMiner  Method = "stopPoPMiner"  // Stop PoP Miner
+	MethodVersion                    Method = "version"                    // Retrieve WASM version information
+	MethodGenerateKey                Method = "generateKey"                // Generate secp256k1 key pair
+	MethodParseKey                   Method = "parseKey"                   // Parses a secp256k1 private and returns key information
+	MethodBitcoinAddressToScriptHash Method = "bitcoinAddressToScriptHash" // Bitcoin address to script hash
+	MethodStartPoPMiner              Method = "startPoPMiner"              // Start PoP Miner
+	MethodStopPoPMiner               Method = "stopPoPMiner"               // Stop PoP Miner
 
 	// The following can only be dispatched after the PoP Miner is running.
 	MethodPing           Method = "ping"           // Ping BFG
@@ -111,6 +112,19 @@ type KeyResult struct {
 
 	// PublicKeyHash is the Bitcoin pay-to-pubkey-hash address for the key.
 	PublicKeyHash string `json:"publicKeyHash"`
+}
+
+// BitcoinAddressToScriptHashResult contains the script hash requested for an
+// address.
+type BitcoinAddressToScriptHashResult struct {
+	// Network is the network the address is for.
+	Network string `json:"network"`
+
+	// Address is the address the script hash is for.
+	Address string `json:"address"`
+
+	// ScriptHash is the script hash for the given address.
+	ScriptHash string `json:"scriptHash"`
 }
 
 // PingResult contains information when pinging the BFG server.

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -39,6 +39,18 @@
     </div>
 
     <div>
+      <input id="BitcoinAddressToScriptHashNetworkInput" value="testnet3">
+      <label for="BitcoinAddressToScriptHashNetworkInput">bitcoin network</label>
+      <br>
+      <input id="BitcoinAddressToScriptHashAddressInput">
+      <label for="BitcoinAddressToScriptHashAddressInput">bitcoin address</label>
+      <br>
+
+      <button id="BitcoinAddressToScriptHashAddressButton">bitcoin address to script hash</button>
+      <pre class="BitcoinAddressToScriptHashAddressShow"></pre>
+    </div>
+
+    <div>
       <input id="StartPopMinerLogLevelInput" value="hemiwasm=INFO:popm=INFO:protocol=INFO">
       <label for="StartPopMinerLogLevelInput">log level</label>
       <br>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -77,6 +77,26 @@ ParseKeyButton.addEventListener('click', () => {
   ParseKey();
 });
 
+const BitcoinAddressToScriptHashAddressShow = document.querySelector('.BitcoinAddressToScriptHashAddressShow');
+
+async function BitcoinAddressToScriptHashAddress() {
+  try {
+    const result = await dispatch({
+      method: 'bitcoinAddressToScriptHash',
+      network: BitcoinAddressToScriptHashNetworkInput.value,
+      address: BitcoinAddressToScriptHashAddressInput.value,
+    });
+    BitcoinAddressToScriptHashAddressShow.innerText = JSON.stringify(result, null, 2);
+  } catch (err) {
+    BitcoinAddressToScriptHashAddressShow.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
+    console.error('Caught exception', err);
+  }
+}
+
+BitcoinAddressToScriptHashAddressButton.addEventListener('click', () => {
+  BitcoinAddressToScriptHashAddress();
+});
+
 // start pop miner
 const StartPopMinerShow = document.querySelector('.StartPopMinerShow');
 


### PR DESCRIPTION
**Summary**
Add a `bitcoinAddressToScriptHash` function to the WebAssembly PoP Miner and `@hemilabs/pop-miner` package that takes a network type and Bitcoin address and returns the script hash.

**Changes**
 - Add `bitcoinAddressToScriptHash` to the WebAssembly PoP Miner.