### PR TITLE
all: build with go1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        go-version: [ "1.22.x" ]
+        go-version: [ "1.23.x" ]
     services:
       postgres:
         image: postgres:16.3-alpine3.20

--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        go-version: [ "1.22.x" ]
+        go-version: [ "1.23.x" ]
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
@@ -42,4 +42,3 @@ jobs:
         working-directory: ./e2e/monitor
         # XXX should this be a make command?
         run: go test -v ./...
-

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 env:
-  GO_VERSION: "1.22.x"
+  GO_VERSION: "1.23.x"
   PNPM_VERSION: "9.4.x"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.22.x"
+  GO_VERSION: "1.23.x"
   PNPM_VERSION: "9.4.x"
   GO_LDFLAGS: >-
     -X 'github.com/hemilabs/heminetwork/version.Brand=Hemi Labs'

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Pre-built binaries are available on the [Releases Page](https://github.com/hemil
 
 - `git`
 - `make`
-- [Go v1.22.2+](https://go.dev/dl/)
+- [Go v1.23+](https://go.dev/dl/)
 
 ### Building with Makefile
 

--- a/cmd/tbcd/README.md
+++ b/cmd/tbcd/README.md
@@ -25,7 +25,7 @@ endpoint.**
 
 ### 🏁 Prerequisites
 
-Ensure Go v1.22.2 or newer is installed on your system.
+Ensure Go v1.23 or newer is installed on your system.
 
 ### Using Makefile
 

--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.22.6-alpine3.20@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 AS builder
+FROM golang:1.23-alpine3.20@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/bssd/Dockerfile
+++ b/docker/bssd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.22.6-alpine3.20@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 AS builder
+FROM golang:1.23-alpine3.20@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.22.6-alpine3.20@sha256:1a478681b671001b7f029f94b5016aed984a23ad99c707f6a0ab6563860ae2f3 AS builder
+FROM golang:1.23-alpine3.20@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
 
 ARG GO_LDFLAGS
 

--- a/e2e/monitor/README.md
+++ b/e2e/monitor/README.md
@@ -5,7 +5,7 @@ that we want to test against.
 
 ## Prerequisites
 
-* Go 1.22+
+* Go 1.23+
 * `docker` available in your cli
 
 ## Running

--- a/e2e/monitor/go.mod
+++ b/e2e/monitor/go.mod
@@ -1,6 +1,8 @@
 module github.com/hemilabs/heminetwork/e2e/monitor
 
-go 1.22.6
+go 1.22
+
+toolchain go1.23.0
 
 replace github.com/hemilabs/heminetwork => ../../
 

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
-FROM golang:1.23-bookworm@sha256:31dc846dd1bcca84d2fa231bcd16c09ff271bcc1a5ae2c48ff10f13b039688f3
+FROM golang:1.22.6-bookworm@sha256:f020456572fc292e9627b3fb435c6de5dfb8020fbcef1fd7b65dd092c0ac56bb
 
 RUN apt-get update
 

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
-FROM golang:1.22.6-bookworm@sha256:39b7e6ebaca464d51989858871f792f2e186dce8ce0cbdba7e88e4444b244407
+FROM golang:1.23-bookworm@sha256:31dc846dd1bcca84d2fa231bcd16c09ff271bcc1a5ae2c48ff10f13b039688f3
 
 RUN apt-get update
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hemilabs/heminetwork
 
 go 1.22
 
-toolchain go1.22.6
+toolchain go1.23.0
 
 // Temporary replace until we upstream our ws_js patch.
 replace github.com/coder/websocket v1.8.12 => github.com/hemilabs/websocket v0.0.0-20240813101919-bf33653e9aa5


### PR DESCRIPTION
**Summary**
Build project with [Go v1.23](https://tip.golang.org/doc/go1.23).
This does not change the `go` directive in the `go.mod` files, meaning we do not require consumers of this module to use `go1.23`, and we cannot use Go v1.23 features yet.

**Changes**
- Use toolchain `go1.23`
- Use Go `1.23.x` in GitHub Actions
- Update Go Docker images to `1.23-alpine3.20` and `1.23-bookworm` (debian)
- Document that Go 1.23 is required for building (previously 1.22.2 or newer)

*Note: Go v1.23 introduces new `go vet` checks for the `slices` package which are currently failing, resolved by #215*
