### PR TITLE
popm/wasm: rename KeyResult fields and add bitcoinScriptHash

### DIFF
--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -130,9 +130,9 @@ export type GenerateKeyArgs = {
  */
 export type KeyResult = {
   /**
-   * The Ethereum address for the key.
+   * The Hemi Ethereum address for the key.
    */
-  readonly ethereumAddress: string;
+  readonly hemiAddress: string;
 
   /**
    * The network the addresses were created for.
@@ -153,7 +153,12 @@ export type KeyResult = {
   /**
    * The Bitcoin pay-to-pubkey-hash address for the key.
    */
-  readonly publicKeyHash: string;
+  readonly bitcoinPubKeyHash: string;
+
+  /**
+   * The Bitcoin pay-to-pubkey-hash script hash for the key.
+   */
+  readonly bitcoinScriptHash: string;
 };
 
 /**

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -97,8 +97,8 @@ type VersionResult struct {
 //
 // Returned by MethodGenerateKey and MethodParseKey.
 type KeyResult struct {
-	// EthereumAddress is the Ethereum address for the key.
-	EthereumAddress string `json:"ethereumAddress"`
+	// HemiAddress is the Hemi Ethereum address for the key.
+	HemiAddress string `json:"hemiAddress"`
 
 	// Network is the network the addresses were created for.
 	Network string `json:"network"`
@@ -110,8 +110,12 @@ type KeyResult struct {
 	// encoded as a hexadecimal string.
 	PublicKey string `json:"publicKey"`
 
-	// PublicKeyHash is the Bitcoin pay-to-pubkey-hash address for the key.
-	PublicKeyHash string `json:"publicKeyHash"`
+	// BitcoinPubKeyHash is the Bitcoin pay-to-pubkey-hash address for the key.
+	BitcoinPubKeyHash string `json:"bitcoinPubKeyHash"`
+
+	// BitcoinScriptHash is the Bitcoin pay-to-pubkey-hash script hash for the
+	// key.
+	BitcoinScriptHash string `json:"bitcoinScriptHash"`
 }
 
 // BitcoinAddressToScriptHashResult contains the script hash requested for an

--- a/web/popminer/dispatch.go
+++ b/web/popminer/dispatch.go
@@ -245,22 +245,30 @@ func parseKey(_ js.Value, args []js.Value) (any, error) {
 	return result, nil
 }
 
-func createKeyResult(privKey *dcrsecp256k1.PrivateKey, net string, btcChainParams *btcchaincfg.Params) (KeyResult, error) {
+func createKeyResult(privKey *dcrsecp256k1.PrivateKey, net string, btcChainParams *btcchaincfg.Params) (*KeyResult, error) {
 	compressedPubKey := privKey.PubKey().SerializeCompressed()
 	uncompressedPubKey := privKey.PubKey().SerializeUncompressed()
 
 	btcAddress, err := btcutil.NewAddressPubKey(compressedPubKey, btcChainParams)
 	if err != nil {
 		log.Errorf("failed to create bitcoin address: %v", err)
-		return KeyResult{}, fmt.Errorf("create bitcoin address from public key: %w", err)
+		return nil, fmt.Errorf("create bitcoin address from public key: %w", err)
 	}
+	btcPubKeyHash := btcAddress.AddressPubKeyHash()
 
-	return KeyResult{
-		EthereumAddress: ethereum.PublicKeyToAddress(uncompressedPubKey).String(),
-		Network:         net,
-		PrivateKey:      hex.EncodeToString(privKey.Serialize()),
-		PublicKey:       hex.EncodeToString(compressedPubKey),
-		PublicKeyHash:   btcAddress.AddressPubKeyHash().String(),
+	btcScript, err := txscript.PayToAddrScript(btcPubKeyHash)
+	if err != nil {
+		return nil, fmt.Errorf("convert address to script: %w", err)
+	}
+	btcScriptHash := sha256.Sum256(btcScript)
+
+	return &KeyResult{
+		HemiAddress:       ethereum.PublicKeyToAddress(uncompressedPubKey).String(),
+		Network:           net,
+		PrivateKey:        hex.EncodeToString(privKey.Serialize()),
+		PublicKey:         hex.EncodeToString(compressedPubKey),
+		BitcoinPubKeyHash: btcPubKeyHash.String(),
+		BitcoinScriptHash: hex.EncodeToString(btcScriptHash[:]),
 	}, nil
 }
 


### PR DESCRIPTION
**Summary**
Rename fields in `KeyResult` and add `bitcoinScriptHash` field.

Resolves #176 

**Changes**
 - Rename `ethereumAddress` to `hemiAddress`
 - Rename `publicKeyHash` to `bitcoinPubKeyHash`
 - Add `bitcoinScriptHash` containing the Bitcoin pay-to-pubkey-hash script for the secp256k1 key.