### PR TITLE
electrumx: improve closing and fix close panic

### DIFF
--- a/hemi/electrumx/conn.go
+++ b/hemi/electrumx/conn.go
@@ -186,13 +186,14 @@ func (c *clientConn) Close() error {
 	if c.onClose != nil {
 		c.onClose(c)
 	}
-	if c.closeCh != nil {
-		close(c.closeCh)
-		c.closeCh = nil
-	}
 
 	if err := c.conn.Close(); err != nil {
 		return err
+	}
+
+	if c.closeCh != nil {
+		close(c.closeCh)
+		c.closeCh = nil
 	}
 
 	// Wait for pinger to exit.

--- a/hemi/electrumx/conn.go
+++ b/hemi/electrumx/conn.go
@@ -193,10 +193,10 @@ func (c *clientConn) Close() error {
 
 	if c.closeCh != nil {
 		close(c.closeCh)
-		c.closeCh = nil
 	}
 
 	// Wait for pinger to exit.
 	c.wg.Wait()
+	c.closeCh = nil
 	return nil
 }

--- a/hemi/electrumx/conn.go
+++ b/hemi/electrumx/conn.go
@@ -181,6 +181,9 @@ func (c *clientConn) Close() error {
 	if c.onClose != nil {
 		c.onClose(c)
 	}
-	close(c.closeCh)
+	if c.closeCh != nil {
+		close(c.closeCh)
+		c.closeCh = nil
+	}
 	return c.conn.Close()
 }


### PR DESCRIPTION
**Summary**
Fix a panic in the ElectrumX client caused by attempting to close the `closeCh` channel twice.
This happened when the `pinger` goroutine attempted to close the connect when the connection had already been closed.

Additionally, add a wait group to the ElectrumX connection struct that is used to wait for the pinger goroutine to exit before returning in the `Close` function, making sure that we don't leak the goroutine and everything gets properly shutdown.

Fixes #191

**Changes**
- Fix `closeCh` channel being closed more than once.
- Add wait group to `clientConn` that is used to wait for the `pinger` goroutine to exit in the `Close` function.
- Close the `closeCh` channel after the underlying connection has been closed.
- Add test for closing `clientConn`s.
