### PR TITLE
Add request limit and timeout to bfgd config

### DIFF
--- a/api/bfgapi/bfgapi.go
+++ b/api/bfgapi/bfgapi.go
@@ -56,6 +56,8 @@ var (
 	DefaultPrometheusListen = "localhost:2112"
 	DefaultPrivateURL       = "ws://" + DefaultPrivateListen + "/" + RouteWebsocketPrivate
 	DefaultPublicURL        = "ws://" + DefaultPublicListen + "/" + RouteWebsocketPublic
+	DefaultRequestLimit     = 10000 // XXX this is a bandaid
+	DefaultRequestTimeout   = 9     // XXX PNOOMA
 )
 
 type AccessPublicKey struct {

--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -87,6 +87,18 @@ var (
 			Help:         "address and port bfgd pprof listens on (open <address>/debug/pprof to see available profiles)",
 			Print:        config.PrintAll,
 		},
+		"BFG_REQUEST_LIMIT": config.Config{
+			Value:        &cfg.RequestLimit,
+			DefaultValue: bfgapi.DefaultRequestLimit,
+			Help:         "maximum request queue depth",
+			Print:        config.PrintAll,
+		},
+		"BFG_REQUEST_TIMEOUT": config.Config{
+			Value:        &cfg.RequestTimeout,
+			DefaultValue: bfgapi.DefaultRequestTimeout,
+			Help:         "request timeout in seconds",
+			Print:        config.PrintAll,
+		},
 	}
 )
 


### PR DESCRIPTION
**Summary**
We are seeing a bunch of rate limited "errors" on testnet. This isn't a real issue but add a bandaid to allow setting the rate limit and timeout variables.

**Changes**
<!-- A list of changes made by this pull request. -->
