### PR TITLE
popm/wasm: add events and clean up globals

### DIFF
--- a/service/popm/event.go
+++ b/service/popm/event.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package popm
+
+import (
+	"github.com/hemilabs/heminetwork/hemi"
+)
+
+// EventHandler is a function that can handle an event.
+type EventHandler = func(event EventType, data any)
+
+// EventType represents a type of event.
+type EventType int
+
+const (
+	// EventTypeMineKeystone is an event dispatched when a L2 keystone is being
+	// mined.
+	EventTypeMineKeystone EventType = iota + 1
+
+	// EventTypeTransactionBroadcast is an event dispatched when a Bitcoin
+	// transaction has been broadcast to the network.
+	EventTypeTransactionBroadcast
+)
+
+// EventMineKeystone is the data for EventTypeMineKeystone.
+type EventMineKeystone struct {
+	Keystone *hemi.L2Keystone
+}
+
+// EventTransactionBroadcast is the data for EventTypeTransactionBroadcast.
+type EventTransactionBroadcast struct {
+	Keystone *hemi.L2Keystone
+	TxHash   string
+}
+
+// RegisterEventHandler registers an event handler to receive all events
+// dispatched by the miner. The dispatched events can be filtered by EventType
+// when received.
+func (m *Miner) RegisterEventHandler(handler EventHandler) {
+	m.eventHandlersMtx.Lock()
+	defer m.eventHandlersMtx.Unlock()
+	m.eventHandlers = append(m.eventHandlers, handler)
+}
+
+// dispatchEvent calls all registered event handlers with the given eventType
+// and data. It is recommended to call this function in a go routine to avoid
+// blocking operation while the event is being dispatched, as all event handlers
+// will be executed synchronously.
+func (m *Miner) dispatchEvent(eventType EventType, data any) {
+	m.eventHandlersMtx.RLock()
+	defer m.eventHandlersMtx.RUnlock()
+	for _, handler := range m.eventHandlers {
+		handler(eventType, data)
+	}
+}

--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -100,3 +100,19 @@ export const bitcoinUTXOs: typeof types.bitcoinUTXOs = ({ scriptHash }) => {
     scriptHash: scriptHash,
   }) as Promise<BitcoinUTXOsResult>;
 };
+
+export const addEventListener: typeof types.addEventListener = (eventType, listener) => {
+  return dispatch({
+    method: 'addEventListener',
+    eventType: eventType,
+    listener: listener,
+  });
+};
+
+export const removeEventListener: typeof types.addEventListener = (eventType, listener) => {
+  return dispatch({
+    method: 'removeEventListener',
+    eventType: eventType,
+    listener: listener,
+  });
+};

--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -101,7 +101,10 @@ export const bitcoinUTXOs: typeof types.bitcoinUTXOs = ({ scriptHash }) => {
   }) as Promise<BitcoinUTXOsResult>;
 };
 
