### PR TITLE
popm/wasm: add estimateCostReward method

### DIFF
--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -338,9 +338,7 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 	scriptHash := btcchainhash.Hash(sha256.Sum256(payToScript))
 
 	// Estimate BTC fees.
-	txLen := 285 // XXX: for now all transactions are the same size
-	feePerKB := 1024 * m.cfg.StaticFee
-	feeAmount := (int64(txLen) * int64(feePerKB)) / 1024
+	feeAmount := m.EstimateFee()
 
 	// Retrieve the current balance for the miner.
 	confirmed, unconfirmed, err := m.bitcoinBalance(ctx, scriptHash[:])
@@ -403,6 +401,14 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 		EventTransactionBroadcast{Keystone: ks, TxHash: txHash.String()})
 
 	return nil
+}
+
+// EstimateFee estimates the fee amount for a PoP transaction.
+func (m *Miner) EstimateFee() int64 {
+	// TODO: Improve fee estimation.
+	const txLen int64 = 285 // XXX: for now all transactions are the same size
+	feePerKB := 1024 * int64(m.cfg.StaticFee)
+	return (txLen * feePerKB) / 1024
 }
 
 func (m *Miner) Ping(ctx context.Context, timestamp int64) (*bfgapi.PingResponse, error) {

--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -10,6 +10,7 @@ import type {
   BitcoinBalanceResult,
   BitcoinInfoResult,
   BitcoinUTXOsResult,
+  EstimateCostRewardResult,
   KeyResult,
   L2KeystonesResult,
   PingResult,
@@ -72,6 +73,12 @@ export const ping: typeof types.ping = () => {
   return dispatch({
     method: 'ping',
   }) as Promise<PingResult>;
+};
+
+export const estimateCostReward: typeof types.estimateCostReward = () => {
+  return dispatch({
+    method: 'estimateCostReward',
+  }) as Promise<EstimateCostRewardResult>;
 };
 
 export const l2Keystones: typeof types.l2Keystones = ({ numL2Keystones }) => {

--- a/web/packages/pop-miner/src/browser/wasm.ts
+++ b/web/packages/pop-miner/src/browser/wasm.ts
@@ -20,6 +20,7 @@ export type Method =
   | 'startPoPMiner'
   | 'stopPoPMiner'
   | 'ping'
+  | 'estimateCostReward'
   | 'l2Keystones'
   | 'bitcoinBalance'
   | 'bitcoinInfo'

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -402,6 +402,30 @@ export type PingResult = {
 export declare function ping(): Promise<PingResult>;
 
 /**
+ * @see estimateCostReward
+ */
+export type EstimateCostRewardResult = {
+  /**
+   * Estimated cost of Bitcoin transaction fees in satoshis, per hour spent
+   * continuously PoP mining.
+   */
+  readonly estimatedHourlyCost: number;
+
+  /**
+   * Estimated PoP mining reward in number of HEMI, per hour spent continuously
+   * PoP mining.
+   */
+  readonly estimatedHourlyReward: number;
+};
+
+/**
+ * Estimates the current costs and rewards for PoP mining.
+ *
+ * **The PoP Miner must be running before calling this function.**
+ */
+export declare function estimateCostReward(): Promise<EstimateCostRewardResult>;
+
+/**
  * @see l2Keystones
  */
 export type L2KeystonesArgs = {

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -25,11 +25,12 @@ const (
 	MethodStopPoPMiner               Method = "stopPoPMiner"               // Stop PoP Miner
 
 	// The following can only be dispatched after the PoP Miner is running.
-	MethodPing           Method = "ping"           // Ping BFG
-	MethodL2Keystones    Method = "l2Keystones"    // Retrieve L2 keystones
-	MethodBitcoinBalance Method = "bitcoinBalance" // Retrieve bitcoin balance
-	MethodBitcoinInfo    Method = "bitcoinInfo"    // Retrieve bitcoin information
-	MethodBitcoinUTXOs   Method = "bitcoinUTXOs"   // Retrieve bitcoin UTXOs
+	MethodPing               Method = "ping"               // Ping BFG
+	MethodEstimateCostReward Method = "estimateCostReward" // Estimate costs and rewards
+	MethodL2Keystones        Method = "l2Keystones"        // Retrieve L2 keystones
+	MethodBitcoinBalance     Method = "bitcoinBalance"     // Retrieve bitcoin balance
+	MethodBitcoinInfo        Method = "bitcoinInfo"        // Retrieve bitcoin information
+	MethodBitcoinUTXOs       Method = "bitcoinUTXOs"       // Retrieve bitcoin UTXOs
 
 	// Events
 	MethodEventListenerAdd    Method = "addEventListener"    // Register event listener
@@ -149,6 +150,18 @@ type PingResult struct {
 	// Timestamp is the time the BFG server sent the ping response, in unix
 	// nanoseconds.
 	Timestamp int64 `json:"timestamp"`
+}
+
+// EstimateCostRewardResult contains estimations for the cost and rewards of
+// running the PoP miner consistently. Returned by MethodEstimateCostReward.
+type EstimateCostRewardResult struct {
+	// EstimatedHourlyCost is the estimated cost of Bitcoin transaction fees in
+	// satoshis, per hour spent continuously PoP mining.
+	EstimatedHourlyCost int64 `json:"estimatedHourlyCost"`
+
+	// EstimatedHourlyReward is the estimated PoP mining reward in number of
+	// HEMI per hour spent continuously mining.
+	EstimatedHourlyReward int64 `json:"estimatedHourlyReward"`
 }
 
 // L2KeystoneResult contains the requested l2 keystones.

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -86,6 +86,11 @@
     </div>
 
     <div>
+      <button id="estimateCostRewardButton">Estimate costs and rewards</button>
+      <pre class="estimateCostRewardDisplay"></pre>
+    </div>
+
+    <div>
       <input id="L2KeystonesNumL2KeystonesInput" value="2" type="number">
       <label for="L2KeystonesNumL2KeystonesInput">num l2 keystones</label>
       <br>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -159,6 +159,24 @@ PingButton.addEventListener('click', () => {
   Ping();
 });
 
+const estimateCostRewardDisplay = document.querySelector('.estimateCostRewardDisplay');
+
+async function estimateCostReward() {
+  try {
+    const result = await dispatch({
+      method: 'estimateCostReward',
+    });
+    estimateCostRewardDisplay.innerText = JSON.stringify(result, null, 2);
+  } catch (err) {
+    estimateCostRewardDisplay.innerText = 'Promise rejected: \n' + JSON.stringify(err, null, 2);
+    console.error('Caught exception', err);
+  }
+}
+
+estimateCostRewardButton.addEventListener('click', () => {
+  estimateCostReward();
+});
+
 // l2 keystones
 const L2KeystonesShow = document.querySelector('.L2KeystonesShow');
 


### PR DESCRIPTION
**Summary**
Add a `estimateCostReward` method to the WebAssembly PoP Miner. This function returns estimations of the costs and rewards of PoP mining per hour spent continuously mining.

**Changes**
 - Refactor popm to expose fee estimation API.
 - Add `estimateCostReward` method to WebAssembly PoP Miner.
 - Add `estimateCostReward` function to the `@hemilabs/pop-miner` package.
