### PR TITLE
tbc: add block-by-hash command to RPC, use chainhash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ PROJECTPATH = $(abspath $(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
 export GOBIN=$(PROJECTPATH)/bin
 export GOCACHE=$(PROJECTPATH)/.gocache
 export GOPKG=$(PROJECTPATH)/pkg
-GO_LDFLAGS=""
+
+GO_LDFLAGS=
 DIST=$(PROJECTPATH)/dist
 
 project = heminetwork

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -36,7 +36,7 @@ import (
 //	Blocks
 //
 //	Balances
-//	Utxos
+//	UTXOs
 
 const (
 	ldbVersion = 1

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1134,7 +1134,7 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 
 	log.Debugf("Syncing indexes to: %v", hash)
 
-	// Utxos
+	// UTXOs
 	if err := s.UtxoIndexer(ctx, hash); err != nil {
 		return fmt.Errorf("utxo indexer: %w", err)
 	}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1445,7 +1445,7 @@ func TestTxByIdNotFound(t *testing.T) {
 	}
 
 	if response.Error != nil {
-		if !strings.Contains(response.Error.Message, "invalid tx id") {
+		if !strings.Contains(response.Error.Message, "tx not found") {
 			t.Fatalf("incorrect error found: %s", response.Error.Message)
 		}
 	}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -707,7 +707,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 				conn: protocol.NewWSConn(c),
 			}
 
-			var response tbcapi.UtxosByAddressRawResponse
+			var response tbcapi.UTXOsByAddressRawResponse
 			select {
 			case <-time.After(1 * time.Second):
 			case <-ctx.Done():
@@ -715,7 +715,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRawRequest{
+			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UTXOsByAddressRawRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
@@ -728,7 +728,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if v.Header.Command != tbcapi.CmdUtxosByAddressRawResponse {
+			if v.Header.Command != tbcapi.CmdUTXOsByAddressRawResponse {
 				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 
@@ -743,9 +743,9 @@ func TestUtxosByAddressRaw(t *testing.T) {
 				expectedCount = tti.limit
 			}
 
-			if !tti.doNotGenerate && len(response.Utxos) != int(expectedCount) {
-				t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.Utxos))
-			} else if tti.doNotGenerate && len(response.Utxos) != 0 {
+			if !tti.doNotGenerate && len(response.UTXOs) != int(expectedCount) {
+				t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.UTXOs))
+			} else if tti.doNotGenerate && len(response.UTXOs) != 0 {
 				t.Fatalf("did not generate any blocks for address, should not have utxos")
 			}
 		})
@@ -919,7 +919,7 @@ func TestUtxosByAddress(t *testing.T) {
 				conn: protocol.NewWSConn(c),
 			}
 
-			var response tbcapi.UtxosByAddressResponse
+			var response tbcapi.UTXOsByAddressResponse
 			select {
 			case <-time.After(1 * time.Second):
 			case <-ctx.Done():
@@ -927,7 +927,7 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UtxosByAddressRequest{
+			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UTXOsByAddressRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
@@ -940,7 +940,7 @@ func TestUtxosByAddress(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if v.Header.Command != tbcapi.CmdUtxosByAddressResponse {
+			if v.Header.Command != tbcapi.CmdUTXOsByAddressResponse {
 				t.Fatalf("received unexpected command: %s", v.Header.Command)
 			}
 
@@ -955,9 +955,9 @@ func TestUtxosByAddress(t *testing.T) {
 				expectedCount = tti.limit
 			}
 
-			if !tti.doNotGenerate && len(response.Utxos) != int(expectedCount) {
-				t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.Utxos))
-			} else if tti.doNotGenerate && len(response.Utxos) != 0 {
+			if !tti.doNotGenerate && len(response.UTXOs) != int(expectedCount) {
+				t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.UTXOs))
+			} else if tti.doNotGenerate && len(response.UTXOs) != 0 {
 				t.Fatalf("did not generate any blocks for address, should not have utxos")
 			}
 		})
@@ -1015,7 +1015,7 @@ func TestTxByIdRaw(t *testing.T) {
 	slices.Reverse(txIdBytes) // convert to natural order
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxId: txIdBytes,
+		TxID: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1104,7 +1104,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 	slices.Reverse(txIdBytes) // convert to natural order
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxId: txIdBytes,
+		TxID: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1200,7 +1200,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	slices.Reverse(txIdBytes) // convert to natural order
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxId: txIdBytes,
+		TxID: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1286,7 +1286,7 @@ func TestTxById(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxId: ctxid[:],
+		TxID: ctxid[:],
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1370,7 +1370,7 @@ func TestTxByIdInvalid(t *testing.T) {
 	txIdBytes[0]++
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxId: txIdBytes,
+		TxID: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1465,7 +1465,7 @@ func TestTxByIdNotFound(t *testing.T) {
 	txIdBytes = append(txIdBytes, 8)
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxId: txIdBytes,
+		TxID: txIdBytes,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1201,7 +1201,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	}
 
 	if response.Error != nil {
-		if !strings.Contains(response.Error.Message, "invalid tx id") {
+		if !strings.Contains(response.Error.Message, "tx not found") {
 			t.Fatalf("incorrect error found: %s", response.Error.Message)
 		}
 	}

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -740,7 +740,7 @@ func runBitcoinCommand(ctx context.Context, t *testing.T, bitcoindContainer test
 	return buf.String()[8 : len(buf.String())-1], nil
 }
 
-func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container) string {
+func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container) *chainhash.Hash {
 	blockHash, err := runBitcoinCommand(
 		ctx,
 		t,
@@ -780,7 +780,11 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 		t.Fatal("was expecting at least 1 transaction")
 	}
 
-	return parsed.Tx[0]
+	hash, err := chainhash.NewHashFromStr(parsed.Tx[0])
+	if err != nil {
+		t.Fatalf("failed to parse tx hash: %v", err)
+	}
+	return hash
 }
 
 func nextPort(ctx context.Context, t *testing.T) int {


### PR DESCRIPTION
**Summary**
Add `tbcapi-block-by-hash` and `tbcapi-block-by-hash-raw` commands to TBC RPC.
Additionally, use `chainhash.Hash` for all hashes in RPC.

Closes #219

**Changes**
- Add `tbcapi-block-by-hash` and `tbcapi-block-by-hash-raw` commands to TBC RPC, these commands can be used to retrieve blocks by their hash.
- Use `chainhash.Hash` instead of `api.ByteSlice` for hashes in RPC. **This is a breaking change. Raw RPC calls must now provide hashes in display-order as well.**
- Capitalise `Utxo` as `UTXO` consistently in the `tbcapi` package. Initialisms should be all uppercase, per https://go.dev/wiki/CodeReviewComments#initialisms 
