### PR TITLE
popm/wasm: fix dispatch params for {add,remove}EventListener

### DIFF
--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -108,7 +108,7 @@ export const addEventListener: typeof types.addEventListener = (
   return dispatchVoid({
     method: 'addEventListener',
     eventType: eventType,
-    listener: listener,
+    handler: listener,
   });
 };
 
@@ -119,6 +119,6 @@ export const removeEventListener: typeof types.addEventListener = (
   return dispatchVoid({
     method: 'removeEventListener',
     eventType: eventType,
-    listener: listener,
+    handler: listener,
   });
 };


### PR DESCRIPTION
**Summary**
Fix dispatch params for `addEventListener` and `removeEventListener` in the `@hemilabs/pop-miner` package.

**Changes**
- Change `listener` param to `handler` in the `addEventListener` and `removeEventListener` functions in the pop-miner NPM package.