### PR TITLE
electrumx: fix removing conn from pool

### DIFF
--- a/hemi/electrumx/conn_pool.go
+++ b/hemi/electrumx/conn_pool.go
@@ -74,7 +74,7 @@ func (p *connPool) onClose(conn *clientConn) {
 
 	p.poolMx.Lock()
 	// Remove the connection from the pool.
-	slices.DeleteFunc(p.pool, func(c *clientConn) bool {
+	p.pool = slices.DeleteFunc(p.pool, func(c *clientConn) bool {
 		return c == conn
 	})
 	p.poolMx.Unlock()


### PR DESCRIPTION
**Summary**
Set `p.pool` to return value of `slices.DeleteFunc` when removing a connection. 
As of go1.23, `go vet` reports this issue: https://go-review.googlesource.com/c/tools/+/554317

The item is still removed from the slice, however the length of the slice is not updated. See implementation of `slices.DeleteFunc`:
```go
	clear(s[i:]) // zero/nil out the obsolete elements, for GC
	return s[:i]
```

This has likely been causing errors with the pool, such as connections not being returned and instead being closed, as well as the size being returned wrong.

**Changes**
- Set `p.pool` to return value of `slices.DeleteFunc` when removing a connection.
