### PR TITLE
Move various arrays and byte slices to use pointers to chainhash.

### DIFF
--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -6,7 +6,6 @@ package main // XXX wrap in structure
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -32,6 +31,7 @@ import (
 	"github.com/hemilabs/heminetwork/cmd/btctool/bdf"
 	"github.com/hemilabs/heminetwork/cmd/btctool/blockstream"
 	"github.com/hemilabs/heminetwork/cmd/btctool/btctool"
+	"github.com/hemilabs/heminetwork/database/tbcd"
 )
 
 var log = loggo.GetLogger("bdf")
@@ -532,14 +532,15 @@ func _main() error {
 		if address == "" {
 			return errors.New("address: must be set")
 		}
-		var (
-			a  btcutil.Address
-			h  []byte
-			sh [32]byte
-		)
-		a, err = addressToScript(address)
-		h, err = txscript.PayToAddrScript(a)
-		sh = sha256.Sum256(h)
+		a, err := addressToScript(address)
+		if err != nil {
+			return err
+		}
+		h, err := txscript.PayToAddrScript(a)
+		if err != nil {
+			return err
+		}
+		sh := tbcd.NewScriptHashFromScript(h)
 		spew.Dump(a)
 		spew.Dump(h)
 		spew.Dump(sh)

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -229,7 +229,7 @@ func tbcdb() error {
 		if err != nil {
 			return fmt.Errorf("chainhash: %w", err)
 		}
-		bh, err := s.DB().BlockHeaderByHash(ctx, ch[:])
+		bh, err := s.DB().BlockHeaderByHash(ctx, ch)
 		if err != nil {
 			return fmt.Errorf("block header by hash: %w", err)
 		}
@@ -241,11 +241,7 @@ func tbcdb() error {
 		if err != nil {
 			return fmt.Errorf("block headers best: %w", err)
 		}
-		hash, err := chainhash.NewHash(bhb.Hash)
-		if err != nil {
-			return fmt.Errorf("block headers best chainhash: %w", err)
-		}
-		fmt.Printf("hash  : %v\n", hash)
+		fmt.Printf("hash  : %v\n", bhb.Hash)
 		fmt.Printf("height: %v\n", bhb.Height)
 
 	case "blockheadersbyheight":
@@ -291,7 +287,7 @@ func tbcdb() error {
 		if err != nil {
 			return fmt.Errorf("chainhash: %w", err)
 		}
-		b, err := s.DB().BlockByHash(ctx, ch[:])
+		b, err := s.DB().BlockByHash(ctx, ch)
 		if err != nil {
 			return fmt.Errorf("block by hash: %w", err)
 		}
@@ -458,10 +454,8 @@ func tbcdb() error {
 		if err != nil {
 			return fmt.Errorf("chainhash: %w", err)
 		}
-		var revTxId [32]byte
-		copy(revTxId[:], chtxid[:])
 
-		bh, err := s.DB().BlocksByTxId(ctx, revTxId[:])
+		bh, err := s.DB().BlocksByTxId(ctx, chtxid)
 		if err != nil {
 			return fmt.Errorf("block by txid: %w", err)
 		}

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -7,8 +7,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -533,13 +531,12 @@ func tbcdb() error {
 			return errors.New("hash or address: both set")
 		}
 
-		var hh [32]byte
+		var sh tbcd.ScriptHash
 		if hash != "" {
-			h, err := hex.DecodeString(hash)
+			sh, err = tbcd.NewScriptHashFromString(hash)
 			if err != nil {
-				return fmt.Errorf("decode hex: %w", err)
+				return fmt.Errorf("new scripthash from string: %w", err)
 			}
-			copy(hh[:], h)
 		}
 		if address != "" {
 			// XXX set params
@@ -551,11 +548,10 @@ func tbcdb() error {
 			if err != nil {
 				return err
 			}
-			sh := sha256.Sum256(h)
-			copy(hh[:], sh[:])
+			sh = tbcd.NewScriptHashFromScript(h)
 		}
 
-		balance, err := s.DB().BalanceByScriptHash(ctx, hh)
+		balance, err := s.DB().BalanceByScriptHash(ctx, sh)
 		if err != nil {
 			return fmt.Errorf("block by hash: %w", err)
 		}
@@ -591,13 +587,12 @@ func tbcdb() error {
 			return err
 		}
 
-		var hh [32]byte
+		var sh tbcd.ScriptHash
 		if hash != "" {
-			h, err := hex.DecodeString(hash)
+			sh, err = tbcd.NewScriptHashFromString(hash)
 			if err != nil {
-				return fmt.Errorf("decode hex: %w", err)
+				return err
 			}
-			copy(hh[:], h)
 		}
 		if address != "" {
 			// XXX set params
@@ -609,11 +604,10 @@ func tbcdb() error {
 			if err != nil {
 				return err
 			}
-			sh := sha256.Sum256(h)
-			copy(hh[:], sh[:])
+			sh = tbcd.NewScriptHashFromScript(h)
 		}
 
-		utxos, err := s.DB().UtxosByScriptHash(ctx, hh, startNum, countNum)
+		utxos, err := s.DB().UtxosByScriptHash(ctx, sh, startNum, countNum)
 		if err != nil {
 			return fmt.Errorf("block by hash: %w", err)
 		}

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 
@@ -60,10 +61,10 @@ type Database interface {
 
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)
-	BlockInsert(ctx context.Context, b *Block) (int64, error)
+	BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error)
 	// XXX replace BlockInsert with plural version
 	// BlocksInsert(ctx context.Context, bs []*Block) (int64, error)
-	BlockByHash(ctx context.Context, hash *chainhash.Hash) (*Block, error)
+	BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error)
 
 	// Transactions
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput) error
@@ -124,12 +125,6 @@ func (bh BlockHeader) ParentHash() *chainhash.Hash {
 		panic(err)
 	}
 	return &wh.PrevBlock
-}
-
-// Block contains a raw bitcoin block and its corresponding hash.
-type Block struct {
-	Hash  *chainhash.Hash
-	Block database.ByteArray // this needs to be converted to either wire or btcutil
 }
 
 // BlockIdentifier uniquely identifies a block using it's hash and height.

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -290,7 +290,7 @@ func NewUtxo(hash [32]byte, value uint64, outIndex uint32) (u Utxo) {
 	return
 }
 
-// ScriptHash is a sha256 that has a stringer.
+// ScriptHash is a SHA256 hash that implements fmt.Stringer.
 type ScriptHash [sha256.Size]byte
 
 func (sh ScriptHash) String() string {

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -88,7 +88,7 @@ type Database interface {
 type BlockHeader struct {
 	Hash       *chainhash.Hash
 	Height     uint64
-	Header     database.ByteArray
+	Header     [80]byte
 	Difficulty big.Int
 }
 
@@ -98,7 +98,7 @@ func (bh BlockHeader) String() string {
 
 func (bh BlockHeader) Timestamp() time.Time {
 	var wbh wire.BlockHeader
-	err := wbh.Deserialize(bytes.NewReader(bh.Header))
+	err := wbh.Deserialize(bytes.NewReader(bh.Header[:]))
 	if err != nil {
 		return time.Time{}
 	}
@@ -107,7 +107,7 @@ func (bh BlockHeader) Timestamp() time.Time {
 
 func (bh BlockHeader) Wire() (*wire.BlockHeader, error) {
 	var wbh wire.BlockHeader
-	err := wbh.Deserialize(bytes.NewReader(bh.Header))
+	err := wbh.Deserialize(bytes.NewReader(bh.Header[:]))
 	if err != nil {
 		return nil, fmt.Errorf("deserialize: %w", err)
 	}

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -296,16 +296,12 @@ func encodeBlockHeader(height uint64, header [80]byte, difficulty *big.Int) (ebh
 // decodeBlockHeader reverse the process of encodeBlockHeader.
 // XXX should we have a function that does not call the expensive headerHash function?
 func decodeBlockHeader(ebh []byte) *tbcd.BlockHeader {
-	// copy the values to prevent slicing reentrancy problems.
-	var (
-		header [80]byte
-	)
-	copy(header[:], ebh[8:88])
 	bh := &tbcd.BlockHeader{
-		Hash:   tbcd.HeaderHash(header[:]),
+		Hash:   tbcd.HeaderHash(ebh[8:88]),
 		Height: binary.BigEndian.Uint64(ebh[0:8]),
-		Header: header[:],
 	}
+	// copy the values to prevent slicing reentrancy problems.
+	copy(bh.Header[:], ebh[8:88])
 	(&bh.Difficulty).SetBytes(ebh[88:])
 	return bh
 }
@@ -537,14 +533,12 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs [][80]byte) (tbcd.Inse
 		lastRecord = ebh[:]
 	}
 
-	var header [80]byte
-	copy(header[:], bhs[len(bhs)-1][:])
 	cbh := &tbcd.BlockHeader{
 		Hash:       &bhash,
 		Height:     height,
-		Header:     header[:],
 		Difficulty: *cdiff,
 	}
+	copy(cbh.Header[:], bhs[len(bhs)-1][:])
 	lbh := cbh
 
 	// XXX: Reason about needing to check fork flag. For now keep it here to

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -63,7 +63,7 @@ type ldb struct {
 	*level.Database
 	pool level.Pool
 
-	blockCache *lru.Cache[string, *tbcd.Block] // block cache
+	blockCache *lru.Cache[string, *btcutil.Block] // block cache
 
 	// Block Header cache. Note that it is only primed during reads. Doing
 	// this during writes would be relatively expensive at nearly no gain.
@@ -104,7 +104,7 @@ func New(ctx context.Context, cfg *Config) (*ldb, error) {
 	}
 
 	if cfg.BlockCache > 0 {
-		l.blockCache, err = lru.New[string, *tbcd.Block](cfg.BlockCache)
+		l.blockCache, err = lru.New[string, *btcutil.Block](cfg.BlockCache)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't setup block cache: %w", err)
 		}
@@ -675,7 +675,7 @@ func (l *ldb) BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error) 
 			return -1, fmt.Errorf("blocks insert put: %w", err)
 		}
 		if l.cfg.BlockCache > 0 {
-			l.blockCache.Add(string(b.Hash[:]), b)
+			l.blockCache.Add(string(b.Hash()[:]), b)
 		}
 	}
 

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -163,13 +163,9 @@ func (s *Server) scriptValue(ctx context.Context, op tbcd.Outpoint) ([]byte, int
 	if len(blockHashes) == 0 {
 		return nil, 0, errors.New("script value: no block hashes")
 	}
-	blk, err := s.db.BlockByHash(ctx, blockHashes[0])
+	b, err := s.db.BlockByHash(ctx, blockHashes[0])
 	if err != nil {
 		return nil, 0, fmt.Errorf("block by hash: %w", err)
-	}
-	b, err := btcutil.NewBlockFromBytes(blk.Block)
-	if err != nil {
-		return nil, 0, fmt.Errorf("new block: %w", err)
 	}
 	for _, tx := range b.Transactions() {
 		if !tx.Hash().IsEqual(txId) {
@@ -316,13 +312,9 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 		}
 
 		// Index block
-		eb, err := s.db.BlockByHash(ctx, bh.Hash)
+		b, err := s.db.BlockByHash(ctx, bh.Hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block by hash %v: %w", bh, err)
-		}
-		b, err := btcutil.NewBlockFromBytes(eb.Block)
-		if err != nil {
-			return 0, last, fmt.Errorf("could not decode block %v: %w", hh, err)
 		}
 
 		// fixupCache is executed in parallel meaning that the utxos
@@ -430,13 +422,9 @@ func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Ha
 		}
 
 		// Index block
-		eb, err := s.db.BlockByHash(ctx, bh.Hash)
+		b, err := s.db.BlockByHash(ctx, bh.Hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block by hash %v: %w", bh, err)
-		}
-		b, err := btcutil.NewBlockFromBytes(eb.Block)
-		if err != nil {
-			return 0, last, fmt.Errorf("could not decode block %v: %w", hh, err)
 		}
 
 		err = s.unprocessUtxos(ctx, b.Transactions(), utxos)
@@ -691,13 +679,9 @@ func (s *Server) indexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, 
 		}
 
 		// Index block
-		eb, err := s.db.BlockByHash(ctx, bh.Hash)
+		b, err := s.db.BlockByHash(ctx, bh.Hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block by hash %v: %w", bh, err)
-		}
-		b, err := btcutil.NewBlockFromBytes(eb.Block)
-		if err != nil {
-			return 0, last, fmt.Errorf("could not decode block %v: %w", hh, err)
 		}
 
 		err = processTxs(b.Hash(), b.Transactions(), txs)
@@ -797,13 +781,9 @@ func (s *Server) unindexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash
 		}
 
 		// Index block
-		eb, err := s.db.BlockByHash(ctx, bh.Hash)
+		b, err := s.db.BlockByHash(ctx, bh.Hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block by hash %v: %w", bh, err)
-		}
-		b, err := btcutil.NewBlockFromBytes(eb.Block)
-		if err != nil {
-			return 0, last, fmt.Errorf("could not decode block %v: %w", hh, err)
 		}
 
 		err = processTxs(b.Hash(), b.Transactions(), txs)

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1140,7 +1140,9 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 		// XXX if bh download fails we will get jammed. We need a queued "must execute this command" added to peer/service.
 		// XXX we may not want to do this when in special "driver mode"
 		log.Infof("resuming block header download at: %v", actualHeight)
-		if err = s.getHeaders(ctx, p, bhb); err != nil {
+		var bh [80]byte
+		copy(bh[:], bhb)
+		if err = s.getHeaders(ctx, p, bh); err != nil {
 			log.Errorf("sync indexers: %v", err)
 			return
 		}

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -6,7 +6,6 @@ package tbc
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"runtime"
@@ -140,7 +139,7 @@ func processUtxos(txs []*btcutil.Tx, utxos map[tbcd.Outpoint]tbcd.CacheOutput) e
 				continue
 			}
 			utxos[tbcd.NewOutpoint(*tx.Hash(), uint32(outIndex))] = tbcd.NewCacheOutput(
-				sha256.Sum256(txOut.PkScript),
+				tbcd.NewScriptHashFromScript(txOut.PkScript),
 				uint64(txOut.Value),
 				uint32(outIndex))
 		}
@@ -210,7 +209,7 @@ func (s *Server) unprocessUtxos(ctx context.Context, txs []*btcutil.Tx, utxos ma
 			if _, ok := utxos[op]; ok {
 				return fmt.Errorf("impossible collision: %v", op)
 			}
-			utxos[op] = tbcd.NewCacheOutput(sha256.Sum256(pkScript),
+			utxos[op] = tbcd.NewCacheOutput(tbcd.NewScriptHashFromScript(pkScript),
 				uint64(value), txIn.PreviousOutPoint.Index)
 		}
 
@@ -226,7 +225,7 @@ func (s *Server) unprocessUtxos(ctx context.Context, txs []*btcutil.Tx, utxos ma
 			if _, ok := utxos[op]; ok {
 				delete(utxos, op)
 			} else {
-				utxos[op] = tbcd.NewDeleteCacheOutput(sha256.Sum256(txOut.PkScript),
+				utxos[op] = tbcd.NewDeleteCacheOutput(tbcd.NewScriptHashFromScript(txOut.PkScript),
 					op.TxIndex())
 			}
 		}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1279,6 +1279,8 @@ func TestTxById(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	slices.Reverse(txIdBytes)
+
 	ctxid, err := chainhash.NewHash(txIdBytes)
 	if err != nil {
 		t.Fatal(err)

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/davecgh/go-spew/spew"
@@ -26,7 +27,6 @@ import (
 	"github.com/hemilabs/heminetwork/api/protocol"
 	"github.com/hemilabs/heminetwork/api/tbcapi"
 	"github.com/hemilabs/heminetwork/bitcoin"
-	"github.com/hemilabs/heminetwork/database/tbcd"
 )
 
 func TestBlockHeadersByHeightRaw(t *testing.T) {
@@ -1279,10 +1279,12 @@ func TestTxById(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	revTxId := tbcd.TxId(reverseBytes(txIdBytes))
-
+	ctxid, err := chainhash.NewHash(txIdBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxId: revTxId[:],
+		TxId: ctxid[:],
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1304,7 +1306,7 @@ func TestTxById(t *testing.T) {
 		t.Fatal(response.Error.Message)
 	}
 
-	tx, err := tbcServer.TxById(ctx, revTxId.Hash())
+	tx, err := tbcServer.TxById(ctx, ctxid)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -81,7 +81,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bh, err := bytes2Header(response.BlockHeaders[0])
+	bh, err := slice2Header(response.BlockHeaders[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +271,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bh, err := bytes2Header(response.BlockHeader)
+	bh, err := slice2Header(response.BlockHeader)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -130,9 +130,18 @@ func h2b(wbh *wire.BlockHeader) []byte {
 	return hb
 }
 
-func bytes2Header(header []byte) (*wire.BlockHeader, error) {
+func bytes2Header(header [80]byte) (*wire.BlockHeader, error) {
 	var bh wire.BlockHeader
-	err := bh.Deserialize(bytes.NewReader(header))
+	err := bh.Deserialize(bytes.NewReader(header[:]))
+	if err != nil {
+		return nil, fmt.Errorf("deserialize block header: %w", err)
+	}
+	return &bh, nil
+}
+
+func slice2Header(header []byte) (*wire.BlockHeader, error) {
+	var bh wire.BlockHeader
+	err := bh.Deserialize(bytes.NewReader(header[:]))
 	if err != nil {
 		return nil, fmt.Errorf("deserialize block header: %w", err)
 	}
@@ -278,7 +287,7 @@ func (s *Server) DB() tbcd.Database {
 	return s.db
 }
 
-func (s *Server) getHeaders(ctx context.Context, p *peer, lastHeaderHash []byte) error {
+func (s *Server) getHeaders(ctx context.Context, p *peer, lastHeaderHash [80]byte) error {
 	bh, err := bytes2Header(lastHeaderHash)
 	if err != nil {
 		return fmt.Errorf("invalid header: %w", err)
@@ -1319,7 +1328,7 @@ func (s *Server) RawBlockHeadersByHeight(ctx context.Context, height uint64) ([]
 
 	var headers []api.ByteSlice
 	for _, bh := range bhs {
-		headers = append(headers, []byte(bh.Header))
+		headers = append(headers, []byte(bh.Header[:]))
 	}
 
 	return headers, nil

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1138,18 +1138,14 @@ func (s *Server) handleBlock(ctx context.Context, p *peer, msg *wire.MsgBlock) {
 
 	block := btcutil.NewBlock(msg)
 	bhs := block.Hash().String()
-	bb, err := block.Bytes() // XXX we should not being doing this twice but requires a modification to the wire package
+	rawBlock, err := block.Bytes()
 	if err != nil {
-		log.Errorf("block bytes %v: %v", block.Hash(), err)
+		log.Errorf("Unable to get raw block %v: %v", bhs, err)
 		return
-	}
-	b := &tbcd.Block{
-		Hash:  block.Hash(),
-		Block: bb,
 	}
 
 	if s.cfg.BlockSanity {
-		err = blockchain.CheckBlockSanity(block, s.chainParams.PowLimit,
+		err := blockchain.CheckBlockSanity(block, s.chainParams.PowLimit,
 			s.timeSource)
 		if err != nil {
 			log.Errorf("Unable to validate block hash %v: %v", bhs, err)
@@ -1171,7 +1167,7 @@ func (s *Server) handleBlock(ctx context.Context, p *peer, msg *wire.MsgBlock) {
 		// }
 	}
 
-	height, err := s.db.BlockInsert(ctx, b)
+	height, err := s.db.BlockInsert(ctx, block)
 	if err != nil {
 		log.Errorf("block insert %v: %v", bhs, err)
 	} else {
@@ -1204,7 +1200,7 @@ func (s *Server) handleBlock(ctx context.Context, p *peer, msg *wire.MsgBlock) {
 
 	// Stats
 	if err == nil {
-		s.blocksSize += uint64(len(b.Block) + len(b.Hash))
+		s.blocksSize += uint64(len(rawBlock) + 32)
 		if _, ok := s.blocksInserted[bhs]; ok {
 			s.blocksDuplicate++
 		} else {
@@ -1273,14 +1269,7 @@ func (s *Server) insertGenesis(ctx context.Context) error {
 	}
 
 	log.Debugf("Inserting genesis block")
-	gb, err := btcutil.NewBlock(s.chainParams.GenesisBlock).Bytes()
-	if err != nil {
-		return fmt.Errorf("genesis block encode: %w", err)
-	}
-	_, err = s.db.BlockInsert(ctx, &tbcd.Block{
-		Hash:  s.chainParams.GenesisHash,
-		Block: gb,
-	})
+	_, err = s.db.BlockInsert(ctx, btcutil.NewBlock(s.chainParams.GenesisBlock))
 	if err != nil {
 		return fmt.Errorf("genesis block insert: %w", err)
 	}
@@ -1474,13 +1463,7 @@ func (s *Server) TxById(ctx context.Context, txId *chainhash.Hash) (*wire.MsgTx,
 		if err != nil {
 			return nil, err
 		}
-
-		parsedBlock, err := btcutil.NewBlockFromBytes(block.Block)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, tx := range parsedBlock.Transactions() {
+		for _, tx := range block.Transactions() {
 			if tx.Hash().IsEqual(txId) {
 				return tx.MsgTx(), nil
 			}
@@ -1528,14 +1511,9 @@ func (s *Server) FeesAtHeight(ctx context.Context, height, count int64) (uint64,
 			panic("fees at height: unsupported fork")
 			// return 0, fmt.Errorf("too many block headers: %v", len(bhs))
 		}
-		be, err := s.db.BlockByHash(ctx, bhs[0].Hash)
+		b, err := s.db.BlockByHash(ctx, bhs[0].Hash)
 		if err != nil {
 			return 0, fmt.Errorf("block by hash: %w", err)
-		}
-		b, err := btcutil.NewBlockFromBytes(be.Block)
-		if err != nil {
-			return 0, fmt.Errorf("could not decode block %v %v: %v",
-				height, bhs[0].Hash, err)
 		}
 
 		// walk block tx'
@@ -1553,9 +1531,6 @@ type SyncInfo struct {
 	BlockHeader HashHeight
 	Utxo        HashHeight
 	Tx          HashHeight
-	// BlockHeaderHeight uint64 // last block header height
-	// UtxoHeight        uint64 // last indexed utxo block height
-	// TxHeight          uint64 // last indexed tx block height
 }
 
 func (s *Server) synced(ctx context.Context) (si SyncInfo) {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -7,7 +7,6 @@ package tbc
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math/big"
@@ -1398,7 +1397,8 @@ func (s *Server) BalanceByAddress(ctx context.Context, encodedAddress string) (u
 		return 0, err
 	}
 
-	balance, err := s.db.BalanceByScriptHash(ctx, sha256.Sum256(script))
+	balance, err := s.db.BalanceByScriptHash(ctx,
+		tbcd.NewScriptHashFromScript(script))
 	if err != nil {
 		return 0, err
 	}
@@ -1419,10 +1419,8 @@ func (s *Server) UtxosByAddress(ctx context.Context, encodedAddress string, star
 	if err != nil {
 		return nil, err
 	}
-
-	scriptHash := sha256.Sum256(script)
-
-	utxos, err := s.db.UtxosByScriptHash(ctx, scriptHash, start, count)
+	utxos, err := s.db.UtxosByScriptHash(ctx, tbcd.NewScriptHashFromScript(script),
+		start, count)
 	if err != nil {
 		return nil, err
 	}

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -67,7 +67,7 @@ func TestBlockHeaderEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	wbh, err := bytes2Header(sh)
+	wbh, err := slice2Header(sh)
 	if err != nil {
 		t.Error(err)
 	}
@@ -79,7 +79,7 @@ func TestBlockHeaderEncodeDecode(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	awbh, err := bytes2Header(ash[:])
+	awbh, err := slice2Header(ash[:])
 	if err != nil {
 		t.Errorf("bytes2Header failed: %v", err)
 	}

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -825,12 +825,12 @@ func mustHave(ctx context.Context, s *Server, blocks ...*block) error {
 				if err != nil {
 					return fmt.Errorf("invalid tx key: %w", err)
 				}
-				_, err = s.TxById(ctx, txId.Hash())
+				_, err = s.TxById(ctx, txId)
 				if err != nil {
 					return fmt.Errorf("tx by id: %w", err)
 				}
 				// db block retrieval tested by TxById
-				if !b.Hash().IsEqual(blockHash.Hash()) {
+				if !b.Hash().IsEqual(blockHash) {
 					return errors.New("t cache block hash invalid")
 				}
 			default:


### PR DESCRIPTION
**Summary**
We are doing all kinds of gymnastics to convert to and from arrays, byte slices and chainhash. Promote chainhash to a main type and propagate it through the stack. This vastly simplifies the code and makes it more readable. This will unfortunately break a bunch of callers but they'll have to cop.

**Changes**
<!-- A list of changes made by this pull request. -->
