### PR TITLE
electrumx,bfg: add electrumx prometheus metrics

### DIFF
--- a/cmd/extool/extool.go
+++ b/cmd/extool/extool.go
@@ -37,7 +37,10 @@ func main() {
 		log.Fatal("No address specified")
 	}
 
-	c, err := electrumx.NewClient(address, 1, 1)
+	c, err := electrumx.NewClient(address, &electrumx.ClientOptions{
+		InitialConnections: 1,
+		MaxConnections:     1,
+	})
 	if err != nil {
 		log.Fatalf("Failed to create electrumx client: %v", err)
 	}

--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -17,9 +17,13 @@ RUN addgroup --gid 65532 bfgd && \
         -G bfgd --uid 65532 bfgd
 
 WORKDIR /build/
-COPY . .
 
+COPY Makefile .
+COPY go.mod .
+COPY go.sum .
 RUN make deps
+
+COPY . .
 RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" bfgd
 
 # Run stage

--- a/docker/bssd/Dockerfile
+++ b/docker/bssd/Dockerfile
@@ -17,9 +17,13 @@ RUN addgroup --gid 65532 bssd && \
         -G bssd --uid 65532 bssd
 
 WORKDIR /build/
-COPY . .
 
+COPY Makefile .
+COPY go.mod .
+COPY go.sum .
 RUN make deps
+
+COPY . .
 RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" bssd
 
 # Run stage

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -17,9 +17,13 @@ RUN addgroup --gid 65532 popmd && \
         -G popmd --uid 65532 popmd
 
 WORKDIR /build/
-COPY . .
 
+COPY Makefile .
+COPY go.mod .
+COPY go.sum .
 RUN make deps
+
+COPY . .
 RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" popmd
 
 # Run stage

--- a/hemi/electrumx/conn_pool.go
+++ b/hemi/electrumx/conn_pool.go
@@ -112,7 +112,9 @@ func (p *connPool) acquireConn() (*clientConn, error) {
 
 	if c != nil {
 		// Successfully acquired a connection from the pool.
-		c.metrics.connsIdle.Dec()
+		if c.metrics != nil {
+			c.metrics.connsIdle.Dec()
+		}
 		return c, nil
 	}
 
@@ -144,7 +146,9 @@ func (p *connPool) freeConn(conn *clientConn) {
 
 	p.pool = append(p.pool, conn)
 	p.poolMx.Unlock()
-	p.metrics.connsIdle.Inc()
+	if p.metrics != nil {
+		p.metrics.connsIdle.Inc()
+	}
 }
 
 // size returns the number of connections in the pool.

--- a/hemi/electrumx/conn_pool_test.go
+++ b/hemi/electrumx/conn_pool_test.go
@@ -15,6 +15,11 @@ const (
 	clientMaximumConnections = 5
 )
 
+var testClientOpts = &ClientOptions{
+	InitialConnections: clientInitialConnections,
+	MaxConnections:     clientMaximumConnections,
+}
+
 func TestConnPool(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -22,8 +27,7 @@ func TestConnPool(t *testing.T) {
 	server := createMockServer(t)
 	defer server.Close()
 
-	pool, err := newConnPool("tcp", server.address,
-		clientInitialConnections, clientMaximumConnections)
+	pool, err := newConnPool("tcp", server.address, testClientOpts, nil)
 	if err != nil {
 		t.Fatalf("failed to create connPool: %v", err)
 	}

--- a/hemi/electrumx/conn_test.go
+++ b/hemi/electrumx/conn_test.go
@@ -34,7 +34,7 @@ func TestClientConn(t *testing.T) {
 		t.Fatalf("failed to dial server: %v", err)
 	}
 
-	c := newClientConn(conn, nil)
+	c := newClientConn(conn, nil, nil)
 	defer c.Close()
 
 	tests := []struct {
@@ -174,7 +174,7 @@ func TestClose(t *testing.T) {
 		t.Fatalf("failed to dial server: %v", err)
 	}
 
-	c := newClientConn(conn, nil)
+	c := newClientConn(conn, nil, nil)
 
 	// Ping the server.
 	if err := c.ping(); err != nil {


### PR DESCRIPTION
**Summary**
Add prometheus metrics to the ElectrumX client and connection pool in BFG.

- `bfg_electrumx_connections_open` - Number of open ElectrumX connections
- `bfg_electrumx_connections_idle` - Number of ElectrumX connections in the pool
- `bfg_electrumx_connections_opened_total` - Total number of ElectrumX connections opened
- `bfg_electrumx_connections_closed_total` - Total number of ElectrumX connections closed
- `bfg_electrumx_rpc_calls_total` - Total number of ElectrumX RPC calls
- `bfg_electrumx_rpc_calls_duration_seconds` - ElectrumX RPC call durations in seconds

**Changes**
- Add metrics to Electrumx client, connection pool and connection.
- Use a struct for electrumx client options: `electrumx.ClientOptions`.
- Only copy `Makefile`, `go.mod` and `go.sum` to run `make deps` in Docker files, making this step significantly faster and more likely to be restored from cache (reduced build time by ~250 seconds for me when changing Go file and rebuilding).
