### PR TITLE
bump bss read limit to 10 mb

### DIFF
--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -630,7 +630,7 @@ func (s *Server) connectBFG(ctx context.Context) error {
 	defer log.Tracef("connectBFG exit")
 
 	conn, err := protocol.NewConn(s.cfg.BFGURL, &protocol.ConnOptions{
-		ReadLimit: 2 * (1 << 20), // 2 MiB
+		ReadLimit: 10 * (1 << 20), // 10 MiB
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
**Summary**
We have a stopgap in bss to increase the `ReadLimit` to handle the large number of pop payouts prior to implementing pagination.  We need to increase that for good measure because we're getting even more than expected.

This should keep us running until #195 gets deployed 

 
**Changes**
Increase `ReadLimit` to 10mb
