### PR TITLE
popm: change BFG reconnect log to 'info' level

### DIFF
--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -750,10 +750,11 @@ func (m *Miner) handleBFGWebsocketRead(ctx context.Context, conn *protocol.Conn)
 				return ctx.Err()
 			case <-time.After(m.holdoffTimeout):
 			}
-			// XXX this is too noisy
-			log.Errorf("Retrying connecting to BFG")
+
+			log.Infof("Reconnecting to BFG server")
 			continue
 		}
+
 		switch cmd {
 		case bfgapi.CmdPingRequest:
 			p := payload.(*bfgapi.PingRequest)


### PR DESCRIPTION
**Summary**
Reword BFG reconnect log and decrease log level to "info".
This probably should not have been "error" in the first place, as it is more informational, and this was resulting in false bug reports from users.

**Changes**
 - Improve BFG reconnect log in PoP Miner
