### PR TITLE
bfg,bss: add pagination to PoP txs and payouts

### DIFF
--- a/api/bfgapi/bfgapi.go
+++ b/api/bfgapi/bfgapi.go
@@ -131,6 +131,7 @@ type BitcoinUTXOsResponse struct {
 
 type PopTxsForL2BlockRequest struct {
 	L2Block api.ByteSlice `json:"l2_block"`
+	Page    uint32        `json:"page,omitempty"`
 }
 
 type PopTxsForL2BlockResponse struct {

--- a/api/bssapi/bssapi.go
+++ b/api/bssapi/bssapi.go
@@ -37,6 +37,7 @@ type PopPayout struct {
 
 type PopPayoutsRequest struct {
 	L2BlockForPayout api.ByteSlice `json:"l2_block_for_payout"`
+	Page             uint32        `json:"page,omitempty"`
 
 	// these are unused at this point, they will be used in the future to determine the
 	// total payout to miners

--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -28,7 +28,7 @@ type Database interface {
 	BtcBlocksHeightsWithNoChildren(ctx context.Context) ([]uint64, error)
 
 	// Pop data
-	PopBasisByL2KeystoneAbrevHash(ctx context.Context, aHash [32]byte, excludeUnconfirmed bool) ([]PopBasis, error)
+	PopBasisByL2KeystoneAbrevHash(ctx context.Context, aHash [32]byte, excludeUnconfirmed bool, page uint32) ([]PopBasis, error)
 	PopBasisInsertFull(ctx context.Context, pb *PopBasis) error
 	PopBasisInsertPopMFields(ctx context.Context, pb *PopBasis) error
 	PopBasisUpdateBTCFields(ctx context.Context, pb *PopBasis) (int64, error)

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -274,7 +274,7 @@ func TestDatabasePostgres(t *testing.T) {
 	}
 
 	// Pop basis get half
-	pbHalfOut, err := db.PopBasisByL2KeystoneAbrevHash(ctx, l2KAH, true)
+	pbHalfOut, err := db.PopBasisByL2KeystoneAbrevHash(ctx, l2KAH, true, 0)
 	if err != nil {
 		t.Fatalf("Failed to get pop basis: %v", err)
 	}
@@ -981,6 +981,7 @@ func TestPopBasisInsertNilMerklePath(t *testing.T) {
 		ctx,
 		[32]byte(fillOutBytes("l2keystoneabrevhash", 32)),
 		false,
+		0,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1026,6 +1027,7 @@ func TestPopBasisInsertNotNilMerklePath(t *testing.T) {
 		ctx,
 		[32]byte(fillOutBytes("l2keystoneabrevhash", 32)),
 		false,
+		0,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1070,6 +1072,7 @@ func TestPopBasisInsertNilMerklePathFromPopM(t *testing.T) {
 		ctx,
 		[32]byte(fillOutBytes("l2keystoneabrevhash", 32)),
 		false,
+		0,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1195,6 +1198,7 @@ func TestPopBasisUpdateOneExistsWithNonNullBTCFields(t *testing.T) {
 		ctx,
 		[32]byte(fillOutBytes("l2keystoneabrevhash", 32)),
 		false,
+		0,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1217,6 +1221,7 @@ func TestPopBasisUpdateOneExistsWithNonNullBTCFields(t *testing.T) {
 		ctx,
 		[32]byte(fillOutBytes("l2keystoneabrevhash", 32)),
 		false,
+		0,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1305,6 +1310,7 @@ func TestPopBasisUpdateOneExistsWithNullBTCFields(t *testing.T) {
 		ctx,
 		[32]byte(fillOutBytes("l2keystoneabrevhash", 32)),
 		false,
+		0,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -474,7 +474,7 @@ func (p *pgdb) PopBasisInsertFull(ctx context.Context, pb *bfgd.PopBasis) error 
 
 func (p *pgdb) PopBasisByL2KeystoneAbrevHash(ctx context.Context, aHash [32]byte, excludeUnconfirmed bool, page uint32) ([]bfgd.PopBasis, error) {
 	// can change later as needed
-	var limit uint32 = 100
+	limit := uint32(100)
 
 	// start at page 0
 	offset := limit * page

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2326,7 +2326,6 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 	var txIndex uint64 = 1
 
 	for range 151 {
-
 		privateKey, err := dcrsecp256k1.GeneratePrivateKeyFromRand(rand.Reader)
 		if err != nil {
 			t.Fatal(err)
@@ -2373,9 +2372,8 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 		L2BlockForPayout: serializedL2Keystone[:],
 	}
 
-	if err := bssapi.Write(
-		ctx, bws.conn, "someid", popPayoutsRequest,
-	); err != nil {
+	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -2401,9 +2399,8 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 	}
 
 	popPayoutsRequest.Page = 1
-	if err := bssapi.Write(
-		ctx, bws.conn, "someid", popPayoutsRequest,
-	); err != nil {
+	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -2428,9 +2425,8 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 	}
 
 	popPayoutsRequest.Page = 2
-	if err := bssapi.Write(
-		ctx, bws.conn, "someid", popPayoutsRequest,
-	); err != nil {
+	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2317,8 +2317,7 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 		Height: 99,
 	}
 
-	err := db.BtcBlockInsert(ctx, &btcBlock)
-	if err != nil {
+	if err := db.BtcBlockInsert(ctx, &btcBlock); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2326,12 +2325,13 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 	// we expect result counts like so : 100, 51, 0
 	var txIndex uint64 = 1
 
-	for i := 0; i < 151; i++ {
+	for range 151 {
 
 		privateKey, err := dcrsecp256k1.GeneratePrivateKeyFromRand(rand.Reader)
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		publicKey := privateKey.PubKey()
 		publicKeyUncompressed := publicKey.SerializeUncompressed()
 
@@ -2346,8 +2346,7 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 			BtcTxIndex:          &txIndex,
 		}
 
-		err = db.PopBasisInsertFull(ctx, &popBasis)
-		if err != nil {
+		if err := db.PopBasisInsertFull(ctx, &popBasis); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -2374,14 +2373,14 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 		L2BlockForPayout: serializedL2Keystone[:],
 	}
 
-	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
-	if err != nil {
+	if err := bssapi.Write(
+		ctx, bws.conn, "someid", popPayoutsRequest,
+	); err != nil {
 		t.Fatal(err)
 	}
 
 	var v protocol.Message
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2390,23 +2389,25 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 	}
 
 	popPayoutsResponse := bssapi.PopPayoutsResponse{}
-	err = json.Unmarshal(v.Payload, &popPayoutsResponse)
-	if err != nil {
+	if err := json.Unmarshal(v.Payload, &popPayoutsResponse); err != nil {
 		t.Fatal(err)
 	}
 
 	if len(popPayoutsResponse.PopPayouts) != 100 {
-		t.Fatalf("expected first page to have 100 results, received %d", len(popPayoutsResponse.PopPayouts))
+		t.Fatalf(
+			"expected first page to have 100 results, received %d",
+			len(popPayoutsResponse.PopPayouts),
+		)
 	}
 
 	popPayoutsRequest.Page = 1
-	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
-	if err != nil {
+	if err := bssapi.Write(
+		ctx, bws.conn, "someid", popPayoutsRequest,
+	); err != nil {
 		t.Fatal(err)
 	}
 
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2420,17 +2421,20 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 	}
 
 	if len(popPayoutsResponse.PopPayouts) != 51 {
-		t.Fatalf("expected first page to have 51 results, received %d", len(popPayoutsResponse.PopPayouts))
+		t.Fatalf(
+			"expected first page to have 51 results, received %d",
+			len(popPayoutsResponse.PopPayouts),
+		)
 	}
 
 	popPayoutsRequest.Page = 2
-	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
-	if err != nil {
+	if err := bssapi.Write(
+		ctx, bws.conn, "someid", popPayoutsRequest,
+	); err != nil {
 		t.Fatal(err)
 	}
 
-	err = wsjson.Read(ctx, c, &v)
-	if err != nil {
+	if err := wsjson.Read(ctx, c, &v); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2438,13 +2442,14 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
-	err = json.Unmarshal(v.Payload, &popPayoutsResponse)
-	if err != nil {
+	if err := json.Unmarshal(v.Payload, &popPayoutsResponse); err != nil {
 		t.Fatal(err)
 	}
 
 	if len(popPayoutsResponse.PopPayouts) != 0 {
-		t.Fatalf("expected first page to have 0 results, received %d", len(popPayoutsResponse.PopPayouts))
+		t.Fatalf(
+			"expected first page to have 0 results, received %d",
+			len(popPayoutsResponse.PopPayouts))
 	}
 }
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2370,7 +2370,6 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 
 	serializedL2Keystone := hemi.L2KeystoneAbbreviate(includedL2Keystone).Serialize()
 
-	// 2
 	popPayoutsRequest := bssapi.PopPayoutsRequest{
 		L2BlockForPayout: serializedL2Keystone[:],
 	}

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2368,6 +2368,8 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 
 	serializedL2Keystone := hemi.L2KeystoneAbbreviate(includedL2Keystone).Serialize()
 
+	uniquePopPayouts := map[string]bool{}
+
 	popPayoutsRequest := bssapi.PopPayoutsRequest{
 		L2BlockForPayout: serializedL2Keystone[:],
 	}
@@ -2398,6 +2400,10 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 		)
 	}
 
+	for _, p := range popPayoutsResponse.PopPayouts {
+		uniquePopPayouts[p.MinerAddress.String()] = true
+	}
+
 	popPayoutsRequest.Page = 1
 	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
 	if err != nil {
@@ -2424,6 +2430,10 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 		)
 	}
 
+	for _, p := range popPayoutsResponse.PopPayouts {
+		uniquePopPayouts[p.MinerAddress.String()] = true
+	}
+
 	popPayoutsRequest.Page = 2
 	err = bssapi.Write(ctx, bws.conn, "someid", popPayoutsRequest)
 	if err != nil {
@@ -2446,6 +2456,11 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 		t.Fatalf(
 			"expected first page to have 0 results, received %d",
 			len(popPayoutsResponse.PopPayouts))
+	}
+
+	// ensure there were 151 unique pop payouts using miner address
+	if len(uniquePopPayouts) != 151 {
+		t.Fatalf("unexpected number of pop payouts %d", len(uniquePopPayouts))
 	}
 }
 

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1201,7 +1201,10 @@ func (s *Server) handlePopTxsForL2Block(ctx context.Context, ptl2 *bfgapi.PopTxs
 	hash := hemi.HashSerializedL2KeystoneAbrev(ptl2.L2Block)
 	var h [32]byte
 	copy(h[:], hash)
-	popTxs, err := s.db.PopBasisByL2KeystoneAbrevHash(ctx, h, true)
+
+	response := &bfgapi.PopTxsForL2BlockResponse{}
+
+	popTxs, err := s.db.PopBasisByL2KeystoneAbrevHash(ctx, h, true, ptl2.Page)
 	if err != nil {
 		e := protocol.NewInternalErrorf("error getting pop basis: %w", err)
 		return &bfgapi.PopTxsForL2BlockResponse{
@@ -1209,8 +1212,6 @@ func (s *Server) handlePopTxsForL2Block(ctx context.Context, ptl2 *bfgapi.PopTxs
 		}, e
 	}
 
-	response := &bfgapi.PopTxsForL2BlockResponse{}
-	response.PopTxs = make([]bfgapi.PopTx, 0, len(popTxs))
 	for k := range popTxs {
 		response.PopTxs = append(response.PopTxs, bfgapi.PopTx{
 			BtcTxId:             api.ByteSlice(popTxs[k].BtcTxId),

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -232,6 +232,7 @@ func (s *Server) handlePopPayoutsRequest(ctx context.Context, msg *bssapi.PopPay
 
 	popTxsForL2BlockRes, err := s.callBFG(ctx, bfgapi.PopTxsForL2BlockRequest{
 		L2Block: msg.L2BlockForPayout,
+		Page:    msg.Page,
 	})
 	if err != nil {
 		e := protocol.NewInternalErrorf("pop tx for l2: block %w", err)


### PR DESCRIPTION
**Summary**
allowing pagination of flow bss.popPayouts --> bfg.popTxsForL2Block

**Changes**
added pagination to aforementioned logical path

**IMPORTANT: optimism will need to be updated to include pagination otherwise this will limit request to 100 results**

fixes #195 
