### PR TITLE
popm/wasm: add 'minerStatus' method

### DIFF
--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -12,6 +12,7 @@ import type {
   BitcoinUTXOsResult,
   KeyResult,
   L2KeystonesResult,
+  MinerStatusResult,
   PingResult,
   VersionResult,
 } from '../types';
@@ -66,6 +67,12 @@ export const stopPoPMiner: typeof types.stopPoPMiner = () => {
   return dispatchVoid({
     method: 'stopPoPMiner',
   });
+};
+
+export const minerStatus: typeof types.minerStatus = () => {
+  return dispatch({
+    method: 'minerStatus',
+  }) as Promise<MinerStatusResult>;
 };
 
 export const ping: typeof types.ping = () => {

--- a/web/packages/pop-miner/src/browser/wasm.ts
+++ b/web/packages/pop-miner/src/browser/wasm.ts
@@ -19,6 +19,7 @@ export type Method =
   | 'bitcoinAddressToScriptHash'
   | 'startPoPMiner'
   | 'stopPoPMiner'
+  | 'minerStatus'
   | 'ping'
   | 'l2Keystones'
   | 'bitcoinBalance'

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -250,38 +250,38 @@ export type EventType =
  * An event that has been dispatched.
  */
 export type Event = {
-  type: EventType;
+  readonly type: EventType;
 };
 
 /**
  * Dispatched when the PoP miner has stopped.
  */
 export type EventMinerStart = Event & {
-  type: 'minerStart';
+  readonly type: 'minerStart';
 };
 
 /**
  * Dispatched when the PoP miner has exited.
  */
 export type EventMinerStop = Event & {
-  type: 'minerStop';
+  readonly type: 'minerStop';
 
   /**
    * The error that caused the PoP miner to exit, or null.
    */
-  error?: Error;
+  readonly error?: Error;
 };
 
 /**
  * Dispatched when the PoP miner begins mining a keystone.
  */
 export type EventMineKeystone = Event & {
-  type: 'mineKeystone';
+  readonly type: 'mineKeystone';
 
   /**
    * The keystone to be mined.
    */
-  keystone: L2Keystone;
+  readonly keystone: L2Keystone;
 };
 
 /**
@@ -289,17 +289,17 @@ export type EventMineKeystone = Event & {
  * network.
  */
 export type EventTransactionBroadcast = Event & {
-  type: 'transactionBroadcast';
+  readonly type: 'transactionBroadcast';
 
   /**
    * The keystone that was mined.
    */
-  keystone: L2Keystone;
+  readonly keystone: L2Keystone;
 
   /**
    * The hash of the Bitcoin transaction.
    */
-  txHash: string;
+  readonly txHash: string;
 };
 
 /**
@@ -378,6 +378,26 @@ export declare function startPoPMiner(args: MinerStartArgs): Promise<void>;
  * Miner exited with an error.
  */
 export declare function stopPoPMiner(): Promise<void>;
+
+/**
+ * @see minerStatus
+ */
+export type MinerStatusResult = {
+  /**
+   * Whether the PoP miner is currently running.
+   */
+  readonly running: boolean;
+
+  /**
+   * Whether the PoP miner is currently connected to a BFG server.
+   */
+  readonly connected: boolean;
+};
+
+/**
+ * Returns information about the status of the PoP miner.
+ */
+export declare function minerStatus(): Promise<MinerStatusResult>;
 
 /**
  * @see ping

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -23,6 +23,7 @@ const (
 	MethodBitcoinAddressToScriptHash Method = "bitcoinAddressToScriptHash" // Bitcoin address to script hash
 	MethodStartPoPMiner              Method = "startPoPMiner"              // Start PoP Miner
 	MethodStopPoPMiner               Method = "stopPoPMiner"               // Stop PoP Miner
+	MethodMinerStatus                Method = "minerStatus"                // PoP Miner status
 
 	// The following can only be dispatched after the PoP Miner is running.
 	MethodPing           Method = "ping"           // Ping BFG
@@ -137,6 +138,17 @@ type BitcoinAddressToScriptHashResult struct {
 
 	// ScriptHash is the script hash for the given address.
 	ScriptHash string `json:"scriptHash"`
+}
+
+// MinerStatusResult contains information about the status of the PoP miner.
+// Returned by MethodMinerStatus.
+type MinerStatusResult struct {
+	// Running is whether the PoP miner is running.
+	Running bool `json:"running"`
+
+	// Connecting is whether the PoP miner is currently connected to a BFG
+	// server.
+	Connected bool `json:"connected"`
 }
 
 // PingResult contains information when pinging the BFG server.

--- a/web/popminer/dispatch.go
+++ b/web/popminer/dispatch.go
@@ -62,6 +62,9 @@ var handlers = map[Method]*Dispatch{
 	MethodStopPoPMiner: {
 		Handler: stopPopMiner,
 	},
+	MethodMinerStatus: {
+		Handler: minerStatus,
+	},
 
 	// The following can only be dispatched after the PoP Miner is running.
 	MethodPing: {
@@ -439,6 +442,20 @@ func stopPopMiner(_ js.Value, _ []js.Value) (any, error) {
 	}
 
 	return js.Null(), nil
+}
+
+func minerStatus(_ js.Value, _ []js.Value) (any, error) {
+	log.Tracef("minerStatus")
+	defer log.Tracef("minerStatus exit")
+
+	var status MinerStatusResult
+	miner, err := runningMiner()
+	if err == nil {
+		status.Running = true
+		status.Connected = miner.Connected()
+	}
+
+	return status, nil
 }
 
 func ping(_ js.Value, _ []js.Value) (any, error) {

--- a/web/popminer/util.go
+++ b/web/popminer/util.go
@@ -52,7 +52,6 @@ type JSMarshaler interface {
 func jsValueOf(x any) js.Value {
 	v, err := jsValueSafe(x)
 	if err != nil {
-		log.Debugf("jsValueOf: attempting reflection for %T: %v", x, err)
 		return jsReflectValueOf(reflect.ValueOf(x))
 	}
 	return v

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -75,6 +75,11 @@
       <pre class="StopPopMinerShow"></pre>
     </div>
 
+    <div>
+      <button id="minerStatusButton">Miner Status</button>
+      <pre class="minerStatusDisplay"></pre>
+    </div>
+
     <!-- connected commands go here, run after StartPopMinerButton -->
     <hr>
     <p>The following commands require a live connection (after StartPopMinerButton)</p>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -140,6 +140,25 @@ StopPopMinerButton.addEventListener('click', () => {
   StopPopMiner();
 });
 
+// miner status
+const minerStatusDisplay = document.querySelector('.minerStatusDisplay');
+
+async function minerStatus() {
+  try {
+    const result = await dispatch({
+      method: 'minerStatus',
+    });
+    minerStatusDisplay.innerText = JSON.stringify(result, null, 2);
+  } catch (err) {
+    minerStatusDisplay.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
+    console.error('Caught exception', err);
+  }
+}
+
+minerStatusButton.addEventListener('click', () => {
+  minerStatus();
+});
+
 // ping
 const PingShow = document.querySelector('.PingShow');
 


### PR DESCRIPTION
**Summary**
Add a `minerStatus` method to the WebAssembly PoP miner that exposes the whether the miner is running, and whether the miner is currently connected to the BFG server.

Closes #171 

**Changes**
 - Add `minerStatus` method to the WebAssembly PoP miner and `@hemilabs/pop-miner` package
 - Add `Connected()` function to the PoP miner that returns whether the miner is currently connected to BFG
 - Add `readonly` to event fields in `@hemilabs/pop-miner` package