### PR TITLE
bss: increase read limit for bfg conn to 2 MiB

### DIFF
--- a/api/auth/secp256k1_test.go
+++ b/api/auth/secp256k1_test.go
@@ -151,7 +151,9 @@ func TestProtocolHandshake(t *testing.T) {
 	}
 
 	clientURI := testServer.URL
-	conn, err := protocol.NewConn(clientURI, clientAuth)
+	conn, err := protocol.NewConn(clientURI, &protocol.ConnOptions{
+		Authenticator: clientAuth,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -629,7 +629,9 @@ func (s *Server) connectBFG(ctx context.Context) error {
 	log.Tracef("connectBFG")
 	defer log.Tracef("connectBFG exit")
 
-	conn, err := protocol.NewConn(s.cfg.BFGURL, nil)
+	conn, err := protocol.NewConn(s.cfg.BFGURL, &protocol.ConnOptions{
+		ReadLimit: 2 * (1 << 20), // 2 MiB
+	})
 	if err != nil {
 		return err
 	}

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -808,7 +808,9 @@ func (m *Miner) connectBFG(pctx context.Context) error {
 		return err
 	}
 
-	conn, err = protocol.NewConn(m.cfg.BFGWSURL, authenticator)
+	conn, err = protocol.NewConn(m.cfg.BFGWSURL, &protocol.ConnOptions{
+		Authenticator: authenticator,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Summary**
Increase the read limit in BSS for the BFG connection to 2 MiB (previously 512 KiB).

When there is a lot of active PoP Miners broadcasting transactions, the `pop-txs-for-l2-block` response from BFG becomes too large for BSS to read. This increases the read limit to temporarily avoid this problem.

Related to: https://github.com/hemilabs/heminetwork/issues/193

**Changes**
 - Add `protocol.ConnOptions` which can be used to provide options when creating a `protocol.Conn`.
 - Increase the BSS -> BFG connection read limit to 2 MiB (previously 512 KiB).
