### PR TITLE
remove L2KeystonesCount from being a public function

### DIFF
--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -18,7 +18,6 @@ type Database interface {
 
 	// L2 keystone table
 	L2KeystonesInsert(ctx context.Context, l2ks []L2Keystone) error
-	L2KeystonesCount(ctx context.Context) (int, error)
 	L2KeystoneByAbrevHash(ctx context.Context, aHash [32]byte) (*L2Keystone, error)
 	L2KeystonesMostRecentN(ctx context.Context, n uint32) ([]L2Keystone, error)
 

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -397,7 +397,7 @@ func TestL2KeystoneInsertSuccess(t *testing.T) {
 		t.Fatalf("unexpected diff %s", diff)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,7 +465,7 @@ func TestL2KeystoneInsertMultipleSuccess(t *testing.T) {
 		t.Fatalf("unexpected diff %s", diff)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -502,7 +502,7 @@ func TestL2KeystoneInsertInvalidHashLength(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -539,7 +539,7 @@ func TestL2KeystoneInsertInvalidEPHashLength(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -576,7 +576,7 @@ func TestL2KeystoneInsertInvalidStateRootLength(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +613,7 @@ func TestL2KeystoneInsertInvalidPrevKeystoneEPHashLength(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -650,7 +650,7 @@ func TestL2KeystoneInsertInvalidParentEPHashLength(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -905,7 +905,7 @@ func TestL2KeystoneInsertMultipleAtomicFailure(t *testing.T) {
 		t.Fatalf("insert should have failed but it did not: %s", err)
 	}
 
-	count, err := db.L2KeystonesCount(ctx)
+	count, err := l2KeystonesCount(ctx, sdb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1960,4 +1960,22 @@ func createBtcBlocksAtStartingHeight(ctx context.Context, t *testing.T, db bfgd.
 	}
 
 	return blocks
+}
+
+func l2KeystonesCount(ctx context.Context, db *sql.DB) (int, error) {
+	const selectCount = `SELECT COUNT(*) FROM l2_keystones;`
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	defer conn.Close()
+
+	var count int
+	if err := conn.QueryRowContext(ctx, selectCount).Scan(&count); err != nil {
+		return 0, err
+	}
+
+	return count, nil
 }

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -95,19 +95,6 @@ func (p *pgdb) Version(ctx context.Context) (int, error) {
 	return dbVersion, nil
 }
 
-func (p *pgdb) L2KeystonesCount(ctx context.Context) (int, error) {
-	log.Tracef("L2KeystonesCount")
-	defer log.Tracef("L2KeystonesCount exit")
-
-	const selectCount = `SELECT COUNT(*) FROM l2_keystones;`
-	var count int
-	if err := p.db.QueryRowContext(ctx, selectCount).Scan(&count); err != nil {
-		return 0, err
-	}
-
-	return count, nil
-}
-
 func (p *pgdb) L2KeystonesInsert(ctx context.Context, l2ks []bfgd.L2Keystone) error {
 	log.Tracef("L2KeystonesInsert")
 	defer log.Tracef("L2KeystonesInsert exit")


### PR DESCRIPTION
**Summary**
Counting `l2_keystones` is only used in tests, there is no need for it to be a public function.

**Changes**
remove the public function `L2KeystonesCount`
