### PR TITLE
popm: exclude tx outputs that would be dust

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
+	github.com/aead/siphash v1.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
@@ -54,6 +55,7 @@ require (
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect
+	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 // indirect
 	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/lufia/plan9stats v0.0.0-20231016141302-07b5767bb0ed // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
+github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -130,6 +131,7 @@ github.com/juju/loggo v1.0.0 h1:Y6ZMQOGR9Aj3BGkiWx7HBbIx6zNwNkxhVNOHU2i1bl0=
 github.com/juju/loggo v1.0.0/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
 github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	btcchaincfg "github.com/btcsuite/btcd/chaincfg"
 	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
+	btcmempool "github.com/btcsuite/btcd/mempool"
 	btctxscript "github.com/btcsuite/btcd/txscript"
 	btcwire "github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
@@ -287,6 +288,8 @@ func pickUTXO(utxos []*bfgapi.BitcoinUTXO, amount int64) (*bfgapi.BitcoinUTXO, e
 	return utxo, nil
 }
 
+const minRelayTxFee = 10000
+
 func createTx(l2Keystone *hemi.L2Keystone, btcHeight uint64, utxo *bfgapi.BitcoinUTXO, payToScript []byte, feeAmount int64) (*btcwire.MsgTx, error) {
 	btx := btcwire.MsgTx{
 		Version:  2,
@@ -298,11 +301,22 @@ func createTx(l2Keystone *hemi.L2Keystone, btcHeight uint64, utxo *bfgapi.Bitcoi
 		Hash:  btcchainhash.Hash(utxo.Hash),
 		Index: utxo.Index,
 	}
-	btx.TxIn = []*btcwire.TxIn{btcwire.NewTxIn(&outPoint, payToScript, nil)}
+	btx.TxIn = []*btcwire.TxIn{
+		btcwire.NewTxIn(&outPoint, payToScript, nil),
+	}
 
 	// Add output for change as P2PKH.
 	changeAmount := utxo.Value - feeAmount
-	btx.TxOut = []*btcwire.TxOut{btcwire.NewTxOut(changeAmount, payToScript)}
+	changeTxOut := btcwire.NewTxOut(changeAmount, payToScript)
+
+	// If the change output would be considered dust, then don't include the
+	// output and instead leave the remaining to be included as a fee.
+	//
+	// TODO: When we rewrite the fee estimation and BFG has access to a mempool,
+	//  improve the minRelayTxFee to be calculated from the mempool data.
+	if !btcmempool.IsDust(changeTxOut, minRelayTxFee) {
+		btx.TxOut = []*btcwire.TxOut{changeTxOut}
+	}
 
 	// Add PoP TX using OP_RETURN output.
 	aks := hemi.L2KeystoneAbbreviate(*l2Keystone)

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -292,7 +292,7 @@ func TestCreateTxVersion2(t *testing.T) {
 
 	mockPayToScript := []byte{}
 
-	btx, err := createTx(&l2Keystone, 1, &utxo, mockPayToScript, 1)
+	btx, err := createTx(&l2Keystone, 1, &utxo, mockPayToScript, 1, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func TestCreateTxLockTime(t *testing.T) {
 
 	var height uint64 = 99
 
-	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, 1)
+	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, 1, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +340,7 @@ func TestCreateTxTxIn(t *testing.T) {
 
 	var feeAmount int64 = 10
 
-	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount)
+	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,22 +366,19 @@ func TestCreateTxTxOutPayTo(t *testing.T) {
 		Index: 5,
 		Value: 10,
 	}
-
 	copy(utxo.Hash, []byte{1, 2, 3})
 
 	mockPayToScript := []byte{4, 5, 6}
+	height := uint64(99)
+	feeAmount := int64(10)
 
-	var height uint64 = 99
-
-	var feeAmount int64 = 10
-
-	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount)
+	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expectexTxOut := btcwire.NewTxOut(utxo.Value-feeAmount, mockPayToScript)
-	diff := deep.Equal(expectexTxOut, btx.TxOut[0])
+	wantTxOut := btcwire.NewTxOut(utxo.Value-feeAmount, mockPayToScript)
+	diff := deep.Equal(btx.TxOut[0], wantTxOut)
 	if len(diff) != 0 {
 		t.Fatalf("got unexpected diff %s", diff)
 	}
@@ -404,7 +401,7 @@ func TestCreateTxTxOutPopTx(t *testing.T) {
 
 	var feeAmount int64 = 10
 
-	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount)
+	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,6 +497,7 @@ func TestSignTx(t *testing.T) {
 				&testTableItem.utxo,
 				testTableItem.payToScript,
 				testTableItem.feeAmount,
+				0,
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -566,7 +564,7 @@ func TestSignTxDifferingPubPrivKeys(t *testing.T) {
 
 	var feeAmount int64 = 10
 
-	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount)
+	btx, err := createTx(&l2Keystone, height, &utxo, mockPayToScript, feeAmount, 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**Summary**
Avoid "dust" errors when broadcasting PoP transactions to Bitcoin by checking if the transaction output would be considered dust with a relay tx fee of 10,000.

If the transaction output would be considered dust, then don't include the output and instead leave the remaining to be included as a fee.

Fixes #183 

**Changes**
 - Don't add a change transaction output when creating a transaction if the transaction output is dust.
