### PR TITLE
Add a header and block cache.

### DIFF
--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -307,7 +307,7 @@ func tbcdb() error {
 
 		levelDBHome := "~/.tbcd" // XXX
 		network := "testnet3"
-		db, err := level.New(ctx, filepath.Join(levelDBHome, network))
+		db, err := level.New(ctx, level.NewConfig(filepath.Join(levelDBHome, network)))
 		if err != nil {
 			return err
 		}
@@ -324,7 +324,7 @@ func tbcdb() error {
 
 		levelDBHome := "~/.tbcd" // XXX
 		network := "testnet3"
-		db, err := level.New(ctx, filepath.Join(levelDBHome, network))
+		db, err := level.New(ctx, level.NewConfig(filepath.Join(levelDBHome, network)))
 		if err != nil {
 			return err
 		}
@@ -342,7 +342,7 @@ func tbcdb() error {
 
 		levelDBHome := "~/.tbcd" // XXX
 		network := "testnet3"
-		db, err := level.New(ctx, filepath.Join(levelDBHome, network))
+		db, err := level.New(ctx, level.NewConfig(filepath.Join(levelDBHome, network)))
 		if err != nil {
 			return err
 		}

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -45,6 +45,18 @@ var (
 			Help:         "enable auto utxo and tx indexes",
 			Print:        config.PrintAll,
 		},
+		"TBC_BLOCK_CACHE": config.Config{
+			Value:        &cfg.BlockCache,
+			DefaultValue: int(250),
+			Help:         "number of cached blocks",
+			Print:        config.PrintAll,
+		},
+		"TBC_BLOCKHEADER_CACHE": config.Config{
+			Value:        &cfg.BlockheaderCache,
+			DefaultValue: int(1e6),
+			Help:         "number of cached blockheaders",
+			Print:        config.PrintAll,
+		},
 		"TBC_BLOCK_SANITY": config.Config{
 			Value:        &cfg.BlockSanity,
 			DefaultValue: false,

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -47,7 +47,7 @@ var (
 		},
 		"TBC_BLOCK_CACHE": config.Config{
 			Value:        &cfg.BlockCache,
-			DefaultValue: int(250),
+			DefaultValue: 250,
 			Help:         "number of cached blocks",
 			Print:        config.PrintAll,
 		},
@@ -77,7 +77,7 @@ var (
 		},
 		"TBC_MAX_CACHED_TXS": config.Config{
 			Value:        &cfg.MaxCachedTxs,
-			DefaultValue: 1000000,
+			DefaultValue: int(1e6),
 			Help:         "maximum cached utxos and/or txs during indexing",
 			Print:        config.PrintAll,
 		},

--- a/database/database.go
+++ b/database/database.go
@@ -72,7 +72,6 @@ var (
 	ErrDuplicate  = DuplicateError("duplicate")
 	ErrNotFound   = NotFoundError("not found")
 	ErrValidation = ValidationError("validation")
-	ErrZeroRows   = ZeroRowsError("zero rows affected")
 )
 
 // ByteArray is a type that corresponds to BYTEA in a database. It supports

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -139,7 +139,7 @@ func (bh BlockHeader) ParentHash() *chainhash.Hash {
 // Block contains a raw bitcoin block and its corresponding hash.
 type Block struct {
 	Hash  database.ByteArray
-	Block database.ByteArray
+	Block database.ByteArray // this needs to be converted to either wire or btcutil
 }
 
 // BlockIdentifier uniquely identifies a block using it's hash and height.

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -148,14 +148,6 @@ type SpentInfo struct {
 	InputIndex uint32
 }
 
-// Peer
-type Peer struct {
-	Host      string
-	Port      string
-	LastAt    database.Timestamp `deep:"-"` // Last time connected
-	CreatedAt database.Timestamp `deep:"-"`
-}
-
 // XXX we can probably save a bunch of bcopy if we construct the key directly
 // for the db. Peek at the s + t cache which does this.
 

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -70,12 +70,6 @@ type Database interface {
 	BlocksByTxId(ctx context.Context, txId []byte) ([]BlockHash, error)
 	SpentOutputsByTxId(ctx context.Context, txId []byte) ([]SpentInfo, error)
 
-	// Peer manager
-	PeersStats(ctx context.Context) (int, int)               // good, bad count
-	PeersInsert(ctx context.Context, peers []Peer) error     // insert or update
-	PeerDelete(ctx context.Context, host, port string) error // remove peer
-	PeersRandom(ctx context.Context, count int) ([]Peer, error)
-
 	// ScriptHash returns the sha256 of PkScript for the provided outpoint.
 	BalanceByScriptHash(ctx context.Context, sh ScriptHash) (uint64, error)
 	ScriptHashByOutpoint(ctx context.Context, op Outpoint) (*ScriptHash, error)

--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,12 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
-	github.com/dgraph-io/ristretto v0.1.1
 	github.com/docker/docker v25.0.5+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ethereum/go-ethereum v1.13.5
 	github.com/go-test/deep v1.1.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/juju/loggo v1.0.0
 	github.com/lib/pq v1.10.9
 	github.com/mitchellh/go-homedir v1.1.0
@@ -52,7 +52,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
+	github.com/dgraph-io/ristretto v0.1.1
 	github.com/docker/docker v25.0.5+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/dustin/go-humanize v1.0.1
@@ -51,6 +52,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,7 +41,6 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
-github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/containerd/containerd v1.7.13 h1:wPYKIeGMN8vaggSKuV1X0wZulpMz4CrgEsZdaCyB6Is=
@@ -63,10 +62,6 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeC
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
-github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
-github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
-github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
-github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v25.0.5+incompatible h1:UmQydMduGkrD5nQde1mecF/YnSbTOaPeFIeP5C4W+DE=
@@ -75,7 +70,6 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ethereum/go-ethereum v1.13.5 h1:U6TCRciCqZRe4FPXmy1sMGxTfuk8P7u2UoinF3VbaFk=
@@ -98,9 +92,6 @@ github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
-github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -127,6 +118,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hemilabs/websocket v0.0.0-20240620132401-b5109a38f904 h1:6kt/B7B5cQNpR0fiCPr53MU5sgao8Tj5NokLddTM3kU=
 github.com/hemilabs/websocket v0.0.0-20240620132401-b5109a38f904/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=
 github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o=
@@ -218,7 +211,6 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -297,7 +289,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -347,7 +338,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/containerd/containerd v1.7.13 h1:wPYKIeGMN8vaggSKuV1X0wZulpMz4CrgEsZdaCyB6Is=
@@ -62,6 +63,10 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeC
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
+github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
+github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v25.0.5+incompatible h1:UmQydMduGkrD5nQde1mecF/YnSbTOaPeFIeP5C4W+DE=
@@ -70,6 +75,7 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ethereum/go-ethereum v1.13.5 h1:U6TCRciCqZRe4FPXmy1sMGxTfuk8P7u2UoinF3VbaFk=
@@ -92,6 +98,9 @@ github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
+github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -209,6 +218,7 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -287,6 +297,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -336,6 +347,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/service/tbc/peer_manager.go
+++ b/service/tbc/peer_manager.go
@@ -111,13 +111,13 @@ func (pm *PeerManager) PeersRandom(count int) ([]string, error) {
 	log.Tracef("PeersRandom")
 
 	i := 0
-	peers := make([]string, count)
+	peers := make([]string, 0, count)
 
 	pm.peersMtx.RLock()
 	allGoodPeers := len(pm.peersGood)
 	allBadPeers := len(pm.peersBad)
 	for k := range pm.peersGood {
-		peers[i] = k
+		peers = append(peers, k)
 		i++
 		if i >= count {
 			break

--- a/service/tbc/peer_manager.go
+++ b/service/tbc/peer_manager.go
@@ -34,8 +34,8 @@ func (pm *PeerManager) Stats() (int, int) {
 	log.Tracef("PeersStats")
 	defer log.Tracef("PeersStats exit")
 
-	pm.peersMtx.Lock()
-	defer pm.peersMtx.Unlock()
+	pm.peersMtx.RLock()
+	defer pm.peersMtx.RUnlock()
 	return len(pm.peersGood), len(pm.peersBad)
 }
 
@@ -113,7 +113,7 @@ func (pm *PeerManager) PeersRandom(count int) ([]string, error) {
 	i := 0
 	peers := make([]string, count)
 
-	pm.peersMtx.Lock()
+	pm.peersMtx.RLock()
 	allGoodPeers := len(pm.peersGood)
 	allBadPeers := len(pm.peersBad)
 	for k := range pm.peersGood {
@@ -123,7 +123,7 @@ func (pm *PeerManager) PeersRandom(count int) ([]string, error) {
 			break
 		}
 	}
-	pm.peersMtx.Unlock()
+	pm.peersMtx.RUnlock()
 
 	log.Debugf("PeersRandom exit %v (good %v bad %v)", len(peers),
 		allGoodPeers, allBadPeers)

--- a/service/tbc/peer_manager.go
+++ b/service/tbc/peer_manager.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2024 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package tbc
+
+import (
+	"net"
+	"sync"
+)
+
+const (
+	maxPeersGood = 1 << 13
+	maxPeersBad  = 1 << 13
+)
+
+// PeerManager keeps track of the available peers and their quality.
+type PeerManager struct {
+	peersMtx  sync.RWMutex
+	peersGood map[string]struct{}
+	peersBad  map[string]struct{}
+}
+
+// newPeerManager returns a new peer manager.
+func newPeerManager() *PeerManager {
+	return &PeerManager{
+		peersGood: make(map[string]struct{}, maxPeersGood),
+		peersBad:  make(map[string]struct{}, maxPeersBad),
+	}
+}
+
+// Stats returns peer statistics.
+func (pm *PeerManager) Stats() (int, int) {
+	log.Tracef("PeersStats")
+	defer log.Tracef("PeersStats exit")
+
+	pm.peersMtx.Lock()
+	defer pm.peersMtx.Unlock()
+	return len(pm.peersGood), len(pm.peersBad)
+}
+
+// PeersInsert adds known peers.
+func (pm *PeerManager) PeersInsert(peers []string) error {
+	log.Tracef("PeersInsert")
+	defer log.Tracef("PeersInsert exit")
+
+	pm.peersMtx.Lock()
+	for _, addr := range peers {
+		if _, ok := pm.peersBad[addr]; ok {
+			// Skip bad peers.
+			continue
+		}
+		if _, ok := pm.peersGood[addr]; ok {
+			// Already inserted.
+			continue
+		}
+
+		pm.peersGood[addr] = struct{}{}
+	}
+	allGoodPeers := len(pm.peersGood)
+	allBadPeers := len(pm.peersBad)
+	pm.peersMtx.Unlock()
+
+	log.Debugf("PeersInsert exit %v good %v bad %v",
+		len(peers), allGoodPeers, allBadPeers)
+
+	return nil
+}
+
+// PeerDelete marks the peer as bad.
+func (pm *PeerManager) PeerDelete(host, port string) error {
+	log.Tracef("PeerDelete")
+	defer log.Tracef("PeerDelete exit")
+
+	a := net.JoinHostPort(host, port)
+	if len(a) < 7 {
+		// 0.0.0.0
+		return nil
+	}
+
+	pm.peersMtx.Lock()
+	if _, ok := pm.peersGood[a]; ok {
+		// Mark peer as bad.
+		delete(pm.peersGood, a)
+		pm.peersBad[a] = struct{}{}
+	}
+
+	// Crude hammer to reset good/bad state of peers
+	if len(pm.peersGood) < minPeersRequired {
+		// Kill all peers to force caller to reseed. This happens when
+		// network is down for a while and all peers are moved into
+		// bad map.
+		clear(pm.peersGood)
+		clear(pm.peersBad)
+		pm.peersGood = make(map[string]struct{}, 8192)
+		pm.peersBad = make(map[string]struct{}, 8192)
+		log.Debugf("peer cache purged")
+	}
+
+	allGoodPeers := len(pm.peersGood)
+	allBadPeers := len(pm.peersBad)
+
+	pm.peersMtx.Unlock()
+
+	log.Debugf("PeerDelete exit good %v bad %v", allGoodPeers, allBadPeers)
+
+	return nil
+}
+
+func (pm *PeerManager) PeersRandom(count int) ([]string, error) {
+	log.Tracef("PeersRandom")
+
+	i := 0
+	peers := make([]string, count)
+
+	pm.peersMtx.Lock()
+	allGoodPeers := len(pm.peersGood)
+	allBadPeers := len(pm.peersBad)
+	for k := range pm.peersGood {
+		peers[i] = k
+		i++
+		if i >= count {
+			break
+		}
+	}
+	pm.peersMtx.Unlock()
+
+	log.Debugf("PeersRandom exit %v (good %v bad %v)", len(peers),
+		allGoodPeers, allBadPeers)
+
+	return peers, nil
+}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -202,7 +202,7 @@ type Server struct {
 	// reentrancy flags for the indexers
 	// utxoIndexerRunning bool
 	// txIndexerRunning   bool
-	quiesced bool // when set do not accept blockheaders and ot blocks.
+	quiesced bool // when set do not accept blockheaders and/or blocks.
 	// clipped  bool // XXX kill including all surrounding code, this is for test only
 	indexing bool // prevent re-entrant indexing
 
@@ -1579,6 +1579,7 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 		// here but the real fix is return an error or add ctx to wire.
 		// This is a workaround. Code prints a bunch of crap during IBD
 		// when shutdown because of this.
+		// XXX make this a function?
 		select {
 		case <-ctx.Done():
 			return

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1573,6 +1573,17 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 	// by one from the last block height seen.
 	bhb, err := s.db.BlockHeaderBest(ctx)
 	if err != nil {
+		// XXX this happens because we shut down and blocks come in.
+		// The context is canceled but wire isn't smart enought so we
+		// make it here. We should not be testing for leveldb errors
+		// here but the real fix is return an error or add ctx to wire.
+		// This is a workaround. Code prints a bunch of crap during IBD
+		// when shutdown because of this.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		panic(err)
 	}
 	bhHash, err := chainhash.NewHash(bhb.Hash)

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -820,7 +820,7 @@ func (s *Server) handleAddr(_ context.Context, p *peer, msg *wire.MsgAddr) {
 	log.Tracef("handleAddr (%v): %v", p, len(msg.AddrList))
 	defer log.Tracef("handleAddr exit (%v)", p)
 
-	peers := make([]string, 0, len(msg.AddrList))
+	peers := make([]string, len(msg.AddrList))
 	for i, a := range msg.AddrList {
 		peers[i] = net.JoinHostPort(a.IP.String(), strconv.Itoa(int(a.Port)))
 	}
@@ -835,13 +835,13 @@ func (s *Server) handleAddrV2(_ context.Context, p *peer, msg *wire.MsgAddrV2) {
 	defer log.Tracef("handleAddrV2 exit (%v)", p)
 
 	peers := make([]string, 0, len(msg.AddrList))
-	for i, a := range msg.AddrList {
+	for _, a := range msg.AddrList {
 		addr := net.JoinHostPort(a.Addr.String(), strconv.Itoa(int(a.Port)))
 		if len(addr) < 7 {
 			// 0.0.0.0
 			continue
 		}
-		peers[i] = addr
+		peers = append(peers, addr)
 	}
 
 	if err := s.pm.PeersInsert(peers); err != nil {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -149,6 +149,8 @@ func sliceChainHash(ch chainhash.Hash) []byte {
 
 type Config struct {
 	AutoIndex               bool
+	BlockCache              int
+	BlockheaderCache        int
 	BlockSanity             bool
 	LevelDBHome             string
 	ListenAddress           string
@@ -1633,7 +1635,10 @@ func (s *Server) DBOpen(ctx context.Context) error {
 
 	// Open db.
 	var err error
-	s.db, err = level.New(ctx, filepath.Join(s.cfg.LevelDBHome, s.cfg.Network))
+	cfg := level.NewConfig(filepath.Join(s.cfg.LevelDBHome, s.cfg.Network))
+	cfg.BlockCache = s.cfg.BlockCache
+	cfg.BlockheaderCache = s.cfg.BlockheaderCache
+	s.db, err = level.New(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("open level database: %w", err)
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -165,10 +165,12 @@ type Config struct {
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		ListenAddress: tbcapi.DefaultListen,
-		LogLevel:      logLevel,
-		MaxCachedTxs:  defaultMaxCachedTxs,
-		PeersWanted:   defaultPeersWanted,
+		ListenAddress:    tbcapi.DefaultListen,
+		BlockCache:       250,
+		BlockheaderCache: 1e6,
+		LogLevel:         logLevel,
+		MaxCachedTxs:     defaultMaxCachedTxs,
+		PeersWanted:      defaultPeersWanted,
 	}
 }
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -883,10 +883,12 @@ func TestFork(t *testing.T) {
 
 	// Connect tbc service
 	cfg := &Config{
-		AutoIndex:     false,
-		BlockSanity:   false,
-		LevelDBHome:   t.TempDir(),
-		ListenAddress: tbcapi.DefaultListen, // TODO: should use random free port
+		AutoIndex:        false,
+		BlockCache:       1000,
+		BlockheaderCache: 1000,
+		BlockSanity:      false,
+		LevelDBHome:      t.TempDir(),
+		ListenAddress:    tbcapi.DefaultListen, // TODO: should use random free port
 		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 		MaxCachedTxs:            1000, // XXX
 		Network:                 networkLocalnet,
@@ -1118,10 +1120,12 @@ func TestIndexNoFork(t *testing.T) {
 
 	// Connect tbc service
 	cfg := &Config{
-		AutoIndex:     false,
-		BlockSanity:   false,
-		LevelDBHome:   t.TempDir(),
-		ListenAddress: tbcapi.DefaultListen,
+		AutoIndex:        false,
+		BlockCache:       1000,
+		BlockheaderCache: 1000,
+		BlockSanity:      false,
+		LevelDBHome:      t.TempDir(),
+		ListenAddress:    tbcapi.DefaultListen,
 		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 		MaxCachedTxs:            1000, // XXX
 		Network:                 networkLocalnet,
@@ -1286,10 +1290,12 @@ func TestIndexFork(t *testing.T) {
 
 	// Connect tbc service
 	cfg := &Config{
-		AutoIndex:     false,
-		BlockSanity:   false,
-		LevelDBHome:   t.TempDir(),
-		ListenAddress: tbcapi.DefaultListen,
+		AutoIndex:        false,
+		BlockCache:       1000,
+		BlockheaderCache: 1000,
+		BlockSanity:      false,
+		LevelDBHome:      t.TempDir(),
+		ListenAddress:    tbcapi.DefaultListen,
 		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 		MaxCachedTxs:            1000, // XXX
 		Network:                 networkLocalnet,


### PR DESCRIPTION
**Summary**
Unwinding a chain is quite expensive when measured in block and header lookups. Often repeating the same process. This creates a cache for both. Note that the header cache is only primed during reads; this is deliberate because the cost of generating the cache entries is too high in the write path.

It tries to keep the block cache at 1GB and the header cache at 100MB.

**Changes**
<!-- A list of changes made by this pull request. -->
