### PR TITLE
remove lastErr variables from rpc_test.go

### DIFF
--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -542,8 +542,9 @@ func TestBalanceByAddress(t *testing.T) {
 						// there is a chance we just haven't finished indexing
 						// the blocks and txs, retry until timeout
 						continue
+					} else {
+						break
 					}
-					break
 				} else {
 					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -446,7 +446,7 @@ func TestBalanceByAddress(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 
 			initialBlocks := 0

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -62,14 +62,14 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
 		Height: 55,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,7 +77,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -133,14 +133,14 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 55,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,7 +148,7 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -197,14 +197,14 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 550,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -212,7 +212,7 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,12 +254,12 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{}); err != nil {
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -267,7 +267,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -323,12 +323,12 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{}); err != nil {
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -336,7 +336,7 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -493,14 +493,14 @@ func TestBalanceByAddress(t *testing.T) {
 				}
 				indexAll(ctx, t, tbcServer)
 
-				if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
+				if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
 					Address: tti.address(),
 				}); err != nil {
 					t.Fatal(err)
 				}
 
 				var v protocol.Message
-				if err = wsjson.Read(ctx, c, &v); err != nil {
+				if err := wsjson.Read(ctx, c, &v); err != nil {
 					t.Fatal(err)
 				}
 
@@ -508,7 +508,7 @@ func TestBalanceByAddress(t *testing.T) {
 					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}
 
-				if err = json.Unmarshal(v.Payload, &response); err != nil {
+				if err := json.Unmarshal(v.Payload, &response); err != nil {
 					t.Fatal(err)
 				}
 
@@ -715,7 +715,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
+			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
@@ -724,7 +724,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 
 			var v protocol.Message
-			if err = wsjson.Read(ctx, c, &v); err != nil {
+			if err := wsjson.Read(ctx, c, &v); err != nil {
 				t.Fatal(err)
 			}
 
@@ -732,7 +732,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 
-			if err = json.Unmarshal(v.Payload, &response); err != nil {
+			if err := json.Unmarshal(v.Payload, &response); err != nil {
 				t.Fatal(err)
 			}
 
@@ -927,7 +927,7 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
+			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
@@ -936,7 +936,7 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 
 			var v protocol.Message
-			if err = wsjson.Read(ctx, c, &v); err != nil {
+			if err := wsjson.Read(ctx, c, &v); err != nil {
 				t.Fatal(err)
 			}
 
@@ -944,7 +944,7 @@ func TestUtxosByAddress(t *testing.T) {
 				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 
-			if err = json.Unmarshal(v.Payload, &response); err != nil {
+			if err := json.Unmarshal(v.Payload, &response); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1014,14 +1014,14 @@ func TestTxByIdRaw(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1029,7 +1029,7 @@ func TestTxByIdRaw(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1103,14 +1103,14 @@ func TestTxByIdRawInvalid(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1118,7 +1118,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1199,14 +1199,14 @@ func TestTxByIdRawNotFound(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1214,7 +1214,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1281,14 +1281,14 @@ func TestTxById(t *testing.T) {
 
 	revTxId := tbcd.TxId(reverseBytes(txIdBytes))
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: revTxId[:],
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1296,7 +1296,7 @@ func TestTxById(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1365,14 +1365,14 @@ func TestTxByIdInvalid(t *testing.T) {
 
 	txIdBytes[0]++
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1380,7 +1380,7 @@ func TestTxByIdInvalid(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1460,14 +1460,14 @@ func TestTxByIdNotFound(t *testing.T) {
 
 	txIdBytes = append(txIdBytes, 8)
 
-	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err = wsjson.Read(ctx, c, &v); err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1475,7 +1475,7 @@ func TestTxByIdNotFound(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err = json.Unmarshal(v.Payload, &response); err != nil {
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1510,11 +1510,11 @@ func indexAll(ctx context.Context, t *testing.T, tbcServer *Server) {
 
 	hash := bh.BlockHash()
 
-	if err = tbcServer.TxIndexer(ctx, &hash); err != nil {
+	if err := tbcServer.TxIndexer(ctx, &hash); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = tbcServer.UtxoIndexer(ctx, &hash); err != nil {
+	if err := tbcServer.UtxoIndexer(ctx, &hash); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -150,7 +150,6 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
-
 	} else {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
@@ -216,7 +215,6 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
-
 	} else {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
@@ -274,7 +272,6 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
-
 	} else {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
@@ -346,7 +343,6 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
-
 	} else {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
@@ -549,7 +545,6 @@ func TestBalanceByAddress(t *testing.T) {
 					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}
 			}
-
 		})
 	}
 }

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -73,12 +73,12 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if v.Header.Command == tbcapi.CmdBlockHeadersByHeightRawResponse {
-		if err := json.Unmarshal(v.Payload, &response); err != nil {
-			t.Fatal(err)
-		}
-	} else {
+	if v.Header.Command != tbcapi.CmdBlockHeadersByHeightRawResponse {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
+	}
+
+	if err := json.Unmarshal(v.Payload, &response); err != nil {
+		t.Fatal(err)
 	}
 
 	bh, err := bytes2Header(response.BlockHeaders[0])

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -446,7 +446,7 @@ func TestBalanceByAddress(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
 
 			initialBlocks := 0

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -56,7 +55,6 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.BlockHeadersByHeightRawResponse
 	for {
 		select {
@@ -64,20 +62,17 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
-		lastErr = nil
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
 			Height: 55,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightRawResponse {
@@ -86,12 +81,8 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 			}
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 
 	bh, err := bytes2Header(response.BlockHeaders[0])
@@ -139,7 +130,6 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.BlockHeadersByHeightResponse
 	for {
 		select {
@@ -147,20 +137,17 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
-		lastErr = nil
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 			Height: 55,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightResponse {
@@ -169,13 +156,9 @@ func TestBlockHeadersByHeight(t *testing.T) {
 			}
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 
 	if response.Error != nil {
@@ -216,7 +199,6 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.BlockHeadersByHeightResponse
 	for {
 		select {
@@ -224,20 +206,17 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
-		lastErr = nil
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 			Height: 550,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightResponse {
@@ -246,13 +225,9 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 			}
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 
 	if response.Error.Message != "block headers not found at height 550" {
@@ -287,7 +262,6 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.BlockHeaderBestRawResponse
 	for {
 		select {
@@ -295,18 +269,15 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
-		lastErr = nil
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdBlockHeaderBestRawResponse {
@@ -315,12 +286,8 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 			}
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 
 	bh, err := bytes2Header(response.BlockHeader)
@@ -368,7 +335,6 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.BlockHeaderBestResponse
 	for {
 		select {
@@ -376,18 +342,16 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
-		lastErr = nil
+
 		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdBlockHeaderBestResponse {
@@ -396,13 +360,9 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 			}
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 
 	if response.Error != nil {
@@ -549,7 +509,6 @@ func TestBalanceByAddress(t *testing.T) {
 				conn: protocol.NewWSConn(c),
 			}
 
-			var lastErr error
 			var response tbcapi.BalanceByAddressResponse
 			for {
 				select {
@@ -558,20 +517,18 @@ func TestBalanceByAddress(t *testing.T) {
 					t.Fatal(ctx.Err())
 				}
 				indexAll(ctx, t, tbcServer)
-				lastErr = nil
+
 				err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
 					Address: tti.address(),
 				})
 				if err != nil {
-					lastErr = err
-					continue
+					t.Fatal(err)
 				}
 
 				var v protocol.Message
 				err = wsjson.Read(ctx, c, &v)
 				if err != nil {
-					lastErr = err
-					continue
+					t.Fatal(err)
 				}
 
 				if v.Header.Command == tbcapi.CmdBalanceByAddressResponse {
@@ -602,13 +559,9 @@ func TestBalanceByAddress(t *testing.T) {
 					}
 					break
 				} else {
-					lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}
 
-			}
-
-			if lastErr != nil {
-				t.Fatal(lastErr)
 			}
 		})
 	}
@@ -781,7 +734,6 @@ func TestUtxosByAddressRaw(t *testing.T) {
 				conn: protocol.NewWSConn(c),
 			}
 
-			var lastErr error
 			var response tbcapi.UtxosByAddressRawResponse
 			for {
 				select {
@@ -790,22 +742,20 @@ func TestUtxosByAddressRaw(t *testing.T) {
 					t.Fatal(ctx.Err())
 				}
 				indexAll(ctx, t, tbcServer)
-				lastErr = nil
+
 				err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
 					Address: tti.address(),
 					Start:   uint(tti.start),
 					Count:   uint(tti.limit),
 				})
 				if err != nil {
-					lastErr = err
-					continue
+					t.Fatal(err)
 				}
 
 				var v protocol.Message
 				err = wsjson.Read(ctx, c, &v)
 				if err != nil {
-					lastErr = err
-					continue
+					t.Fatal(err)
 				}
 
 				if v.Header.Command == tbcapi.CmdUtxosByAddressRawResponse {
@@ -827,13 +777,9 @@ func TestUtxosByAddressRaw(t *testing.T) {
 					}
 					break
 				} else {
-					lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}
 
-			}
-
-			if lastErr != nil {
-				t.Fatal(lastErr)
 			}
 		})
 	}
@@ -1006,7 +952,6 @@ func TestUtxosByAddress(t *testing.T) {
 				conn: protocol.NewWSConn(c),
 			}
 
-			var lastErr error
 			var response tbcapi.UtxosByAddressResponse
 			for {
 				select {
@@ -1015,22 +960,20 @@ func TestUtxosByAddress(t *testing.T) {
 					t.Fatal(ctx.Err())
 				}
 				indexAll(ctx, t, tbcServer)
-				lastErr = nil
+
 				err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
 					Address: tti.address(),
 					Start:   uint(tti.start),
 					Count:   uint(tti.limit),
 				})
 				if err != nil {
-					lastErr = err
-					continue
+					t.Fatal(err)
 				}
 
 				var v protocol.Message
 				err = wsjson.Read(ctx, c, &v)
 				if err != nil {
-					lastErr = err
-					continue
+					t.Fatal(err)
 				}
 
 				if v.Header.Command == tbcapi.CmdUtxosByAddressResponse {
@@ -1052,13 +995,9 @@ func TestUtxosByAddress(t *testing.T) {
 					}
 					break
 				} else {
-					lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}
 
-			}
-
-			if lastErr != nil {
-				t.Fatal(lastErr)
 			}
 		})
 	}
@@ -1098,7 +1037,6 @@ func TestTxByIdRaw(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.TxByIdRawResponse
 	for {
 		select {
@@ -1107,7 +1045,7 @@ func TestTxByIdRaw(t *testing.T) {
 			t.Fatal(ctx.Err())
 		}
 		indexAll(ctx, t, tbcServer)
-		lastErr = nil
+
 		txId := getRandomTxId(ctx, t, bitcoindContainer)
 		txIdBytes, err := hex.DecodeString(txId)
 		if err != nil {
@@ -1120,15 +1058,13 @@ func TestTxByIdRaw(t *testing.T) {
 			TxId: txIdBytes,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
@@ -1156,13 +1092,9 @@ func TestTxByIdRaw(t *testing.T) {
 
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 }
 
@@ -1199,7 +1131,6 @@ func TestTxByIdRawInvalid(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.TxByIdRawResponse
 	for {
 		select {
@@ -1208,7 +1139,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 			t.Fatal(ctx.Err())
 		}
 		indexAll(ctx, t, tbcServer)
-		lastErr = nil
+
 		txId := getRandomTxId(ctx, t, bitcoindContainer)
 		txIdBytes, err := hex.DecodeString(txId)
 		if err != nil {
@@ -1223,15 +1154,13 @@ func TestTxByIdRawInvalid(t *testing.T) {
 			TxId: txIdBytes,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
@@ -1251,13 +1180,9 @@ func TestTxByIdRawInvalid(t *testing.T) {
 
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 }
 
@@ -1309,7 +1234,6 @@ func TestTxByIdRawNotFound(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.TxByIdRawResponse
 	for {
 		select {
@@ -1318,7 +1242,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 			t.Fatal(ctx.Err())
 		}
 		indexAll(ctx, t, tbcServer)
-		lastErr = nil
+
 		txId := getRandomTxId(ctx, t, bitcoindContainer)
 		txIdBytes, err := hex.DecodeString(txId)
 		if err != nil {
@@ -1333,15 +1257,13 @@ func TestTxByIdRawNotFound(t *testing.T) {
 			TxId: txIdBytes,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
@@ -1361,13 +1283,9 @@ func TestTxByIdRawNotFound(t *testing.T) {
 
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 }
 
@@ -1405,7 +1323,6 @@ func TestTxById(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.TxByIdResponse
 	for {
 		select {
@@ -1416,7 +1333,6 @@ func TestTxById(t *testing.T) {
 
 		indexAll(ctx, t, tbcServer)
 
-		lastErr = nil
 		txId, err := chainhash.NewHashFromStr(getRandomTxId(ctx, t, bitcoindContainer))
 		if err != nil {
 			t.Fatal(err)
@@ -1426,15 +1342,13 @@ func TestTxById(t *testing.T) {
 			TxId: txId[:],
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdTxByIdResponse {
@@ -1459,13 +1373,9 @@ func TestTxById(t *testing.T) {
 
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 }
 
@@ -1502,7 +1412,6 @@ func TestTxByIdInvalid(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.TxByIdResponse
 	for {
 		select {
@@ -1511,7 +1420,7 @@ func TestTxByIdInvalid(t *testing.T) {
 			t.Fatal(ctx.Err())
 		}
 		indexAll(ctx, t, tbcServer)
-		lastErr = nil
+
 		txId := getRandomTxId(ctx, t, bitcoindContainer)
 		txIdBytes, err := hex.DecodeString(txId)
 		if err != nil {
@@ -1524,15 +1433,13 @@ func TestTxByIdInvalid(t *testing.T) {
 			TxId: txIdBytes,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdTxByIdResponse {
@@ -1552,13 +1459,9 @@ func TestTxByIdInvalid(t *testing.T) {
 
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 }
 
@@ -1610,7 +1513,6 @@ func TestTxByIdNotFound(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var lastErr error
 	var response tbcapi.TxByIdResponse
 	for {
 		select {
@@ -1621,7 +1523,6 @@ func TestTxByIdNotFound(t *testing.T) {
 
 		indexAll(ctx, t, tbcServer)
 
-		lastErr = nil
 		txId := getRandomTxId(ctx, t, bitcoindContainer)
 		txIdBytes, err := hex.DecodeString(txId)
 		if err != nil {
@@ -1634,15 +1535,13 @@ func TestTxByIdNotFound(t *testing.T) {
 			TxId: txIdBytes,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		var v protocol.Message
 		err = wsjson.Read(ctx, c, &v)
 		if err != nil {
-			lastErr = err
-			continue
+			t.Fatal(err)
 		}
 
 		if v.Header.Command == tbcapi.CmdTxByIdResponse {
@@ -1662,13 +1561,9 @@ func TestTxByIdNotFound(t *testing.T) {
 
 			break
 		} else {
-			lastErr = fmt.Errorf("received unexpected command: %s", v.Header.Command)
+			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
-	}
-
-	if lastErr != nil {
-		t.Fatal(lastErr)
 	}
 }
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -500,41 +500,40 @@ func TestBalanceByAddress(t *testing.T) {
 				}
 
 				var v protocol.Message
-				err = wsjson.Read(ctx, c, &v)
-				if err != nil {
+				if err = wsjson.Read(ctx, c, &v); err != nil {
 					t.Fatal(err)
 				}
 
 				if v.Header.Command != tbcapi.CmdBalanceByAddressResponse {
 					t.Fatalf("received unexpected command: %s", v.Header.Command)
+				}
+
+				if err = json.Unmarshal(v.Payload, &response); err != nil {
+					t.Fatal(err)
+				}
+
+				var pricePerBlock uint64 = 50 * 100000000
+				var blocks uint64 = 4
+				var expectedBalance uint64 = 0
+				if !tti.doNotGenerate {
+					expectedBalance = pricePerBlock * blocks
+				}
+
+				expected := tbcapi.BalanceByAddressResponse{
+					Balance: expectedBalance,
+					Error:   nil,
+				}
+				if diff := deep.Equal(expected, response); len(diff) > 0 {
+					if response.Error != nil {
+						t.Error(response.Error.Message)
+					}
+					t.Logf("unexpected diff: %s", diff)
+
+					// there is a chance we just haven't finished indexing
+					// the blocks and txs, retry until timeout
+					continue
 				} else {
-					if err = json.Unmarshal(v.Payload, &response); err != nil {
-						t.Fatal(err)
-					}
-
-					var pricePerBlock uint64 = 50 * 100000000
-					var blocks uint64 = 4
-					var expectedBalance uint64 = 0
-					if !tti.doNotGenerate {
-						expectedBalance = pricePerBlock * blocks
-					}
-
-					expected := tbcapi.BalanceByAddressResponse{
-						Balance: expectedBalance,
-						Error:   nil,
-					}
-					if diff := deep.Equal(expected, response); len(diff) > 0 {
-						if response.Error != nil {
-							t.Error(response.Error.Message)
-						}
-						t.Logf("unexpected diff: %s", diff)
-
-						// there is a chance we just haven't finished indexing
-						// the blocks and txs, retry until timeout
-						continue
-					} else {
-						break
-					}
+					break
 				}
 			}
 		})
@@ -725,8 +724,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 
 			var v protocol.Message
-			err = wsjson.Read(ctx, c, &v)
-			if err != nil {
+			if err = wsjson.Read(ctx, c, &v); err != nil {
 				t.Fatal(err)
 			}
 
@@ -938,8 +936,7 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 
 			var v protocol.Message
-			err = wsjson.Read(ctx, c, &v)
-			if err != nil {
+			if err = wsjson.Read(ctx, c, &v); err != nil {
 				t.Fatal(err)
 			}
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -56,33 +56,30 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 	}
 
 	var response tbcapi.BlockHeadersByHeightRawResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
-			Height: 55,
-		})
-		if err != nil {
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
+		Height: 55,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdBlockHeadersByHeightRawResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
-
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightRawResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
 	bh, err := bytes2Header(response.BlockHeaders[0])
@@ -131,34 +128,31 @@ func TestBlockHeadersByHeight(t *testing.T) {
 	}
 
 	var response tbcapi.BlockHeadersByHeightResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
-			Height: 55,
-		})
-		if err != nil {
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+		Height: 55,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdBlockHeadersByHeightResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
 	if response.Error != nil {
@@ -200,34 +194,31 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 	}
 
 	var response tbcapi.BlockHeadersByHeightResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
-			Height: 550,
-		})
-		if err != nil {
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+		Height: 550,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdBlockHeadersByHeightResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if v.Header.Command == tbcapi.CmdBlockHeadersByHeightResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
 	if response.Error.Message != "block headers not found at height 550" {
@@ -263,31 +254,29 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 	}
 
 	var response tbcapi.BlockHeaderBestRawResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{})
-		if err != nil {
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdBlockHeaderBestRawResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if v.Header.Command == tbcapi.CmdBlockHeaderBestRawResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
 	bh, err := bytes2Header(response.BlockHeader)
@@ -336,33 +325,30 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 	}
 
 	var response tbcapi.BlockHeaderBestResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
 
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{})
-		if err != nil {
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdBlockHeaderBestResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if v.Header.Command == tbcapi.CmdBlockHeaderBestResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
 	if response.Error != nil {
@@ -557,12 +543,11 @@ func TestBalanceByAddress(t *testing.T) {
 						// the blocks and txs, retry until timeout
 						continue
 					}
-					break
 				} else {
 					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}
-
 			}
+
 		})
 	}
 }
@@ -735,51 +720,48 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 
 			var response tbcapi.UtxosByAddressRawResponse
-			for {
-				select {
-				case <-time.After(1 * time.Second):
-				case <-ctx.Done():
-					t.Fatal(ctx.Err())
-				}
-				indexAll(ctx, t, tbcServer)
+			select {
+			case <-time.After(1 * time.Second):
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			indexAll(ctx, t, tbcServer)
 
-				err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
-					Address: tti.address(),
-					Start:   uint(tti.start),
-					Count:   uint(tti.limit),
-				})
-				if err != nil {
+			err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
+				Address: tti.address(),
+				Start:   uint(tti.start),
+				Count:   uint(tti.limit),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var v protocol.Message
+			err = wsjson.Read(ctx, c, &v)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if v.Header.Command == tbcapi.CmdUtxosByAddressRawResponse {
+				if err := json.Unmarshal(v.Payload, &response); err != nil {
 					t.Fatal(err)
 				}
 
-				var v protocol.Message
-				err = wsjson.Read(ctx, c, &v)
-				if err != nil {
-					t.Fatal(err)
+				// we generated 4 blocks to this address previously, therefore
+				// there should be 4 utxos
+				expectedCount := 4 - tti.start
+				if tti.limit < uint64(expectedCount) {
+					expectedCount = tti.limit
 				}
 
-				if v.Header.Command == tbcapi.CmdUtxosByAddressRawResponse {
-					if err := json.Unmarshal(v.Payload, &response); err != nil {
-						t.Fatal(err)
-					}
-
-					// we generated 4 blocks to this address previously, therefore
-					// there should be 4 utxos
-					expectedCount := 4 - tti.start
-					if tti.limit < uint64(expectedCount) {
-						expectedCount = tti.limit
-					}
-
-					if !tti.doNotGenerate && len(response.Utxos) != int(expectedCount) {
-						t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.Utxos))
-					} else if tti.doNotGenerate && len(response.Utxos) != 0 {
-						t.Fatalf("did not generate any blocks for address, should not have utxos")
-					}
-					break
-				} else {
-					t.Fatalf("received unexpected command: %s", v.Header.Command)
+				if !tti.doNotGenerate && len(response.Utxos) != int(expectedCount) {
+					t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.Utxos))
+				} else if tti.doNotGenerate && len(response.Utxos) != 0 {
+					t.Fatalf("did not generate any blocks for address, should not have utxos")
 				}
 
+			} else {
+				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 		})
 	}
@@ -953,51 +935,48 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 
 			var response tbcapi.UtxosByAddressResponse
-			for {
-				select {
-				case <-time.After(1 * time.Second):
-				case <-ctx.Done():
-					t.Fatal(ctx.Err())
-				}
-				indexAll(ctx, t, tbcServer)
+			select {
+			case <-time.After(1 * time.Second):
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			}
+			indexAll(ctx, t, tbcServer)
 
-				err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
-					Address: tti.address(),
-					Start:   uint(tti.start),
-					Count:   uint(tti.limit),
-				})
-				if err != nil {
+			err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
+				Address: tti.address(),
+				Start:   uint(tti.start),
+				Count:   uint(tti.limit),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var v protocol.Message
+			err = wsjson.Read(ctx, c, &v)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if v.Header.Command == tbcapi.CmdUtxosByAddressResponse {
+				if err := json.Unmarshal(v.Payload, &response); err != nil {
 					t.Fatal(err)
 				}
 
-				var v protocol.Message
-				err = wsjson.Read(ctx, c, &v)
-				if err != nil {
-					t.Fatal(err)
+				// we generated 4 blocks to this address previously, therefore
+				// there should be 4 utxos
+				expectedCount := 4 - tti.start
+				if tti.limit < uint64(expectedCount) {
+					expectedCount = tti.limit
 				}
 
-				if v.Header.Command == tbcapi.CmdUtxosByAddressResponse {
-					if err := json.Unmarshal(v.Payload, &response); err != nil {
-						t.Fatal(err)
-					}
-
-					// we generated 4 blocks to this address previously, therefore
-					// there should be 4 utxos
-					expectedCount := 4 - tti.start
-					if tti.limit < uint64(expectedCount) {
-						expectedCount = tti.limit
-					}
-
-					if !tti.doNotGenerate && len(response.Utxos) != int(expectedCount) {
-						t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.Utxos))
-					} else if tti.doNotGenerate && len(response.Utxos) != 0 {
-						t.Fatalf("did not generate any blocks for address, should not have utxos")
-					}
-					break
-				} else {
-					t.Fatalf("received unexpected command: %s", v.Header.Command)
+				if !tti.doNotGenerate && len(response.Utxos) != int(expectedCount) {
+					t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.Utxos))
+				} else if tti.doNotGenerate && len(response.Utxos) != 0 {
+					t.Fatalf("did not generate any blocks for address, should not have utxos")
 				}
 
+			} else {
+				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 		})
 	}
@@ -1038,63 +1017,59 @@ func TestTxByIdRaw(t *testing.T) {
 	}
 
 	var response tbcapi.TxByIdRawResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		indexAll(ctx, t, tbcServer)
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	indexAll(ctx, t, tbcServer)
 
-		txId := getRandomTxId(ctx, t, bitcoindContainer)
-		txIdBytes, err := hex.DecodeString(txId)
+	txId := getRandomTxId(ctx, t, bitcoindContainer)
+	txIdBytes, err := hex.DecodeString(txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	slices.Reverse(txIdBytes) // convert to natural order
+
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+		TxId: txIdBytes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
+			t.Fatal(err)
+		}
+
+		if response.Error != nil {
+			t.Fatal(response.Error.Message)
+		}
+
+		// XXX - write a better test than this, we should be able to compare
+		// against bitcoin-cli response fields
+
+		// did we get the tx and can we parse it?
+		tx, err := bytes2Tx(response.Tx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		slices.Reverse(txIdBytes) // convert to natural order
-
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-			TxId: txIdBytes,
-		})
-		if err != nil {
-			t.Fatal(err)
+		// is the hash equal to what we queried for?
+		if tx.TxHash().String() != txId {
+			t.Fatalf("id mismatch: %s != %s", tx.TxHash().String(), txId)
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-
-			if response.Error != nil {
-				t.Fatal(response.Error.Message)
-			}
-
-			// XXX - write a better test than this, we should be able to compare
-			// against bitcoin-cli response fields
-
-			// did we get the tx and can we parse it?
-			tx, err := bytes2Tx(response.Tx)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// is the hash equal to what we queried for?
-			if tx.TxHash().String() != txId {
-				t.Fatalf("id mismatch: %s != %s", tx.TxHash().String(), txId)
-			}
-
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 }
 
@@ -1132,57 +1107,53 @@ func TestTxByIdRawInvalid(t *testing.T) {
 	}
 
 	var response tbcapi.TxByIdRawResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		indexAll(ctx, t, tbcServer)
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	indexAll(ctx, t, tbcServer)
 
-		txId := getRandomTxId(ctx, t, bitcoindContainer)
-		txIdBytes, err := hex.DecodeString(txId)
-		if err != nil {
+	txId := getRandomTxId(ctx, t, bitcoindContainer)
+	txIdBytes, err := hex.DecodeString(txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txIdBytes[0]++
+
+	slices.Reverse(txIdBytes) // convert to natural order
+
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+		TxId: txIdBytes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		txIdBytes[0]++
-
-		slices.Reverse(txIdBytes) // convert to natural order
-
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-			TxId: txIdBytes,
-		})
-		if err != nil {
-			t.Fatal(err)
+		if response.Error == nil {
+			t.Fatal("expecting error")
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
+		if response.Error != nil {
+			if !strings.Contains(response.Error.Message, "not found:") {
+				t.Fatalf("incorrect error found %s", response.Error.Message)
+			}
 		}
 
-		if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-
-			if response.Error == nil {
-				t.Fatal("expecting error")
-			}
-
-			if response.Error != nil {
-				if !strings.Contains(response.Error.Message, "not found:") {
-					t.Fatalf("incorrect error found %s", response.Error.Message)
-				}
-			}
-
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 }
 
@@ -1235,57 +1206,53 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	}
 
 	var response tbcapi.TxByIdRawResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		indexAll(ctx, t, tbcServer)
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	indexAll(ctx, t, tbcServer)
 
-		txId := getRandomTxId(ctx, t, bitcoindContainer)
-		txIdBytes, err := hex.DecodeString(txId)
-		if err != nil {
+	txId := getRandomTxId(ctx, t, bitcoindContainer)
+	txIdBytes, err := hex.DecodeString(txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txIdBytes = append(txIdBytes, 8)
+
+	slices.Reverse(txIdBytes) // convert to natural order
+
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+		TxId: txIdBytes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		txIdBytes = append(txIdBytes, 8)
-
-		slices.Reverse(txIdBytes) // convert to natural order
-
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-			TxId: txIdBytes,
-		})
-		if err != nil {
-			t.Fatal(err)
+		if response.Error == nil {
+			t.Fatal("expecting error")
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
+		if response.Error != nil {
+			if !strings.Contains(response.Error.Message, "invalid tx id") {
+				t.Fatalf("incorrect error found: %s", response.Error.Message)
+			}
 		}
 
-		if v.Header.Command == tbcapi.CmdTxByIdRawResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-
-			if response.Error == nil {
-				t.Fatal("expecting error")
-			}
-
-			if response.Error != nil {
-				if !strings.Contains(response.Error.Message, "invalid tx id") {
-					t.Fatalf("incorrect error found: %s", response.Error.Message)
-				}
-			}
-
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 }
 
@@ -1324,14 +1291,41 @@ func TestTxById(t *testing.T) {
 	}
 
 	var response tbcapi.TxByIdResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	indexAll(ctx, t, tbcServer)
+
+	txId := getRandomTxId(ctx, t, bitcoindContainer)
+	txIdBytes, err := hex.DecodeString(txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+		TxId: txIdBytes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdTxByIdResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
+			t.Fatal(err)
 		}
 
-		indexAll(ctx, t, tbcServer)
+		if response.Error != nil {
+			t.Fatal(response.Error.Message)
+		}
 
 		txId, err := chainhash.NewHashFromStr(getRandomTxId(ctx, t, bitcoindContainer))
 		if err != nil {
@@ -1376,6 +1370,8 @@ func TestTxById(t *testing.T) {
 			t.Fatalf("received unexpected command: %s", v.Header.Command)
 		}
 
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 }
 
@@ -1413,55 +1409,51 @@ func TestTxByIdInvalid(t *testing.T) {
 	}
 
 	var response tbcapi.TxByIdResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
-		indexAll(ctx, t, tbcServer)
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	indexAll(ctx, t, tbcServer)
 
-		txId := getRandomTxId(ctx, t, bitcoindContainer)
-		txIdBytes, err := hex.DecodeString(txId)
-		if err != nil {
+	txId := getRandomTxId(ctx, t, bitcoindContainer)
+	txIdBytes, err := hex.DecodeString(txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txIdBytes[0]++
+
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+		TxId: txIdBytes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdTxByIdResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		txIdBytes[0]++
-
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-			TxId: txIdBytes,
-		})
-		if err != nil {
-			t.Fatal(err)
+		if response.Error == nil {
+			t.Fatal("expecting error")
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
+		if response.Error != nil {
+			if !strings.Contains(response.Error.Message, "not found:") {
+				t.Fatalf("incorrect error found %s", response.Error.Message)
+			}
 		}
 
-		if v.Header.Command == tbcapi.CmdTxByIdResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-
-			if response.Error == nil {
-				t.Fatal("expecting error")
-			}
-
-			if response.Error != nil {
-				if !strings.Contains(response.Error.Message, "not found:") {
-					t.Fatalf("incorrect error found %s", response.Error.Message)
-				}
-			}
-
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 }
 
@@ -1514,56 +1506,52 @@ func TestTxByIdNotFound(t *testing.T) {
 	}
 
 	var response tbcapi.TxByIdResponse
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
+	select {
+	case <-time.After(1 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
 
-		indexAll(ctx, t, tbcServer)
+	indexAll(ctx, t, tbcServer)
 
-		txId := getRandomTxId(ctx, t, bitcoindContainer)
-		txIdBytes, err := hex.DecodeString(txId)
-		if err != nil {
+	txId := getRandomTxId(ctx, t, bitcoindContainer)
+	txIdBytes, err := hex.DecodeString(txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txIdBytes = append(txIdBytes, 8)
+
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+		TxId: txIdBytes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+	err = wsjson.Read(ctx, c, &v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Header.Command == tbcapi.CmdTxByIdResponse {
+		if err := json.Unmarshal(v.Payload, &response); err != nil {
 			t.Fatal(err)
 		}
 
-		txIdBytes = append(txIdBytes, 8)
-
-		err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-			TxId: txIdBytes,
-		})
-		if err != nil {
-			t.Fatal(err)
+		if response.Error == nil {
+			t.Fatal("expecting error")
 		}
 
-		var v protocol.Message
-		err = wsjson.Read(ctx, c, &v)
-		if err != nil {
-			t.Fatal(err)
+		if response.Error != nil {
+			if !strings.Contains(response.Error.Message, "invalid tx id") {
+				t.Fatalf("incorrect error found: %s", response.Error.Message)
+			}
 		}
 
-		if v.Header.Command == tbcapi.CmdTxByIdResponse {
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
-				t.Fatal(err)
-			}
-
-			if response.Error == nil {
-				t.Fatal("expecting error")
-			}
-
-			if response.Error != nil {
-				if !strings.Contains(response.Error.Message, "invalid tx id") {
-					t.Fatalf("incorrect error found: %s", response.Error.Message)
-				}
-			}
-
-			break
-		} else {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
-		}
-
+	} else {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 }
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -69,8 +69,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1301,7 +1301,9 @@ func TestTxById(t *testing.T) {
 		t.Fatal(response.Error.Message)
 	}
 
-	tx, err := tbcServer.TxById(ctx, tbcd.TxId(reverseBytes(txIdBytes)))
+	revTxId := tbcd.TxId(reverseBytes(txIdBytes))
+
+	tx, err := tbcServer.TxById(ctx, revTxId.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -140,8 +140,7 @@ func TestBlockHeadersByHeight(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -205,8 +204,7 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -262,8 +260,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -333,8 +330,7 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1034,8 +1030,7 @@ func TestTxByIdRaw(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1125,8 +1120,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1223,8 +1217,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1304,8 +1297,7 @@ func TestTxById(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1390,13 +1382,11 @@ func TestTxByIdInvalid(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
 	if v.Header.Command != tbcapi.CmdTxByIdResponse {
-
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
@@ -1488,8 +1478,7 @@ func TestTxByIdNotFound(t *testing.T) {
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -62,7 +62,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
 		Height: 55,
 	}); err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -133,14 +133,14 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 55,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,7 +148,7 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -197,14 +197,14 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 550,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -212,7 +212,7 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,12 +254,12 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{}); err != nil {
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -267,7 +267,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -323,12 +323,12 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{}); err != nil {
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -336,7 +336,7 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -493,7 +493,7 @@ func TestBalanceByAddress(t *testing.T) {
 				}
 				indexAll(ctx, t, tbcServer)
 
-				if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
+				if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
 					Address: tti.address(),
 				}); err != nil {
 					t.Fatal(err)
@@ -508,7 +508,7 @@ func TestBalanceByAddress(t *testing.T) {
 				if v.Header.Command != tbcapi.CmdBalanceByAddressResponse {
 					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				} else {
-					if err := json.Unmarshal(v.Payload, &response); err != nil {
+					if err = json.Unmarshal(v.Payload, &response); err != nil {
 						t.Fatal(err)
 					}
 
@@ -716,7 +716,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
+			if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
@@ -734,7 +734,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
+			if err = json.Unmarshal(v.Payload, &response); err != nil {
 				t.Fatal(err)
 			}
 
@@ -929,7 +929,7 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
+			if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
@@ -947,7 +947,7 @@ func TestUtxosByAddress(t *testing.T) {
 				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 
-			if err := json.Unmarshal(v.Payload, &response); err != nil {
+			if err = json.Unmarshal(v.Payload, &response); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1017,14 +1017,14 @@ func TestTxByIdRaw(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1032,7 +1032,7 @@ func TestTxByIdRaw(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1106,14 +1106,14 @@ func TestTxByIdRawInvalid(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1121,7 +1121,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1202,14 +1202,14 @@ func TestTxByIdRawNotFound(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1217,7 +1217,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1281,14 +1281,14 @@ func TestTxById(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1296,7 +1296,7 @@ func TestTxById(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1365,14 +1365,14 @@ func TestTxByIdInvalid(t *testing.T) {
 
 	txIdBytes[0]++
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1380,7 +1380,7 @@ func TestTxByIdInvalid(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1460,14 +1460,14 @@ func TestTxByIdNotFound(t *testing.T) {
 
 	txIdBytes = append(txIdBytes, 8)
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	if err := wsjson.Read(ctx, c, &v); err != nil {
+	if err = wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1475,7 +1475,7 @@ func TestTxByIdNotFound(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	if err := json.Unmarshal(v.Payload, &response); err != nil {
+	if err = json.Unmarshal(v.Payload, &response); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1510,11 +1510,11 @@ func indexAll(ctx context.Context, t *testing.T, tbcServer *Server) {
 
 	hash := bh.BlockHash()
 
-	if err := tbcServer.TxIndexer(ctx, &hash); err != nil {
+	if err = tbcServer.TxIndexer(ctx, &hash); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := tbcServer.UtxoIndexer(ctx, &hash); err != nil {
+	if err = tbcServer.UtxoIndexer(ctx, &hash); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1265,7 +1265,7 @@ func TestTxById(t *testing.T) {
 
 	var response tbcapi.TxByIdResponse
 	select {
-	case <-time.After(1 * time.Second):
+	case <-time.After(2 * time.Second):
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1263,12 +1263,13 @@ func TestTxById(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var response tbcapi.TxByIdResponse
 	select {
-	case <-time.After(2 * time.Second):
+	case <-time.After(1 * time.Second):
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
+
+	var response tbcapi.TxByIdResponse
 
 	indexAll(ctx, t, tbcServer)
 
@@ -1278,8 +1279,10 @@ func TestTxById(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	revTxId := tbcd.TxId(reverseBytes(txIdBytes))
+
 	if err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxId: txIdBytes,
+		TxId: revTxId[:],
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1300,8 +1303,6 @@ func TestTxById(t *testing.T) {
 	if response.Error != nil {
 		t.Fatal(response.Error.Message)
 	}
-
-	revTxId := tbcd.TxId(reverseBytes(txIdBytes))
 
 	tx, err := tbcServer.TxById(ctx, revTxId.Hash())
 	if err != nil {

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -543,6 +543,7 @@ func TestBalanceByAddress(t *testing.T) {
 						// the blocks and txs, retry until timeout
 						continue
 					}
+					break
 				} else {
 					t.Fatalf("received unexpected command: %s", v.Header.Command)
 				}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -61,10 +61,10 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
+
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
 		Height: 55,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -132,10 +132,10 @@ func TestBlockHeadersByHeight(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 55,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -196,10 +196,10 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 550,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,8 +254,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{})
-	if err != nil {
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRawRequest{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -324,8 +323,7 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{})
-	if err != nil {
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeaderBestRequest{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -495,10 +493,9 @@ func TestBalanceByAddress(t *testing.T) {
 				}
 				indexAll(ctx, t, tbcServer)
 
-				err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
+				if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
 					Address: tti.address(),
-				})
-				if err != nil {
+				}); err != nil {
 					t.Fatal(err)
 				}
 
@@ -719,12 +716,11 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
+			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
-			})
-			if err != nil {
+			}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -933,12 +929,11 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
+			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
-			})
-			if err != nil {
+			}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1022,10 +1017,9 @@ func TestTxByIdRaw(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1112,10 +1106,9 @@ func TestTxByIdRawInvalid(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1209,10 +1202,9 @@ func TestTxByIdRawNotFound(t *testing.T) {
 
 	slices.Reverse(txIdBytes) // convert to natural order
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxId: txIdBytes,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1289,10 +1281,9 @@ func TestTxById(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1374,10 +1365,9 @@ func TestTxByIdInvalid(t *testing.T) {
 
 	txIdBytes[0]++
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1470,10 +1460,9 @@ func TestTxByIdNotFound(t *testing.T) {
 
 	txIdBytes = append(txIdBytes, 8)
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxId: txIdBytes,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
**Summary**
lastErr was added to handle for something that likely shouldn't have been; it's an un-needed way to handle for errors.  replace with simply failing the test if there are errors.


**Changes**
remove lastErr variables from rpc_test.go

fixes #182 