-export const addEventListener: typeof types.addEventListener = (eventType, listener) => {
+export const addEventListener: typeof types.addEventListener = (
+  eventType,
+  listener,
+) => {
   return dispatchVoid({
     method: 'addEventListener',
     eventType: eventType,
@@ -109,7 +112,10 @@ export const addEventListener: typeof types.addEventListener = (eventType, liste
   });
 };
 
-export const removeEventListener: typeof types.addEventListener = (eventType, listener) => {
+export const removeEventListener: typeof types.addEventListener = (
+  eventType,
+  listener,
+) => {
   return dispatchVoid({
     method: 'removeEventListener',
     eventType: eventType,

--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -102,7 +102,7 @@ export const bitcoinUTXOs: typeof types.bitcoinUTXOs = ({ scriptHash }) => {
 };
 
 export const addEventListener: typeof types.addEventListener = (eventType, listener) => {
-  return dispatch({
+  return dispatchVoid({
     method: 'addEventListener',
     eventType: eventType,
     listener: listener,
@@ -110,7 +110,7 @@ export const addEventListener: typeof types.addEventListener = (eventType, liste
 };
 
 export const removeEventListener: typeof types.addEventListener = (eventType, listener) => {
-  return dispatch({
+  return dispatchVoid({
     method: 'removeEventListener',
     eventType: eventType,
     listener: listener,

--- a/web/packages/pop-miner/src/browser/wasm.ts
+++ b/web/packages/pop-miner/src/browser/wasm.ts
@@ -23,14 +23,16 @@ export type Method =
   | 'l2Keystones'
   | 'bitcoinBalance'
   | 'bitcoinInfo'
-  | 'bitcoinUTXOs';
+  | 'bitcoinUTXOs'
+  | 'addEventListener'
+  | 'removeEventListener';
 
 /**
  * Dispatch args.
  *
  * @see dispatch
  */
-export type DispatchArgs = Record<string, unknown> & {
+export type DispatchArgs = Record<string, any> & {
   /**
    * The method to be dispatched.
    *
@@ -66,7 +68,7 @@ export const init: typeof types.init = async ({ wasmURL }) => {
     loadPromise = loadWASM({ wasmURL }).catch((err) => {
       loadPromise = undefined;
       throw err;
-    });
+    }) as Promise<WASM>;
   }
 
   globalWASM = globalWASM || (await loadPromise);

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -310,7 +310,10 @@ export interface EventListener {
  * @param eventType The event type to listen for. If '' then all events.
  * @param listener The event listener that will be called when the event is dispatched.
  */
-export declare function addEventListener(eventType: EventType | '', listener: EventListener): Promise<void>;
+export declare function addEventListener(
+  eventType: EventType | '',
+  listener: EventListener,
+): Promise<void>;
 
 /**
  * Unregisters an event listener.
@@ -318,7 +321,10 @@ export declare function addEventListener(eventType: EventType | '', listener: Ev
  * @param eventType The event type to stop listening for.
  * @param listener The event listener to unregister.
  */
-export declare function removeEventListener(eventType: EventType | '', listener: EventListener): Promise<void>;
+export declare function removeEventListener(
+  eventType: EventType | '',
+  listener: EventListener,
+): Promise<void>;
 
 /**
  * @see startPoPMiner

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -233,6 +233,94 @@ export declare function bitcoinAddressToScriptHash(
 ): Promise<BitcoinAddressToScriptHashResult>;
 
 /**
+ * Represents a type of event.
+ */
+export type EventType =
+  | 'minerStart'
+  | 'minerStop'
+  | 'mineKeystone'
+  | 'transactionBroadcast';
+
+/**
+ * An event that has been dispatched.
+ */
+export type Event = {
+  type: EventType;
+};
+
+/**
+ * Dispatched when the PoP miner has stopped.
+ */
+export type EventMinerStart = Event & {
+  type: 'minerStart';
+};
+
+/**
+ * Dispatched when the PoP miner has exited.
+ */
+export type EventMinerStop = Event & {
+  type: 'minerStop';
+
+  /**
+   * The error that caused the PoP miner to exit, or null.
+   */
+  error?: Error;
+};
+
+/**
+ * Dispatched when the PoP miner begins mining a keystone.
+ */
+export type EventMineKeystone = Event & {
+  type: 'mineKeystone';
+
+  /**
+   * The keystone to be mined.
+   */
+  keystone: L2Keystone;
+};
+
+/**
+ * Dispatched when the PoP miner broadcasts a PoP transaction to the Bitcoin
+ * network.
+ */
+export type EventTransactionBroadcast = Event & {
+  type: 'transactionBroadcast';
+
+  /**
+   * The keystone that was mined.
+   */
+  keystone: L2Keystone;
+
+  /**
+   * The hash of the Bitcoin transaction.
+   */
+  txHash: string;
+};
+
+/**
+ * An event listener that can receive events.
+ */
+export interface EventListener {
+  (event: Event): void;
+}
+
+/**
+ * Registers an event listener.
+ *
+ * @param eventType The event type to listen for. If '' then all events.
+ * @param listener The event listener that will be called when the event is dispatched.
+ */
+export declare function addEventListener(eventType: EventType | '', listener: EventListener): Promise<void>;
+
+/**
+ * Unregisters an event listener.
+ *
+ * @param eventType The event type to stop listening for.
+ * @param listener The event listener to unregister.
+ */
+export declare function removeEventListener(eventType: EventType | '', listener: EventListener): Promise<void>;
+
+/**
  * @see startPoPMiner
  */
 export type MinerStartArgs = {

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -311,7 +311,7 @@ export interface EventListener {
  * @param listener The event listener that will be called when the event is dispatched.
  */
 export declare function addEventListener(
-  eventType: EventType | '',
+  eventType: EventType | '*',
   listener: EventListener,
 ): Promise<void>;
 
@@ -322,7 +322,7 @@ export declare function addEventListener(
  * @param listener The event listener to unregister.
  */
 export declare function removeEventListener(
-  eventType: EventType | '',
+  eventType: EventType | '*',
   listener: EventListener,
 ): Promise<void>;
 

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -307,7 +307,7 @@ export interface EventListener {
 /**
  * Registers an event listener.
  *
- * @param eventType The event type to listen for. If '' then all events.
+ * @param eventType The event type to listen for. If '*' then listen for all events.
  * @param listener The event listener that will be called when the event is dispatched.
  */
 export declare function addEventListener(

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -244,7 +244,7 @@ var popmEvents = map[popm.EventType]EventType{
 
 // eventTypes is a map used to parse string event types.
 var eventTypes = map[string]EventType{
-	"":                                     "", // Listen for all events.
+	"*":                                    "*", // Listen for all events.
 	EventTypeMinerStart.String():           EventTypeMinerStart,
 	EventTypeMinerStop.String():            EventTypeMinerStop,
 	EventTypeMineKeystone.String():         EventTypeMineKeystone,

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -6,7 +6,11 @@
 
 package main
 
-import "syscall/js"
+import (
+	"syscall/js"
+
+	"github.com/hemilabs/heminetwork/service/popm"
+)
 
 // Method represents a method that can be dispatched.
 type Method string
@@ -26,6 +30,10 @@ const (
 	MethodBitcoinBalance Method = "bitcoinBalance" // Retrieve bitcoin balance
 	MethodBitcoinInfo    Method = "bitcoinInfo"    // Retrieve bitcoin information
 	MethodBitcoinUTXOs   Method = "bitcoinUTXOs"   // Retrieve bitcoin UTXOs
+
+	// Events
+	MethodEventListenerAdd    Method = "addEventListener"    // Register event listener
+	MethodEventListenerRemove Method = "removeEventListener" // Unregister event listener
 )
 
 // ErrorCode is used to differentiate between error types.
@@ -205,4 +213,66 @@ type BitcoinUTXO struct {
 
 	// Value is the value of the output in satoshis.
 	Value int64 `json:"value"`
+}
+
+// EventType represents a type of event.
+type EventType string
+
+const (
+	// EventTypeMinerStart is dispatched when the PoP miner has started.
+	EventTypeMinerStart EventType = "minerStart"
+
+	// EventTypeMinerStop is dispatched when the PoP miner has exited.
+	EventTypeMinerStop EventType = "minerStop"
+
+	// EventTypeMineKeystone is dispatched when the PoP miner is mining an L2
+	// keystone.
+	EventTypeMineKeystone EventType = "mineKeystone"
+
+	// EventTypeTransactionBroadcast is dispatched when the PoP miner has
+	// broadcast a Bitcoin transaction to the network.
+	EventTypeTransactionBroadcast EventType = "transactionBroadcast"
+)
+
+// popmEvents contains events dispatched by the native PoP Miner.
+// These events will be forwarded to JavaScript, however we also dispatch events
+// that are specific to the WebAssembly PoP Miner.
+var popmEvents = map[popm.EventType]EventType{
+	popm.EventTypeMineKeystone:         EventTypeMineKeystone,
+	popm.EventTypeTransactionBroadcast: EventTypeTransactionBroadcast,
+}
+
+// eventTypes is a map used to parse string event types.
+var eventTypes = map[string]EventType{
+	"":                                     "", // Listen for all events.
+	EventTypeMinerStart.String():           EventTypeMinerStart,
+	EventTypeMinerStop.String():            EventTypeMinerStop,
+	EventTypeMineKeystone.String():         EventTypeMineKeystone,
+	EventTypeTransactionBroadcast.String(): EventTypeTransactionBroadcast,
+}
+
+// String returns the string representation of the event type.
+func (e EventType) String() string {
+	return string(e)
+}
+
+// MarshalJS returns the JavaScript representation of the event type.
+func (e EventType) MarshalJS() (js.Value, error) {
+	return jsValueOf(e.String()), nil
+}
+
+// EventMinerStop is the data for EventTypeMinerStop.
+type EventMinerStop struct {
+	Error *Error `json:"error"`
+}
+
+// EventMineKeystone is the data for EventTypeMineKeystone.
+type EventMineKeystone struct {
+	Keystone L2Keystone `json:"keystone"`
+}
+
+// EventTransactionBroadcast is the data for EventTypeTransactionBroadcast.
+type EventTransactionBroadcast struct {
+	Keystone L2Keystone `json:"keystone"`
+	TxHash   string     `json:"txHash"`
 }

--- a/web/popminer/popminer.go
+++ b/web/popminer/popminer.go
@@ -56,7 +56,7 @@ func (s *Service) handleMinerEvent(popmEventType popm.EventType, data any) {
 func (s *Service) dispatchEvent(eventType EventType, data any) {
 	s.listenersMtx.RLock()
 	defer s.listenersMtx.RUnlock()
-	allHs, aok := s.listeners[""] // Special handlers that receive all events.
+	allHs, aok := s.listeners["*"] // Special handlers that receive all events.
 	hs, ok := s.listeners[eventType]
 	if !ok && !aok {
 		// There are no listeners for this event type.

--- a/web/popminer/popminer.go
+++ b/web/popminer/popminer.go
@@ -29,20 +29,85 @@ var (
 	log      = loggo.GetLogger("@hemilabs/pop-miner")
 )
 
-var (
-	pmMtx sync.Mutex
-	pm    *Miner // Global Miner instance.
-)
+// svc is a global object storing data for the WebAssembly service.
+// This can be accessed concurrently, however certain mutexes must be used to
+// read/write certain fields.
+var svc Service
 
-// Miner is a global instance of [popm.Miner].
+// Service is a global struct used to store data for the WebAssembly service.
+type Service struct {
+	minerMtx sync.RWMutex
+	miner    *Miner
+
+	listenersMtx sync.RWMutex
+	listeners    map[EventType][]js.Value
+}
+
+// handleMinerEvent handles an event dispatched by the PoP miner.
+func (s *Service) handleMinerEvent(popmEventType popm.EventType, data any) {
+	eventType, ok := popmEvents[popmEventType]
+	if !ok {
+		log.Errorf("unknown popm event type: %v", popmEventType)
+		return
+	}
+	s.dispatchEvent(eventType, convertEvent(data))
+}
+
+func (s *Service) dispatchEvent(eventType EventType, data any) {
+	s.listenersMtx.RLock()
+	defer s.listenersMtx.RUnlock()
+	allHs, aok := s.listeners[""] // Special handlers that receive all events.
+	hs, ok := s.listeners[eventType]
+	if !ok && !aok {
+		// There are no listeners for this event type.
+		return
+	}
+
+	jsEvent := jsValueOf(data)
+	if jsEvent.IsNull() {
+		jsEvent = objectConstructor.New()
+	} else if jsEvent.Type() != js.TypeObject {
+		log.Errorf("Invalid event data: %s, must be %s",
+			jsEvent.Type(), js.TypeObject)
+		return
+	}
+	jsEvent.Set("type", jsValueOf(eventType))
+
+	// Dispatch to all handlers for this event type.
+	for _, h := range hs {
+		h.Invoke(jsEvent)
+	}
+
+	// Dispatch to handlers that receive all events, after dispatching to
+	// handlers specific to this event type.
+	for _, h := range allHs {
+		h.Invoke(jsEvent)
+	}
+}
+
+// Miner represents a running PoP Miner along with its context.
+// Errors encountered while starting the miner should be sent to the errCh channel.
 type Miner struct {
-	// Don't like adding these into the object but c'est la wasm
 	ctx    context.Context
 	cancel context.CancelFunc
-	miner  *popm.Miner
+	*popm.Miner
 
-	wg  sync.WaitGroup
-	err error
+	errCh chan error
+	wg    sync.WaitGroup
+}
+
+func (m *Miner) shutdown() error {
+	m.cancel()
+	m.wg.Wait()
+
+	select {
+	case err := <-m.errCh:
+		return err
+	default:
+	}
+	close(m.errCh)
+
+	return nil
 }
 
 func init() {
@@ -52,6 +117,9 @@ func init() {
 func main() {
 	log.Tracef("main")
 	defer log.Tracef("main exit")
+
+	// Create event listeners map
+	svc.listeners = make(map[EventType][]js.Value)
 
 	// Enable function dispatcher
 	log.Infof("=== Start of Day ===")
@@ -68,11 +136,11 @@ func main() {
 	<-make(chan struct{}) // prevents the program from exiting
 }
 
-func activeMiner() (*Miner, error) {
-	pmMtx.Lock()
-	defer pmMtx.Unlock()
-	if pm == nil {
-		return nil, errors.New("pop miner not running")
+func runningMiner() (*Miner, error) {
+	svc.minerMtx.RLock()
+	defer svc.minerMtx.RUnlock()
+	if m := svc.miner; m != nil {
+		return m, nil
 	}
-	return pm, nil
+	return nil, errors.New("miner not running")
 }

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -117,6 +117,12 @@
       <pre class="BitcoinUTXOsShow"></pre>
     </div>
 
+    <div>
+      <br><hr><br>
+      <p>Events</p>
+      <pre style="height: 50vh; text-wrap: normal; overflow-y: scroll;" class="eventsDisplay"></pre>
+    </div>
+
     <script src="index.js" defer></script>
   </body>
 </html>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -245,7 +245,7 @@ async function registerEventListener() {
   try {
     const result = await dispatch({
       method: 'addEventListener',
-      eventType: '',
+      eventType: '*',
       handler: handleEvent,
     });
     console.debug('addEventListener: ', JSON.stringify(result, null, 2));

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -9,6 +9,7 @@ let wasm; // This stores the global object created by the WASM binary.
 // Called after the WASM binary has been loaded.
 async function init() {
   wasm = globalThis['@hemilabs/pop-miner'];
+  void registerEventListener();
 }
 
 async function dispatch(args) {
@@ -236,3 +237,23 @@ async function BitcoinUTXOs() {
 BitcoinUTXOsButton.addEventListener('click', () => {
   BitcoinUTXOs();
 });
+
+// Events
+const eventsDisplay = document.querySelector('.eventsDisplay');
+
+async function registerEventListener() {
+  try {
+    const result = await dispatch({
+      method: 'addEventListener',
+      eventType: '',
+      handler: handleEvent,
+    });
+    console.debug('addEventListener: ', JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.error('Caught exception', err);
+  }
+}
+
+function handleEvent(event) {
+  eventsDisplay.innerText += `\n${JSON.stringify(event, null, 2)}\n`;
+}


### PR DESCRIPTION
**Summary**
Add events to the PoP Miner and WebAssembly PoP Miner.

**Changes**
- Add events to `popm` and `Miner.RegisterEventHandler(EventHandler)`
- Add events to the WebAssembly PoP Miner and `@hemilabs/pop-miner` package
- Rename `activeMiner()` to `runningMiner()`
- Add a `Service` type and use `svc` global variable (replaces `pm` and `pmMtx`). This allows us to have a global struct to store data in, without the need to use a lock to access the data. The miner is now stored in a `miner` field, guarded by the `minerMtx` RWMutex. This service also contains the event listeners and the listeners map RWMutex.
- Add initial 4 events: `minerStart`, `minerStop`, `mineKeystone`, and `transactionBroadcast`.
