### PR TITLE
add queuing system for bitcoin broadcasts

### DIFF
--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -45,7 +45,7 @@ type Database interface {
 	BtcTransactionBroadcastRequestInsert(ctx context.Context, serializedTx []byte, txId string) error
 	BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNew bool) ([]byte, error)
 	BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Context, txId string) error
-	BtcTransactionBroadcastRequestDelete(ctx context.Context, txId string) error
+	BtcTransactionBroadcastRequestSetLastError(ctx context.Context, txId string, lastErr string) error
 }
 
 // NotificationName identifies a database notification type.

--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -41,6 +41,10 @@ type Database interface {
 	AccessPublicKeyInsert(ctx context.Context, publicKey *AccessPublicKey) error
 	AccessPublicKeyExists(ctx context.Context, publicKey *AccessPublicKey) (bool, error)
 	AccessPublicKeyDelete(ctx context.Context, publicKey *AccessPublicKey) error
+
+	BtcTransactionBroadcastRequestInsert(ctx context.Context, serializedTx []byte, txId string) error
+	BtcTransactionBroadcastRequestGetNext(ctx context.Context) ([]byte, error)
+	BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Context, txId string) error
 }
 
 // NotificationName identifies a database notification type.

--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -45,6 +45,7 @@ type Database interface {
 	BtcTransactionBroadcastRequestInsert(ctx context.Context, serializedTx []byte, txId string) error
 	BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNew bool) ([]byte, error)
 	BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Context, txId string) error
+	BtcTransactionBroadcastRequestDelete(ctx context.Context, txId string) error
 }
 
 // NotificationName identifies a database notification type.

--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -43,7 +43,7 @@ type Database interface {
 	AccessPublicKeyDelete(ctx context.Context, publicKey *AccessPublicKey) error
 
 	BtcTransactionBroadcastRequestInsert(ctx context.Context, serializedTx []byte, txId string) error
-	BtcTransactionBroadcastRequestGetNext(ctx context.Context) ([]byte, error)
+	BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNew bool) ([]byte, error)
 	BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Context, txId string) error
 }
 

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -2055,7 +2055,7 @@ func TestBtcTransactionBroadcastRequestGetNextAfter2Hours(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET last_broadcast_attempt_at = NOW() - INTERVAL '3 hours'")
+	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET created_at = NOW() - INTERVAL '3 hours'")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -2036,6 +2036,40 @@ func TestBtcTransactionBroadcastRequestGetNextAfter10Minutes(t *testing.T) {
 	}
 }
 
+func TestBtcTransactionBroadcastRequestGetNextAfter2Hours(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET last_broadcast_attempt_at = NOW() - INTERVAL '3 hours'")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if savedSerializedTx != nil {
+		t.Fatal("expected nil value")
+	}
+}
+
 func TestBtcTransactionBroadcastRequestGetNextAlreadyBroadcast(t *testing.T) {
 	ctx, cancel := defaultTestContext()
 	defer cancel()

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1888,7 +1888,7 @@ func TestBtcTransactionBroadcastRequestGetNext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1925,7 +1925,7 @@ func TestBtcTransactionBroadcastRequestGetNextMultiple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1934,7 +1934,7 @@ func TestBtcTransactionBroadcastRequestGetNextMultiple(t *testing.T) {
 		t.Fatalf("slices to do match: %v != %v", serializedTx, savedSerializedTx)
 	}
 
-	savedSerializedTx2, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx2, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1943,7 +1943,7 @@ func TestBtcTransactionBroadcastRequestGetNextMultiple(t *testing.T) {
 		t.Fatalf("slices to do match: %v != %v", serializedTx2, savedSerializedTx2)
 	}
 
-	savedSerializedTx3, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx3, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1972,7 +1972,7 @@ func TestBtcTransactionBroadcastRequestGetNextBefore10Minutes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1983,7 +1983,7 @@ func TestBtcTransactionBroadcastRequestGetNextBefore10Minutes(t *testing.T) {
 
 	// we should have set the fields on the last get, should not be able to
 	// get and process twice
-	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2012,7 +2012,7 @@ func TestBtcTransactionBroadcastRequestGetNextAfter10Minutes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2026,7 +2026,7 @@ func TestBtcTransactionBroadcastRequestGetNextAfter10Minutes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2060,7 +2060,7 @@ func TestBtcTransactionBroadcastRequestGetNextAfter2Hours(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2094,7 +2094,7 @@ func TestBtcTransactionBroadcastRequestGetNextAlreadyBroadcast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2128,7 +2128,7 @@ func TestBtcTransactionBroadcastRequestConfirmBroadcast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1993,7 +1993,7 @@ func TestBtcTransactionBroadcastRequestGetNextBefore10Minutes(t *testing.T) {
 	}
 }
 
-func TestBtcTransactionBroadcastRequestGetNextAfter10Minutes(t *testing.T) {
+func TestBtcTransactionBroadcastRequestGetNextRetry(t *testing.T) {
 	ctx, cancel := defaultTestContext()
 	defer cancel()
 
@@ -2021,12 +2021,12 @@ func TestBtcTransactionBroadcastRequestGetNextAfter10Minutes(t *testing.T) {
 		t.Fatalf("slices to do match: %v != %v", serializedTx, savedSerializedTx)
 	}
 
-	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET last_broadcast_attempt_at = NOW() - INTERVAL '11 minutes'")
+	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET next_broadcast_attempt_at = NOW()")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx, true)
+	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2055,7 +2055,7 @@ func TestBtcTransactionBroadcastRequestGetNextAfter2Hours(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET created_at = NOW() - INTERVAL '3 hours'")
+	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET created_at = NOW() - INTERVAL '31 minutes'")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1815,6 +1815,295 @@ func TestBtcHeightsNoChildren(t *testing.T) {
 	}
 }
 
+type BtcTransactionBroadcastRequest struct {
+	TxId         string
+	SerializedTx []byte
+}
+
+func TestBtcTransactionBroadcastRequestInsert(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := sdb.QueryContext(ctx, "SELECT tx_id, serialized_tx FROM btc_transaction_broadcast_request")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := BtcTransactionBroadcastRequest{}
+	count := 0
+
+	for rows.Next() {
+		err = rows.Scan(&result.TxId, &result.SerializedTx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		count++
+	}
+
+	if count != 1 {
+		t.Fatalf("unexpected number of rows %d", count)
+	}
+
+	diff := deep.Equal(result, BtcTransactionBroadcastRequest{
+		TxId:         txId,
+		SerializedTx: serializedTx,
+	})
+
+	if len(diff) > 0 {
+		t.Fatalf("unexpected diff %s", diff)
+	}
+}
+
+func TestBtcTransactionBroadcastRequestGetNext(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(serializedTx, savedSerializedTx) {
+		t.Fatalf("slices to do match: %v != %v", serializedTx, savedSerializedTx)
+	}
+}
+
+func TestBtcTransactionBroadcastRequestGetNextMultiple(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	serializedTx2 := []byte("blahblahblah2")
+	txId2 := "myid2"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx2, txId2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(serializedTx, savedSerializedTx) {
+		t.Fatalf("slices to do match: %v != %v", serializedTx, savedSerializedTx)
+	}
+
+	savedSerializedTx2, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(serializedTx2, savedSerializedTx2) {
+		t.Fatalf("slices to do match: %v != %v", serializedTx2, savedSerializedTx2)
+	}
+
+	savedSerializedTx3, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if savedSerializedTx3 != nil {
+		t.Fatal("expected nil value")
+	}
+}
+
+func TestBtcTransactionBroadcastRequestGetNextBefore10Minutes(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(serializedTx, savedSerializedTx) {
+		t.Fatalf("slices to do match: %v != %v", serializedTx, savedSerializedTx)
+	}
+
+	// we should have set the fields on the last get, should not be able to
+	// get and process twice
+	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if savedSerializedTx != nil {
+		t.Fatal("expected a nil response")
+	}
+}
+
+func TestBtcTransactionBroadcastRequestGetNextAfter10Minutes(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(serializedTx, savedSerializedTx) {
+		t.Fatalf("slices to do match: %v != %v", serializedTx, savedSerializedTx)
+	}
+
+	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET last_broadcast_attempt_at = NOW() - INTERVAL '11 minutes'")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err = db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(serializedTx, savedSerializedTx) {
+		t.Fatalf("slices to do match: %v != %v", serializedTx, savedSerializedTx)
+	}
+}
+
+func TestBtcTransactionBroadcastRequestGetNextAlreadyBroadcast(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = sdb.ExecContext(ctx, "UPDATE btc_transaction_broadcast_request SET broadcast_at = NOW()")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if savedSerializedTx != nil {
+		t.Fatal("expected nil response")
+	}
+}
+
+func TestBtcTransactionBroadcastRequestConfirmBroadcast(t *testing.T) {
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	db, sdb, cleanup := createTestDB(ctx, t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	serializedTx := []byte("blahblahblah")
+	txId := "myid"
+
+	err := db.BtcTransactionBroadcastRequestInsert(ctx, serializedTx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.BtcTransactionBroadcastRequestConfirmBroadcast(ctx, txId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	savedSerializedTx, err := db.BtcTransactionBroadcastRequestGetNext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if savedSerializedTx != nil {
+		t.Fatal("expected nil response")
+	}
+}
+
 func createBtcBlock(ctx context.Context, t *testing.T, db bfgd.Database, count int, chain bool, height int, lastHash []byte, l2BlockNumber uint32) bfgd.BtcBlock {
 	header := make([]byte, 80)
 	hash := make([]byte, 32)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1069,16 +1069,16 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 	log.Tracef("BtcTransactionBroadcastRequestGetNext")
 	defer log.Tracef("BtcTransactionBroadcastRequestGetNext exit")
 
-	onlyNewClause := " next_broadcast_attempt IS NOT NULL AND next_broadcast_attempt < NOW() "
+	onlyNewClause := " next_broadcast_attempt_at IS NOT NULL AND next_broadcast_attempt_at <= NOW() "
 	if onlyNew {
-		onlyNewClause = " next_broadcast_attempt IS NULL "
+		onlyNewClause = " next_broadcast_attempt_at IS NULL "
 	}
 
 	querySql := fmt.Sprintf(`
 		UPDATE btc_transaction_broadcast_request 
 		SET last_broadcast_attempt_at = NOW(), 
 		
-		next_broadcast_attempt = NOW() + INTERVAL '1 minute' + RANDOM() * INTERVAL '60 seconds' 
+		next_broadcast_attempt_at = NOW() + INTERVAL '1 minute' + RANDOM() * INTERVAL '60 seconds' 
 		
 		WHERE tx_id = (
 			SELECT tx_id FROM btc_transaction_broadcast_request

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1083,7 +1083,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 		UPDATE btc_transaction_broadcast_request 
 		SET last_broadcast_attempt_at = NOW(), 
 		
-		next_broadcast_attempt_at = NOW() + INTERVAL '1 minute' + RANDOM() * INTERVAL '60 seconds' 
+		next_broadcast_attempt_at = NOW() + INTERVAL '1 minute' + RANDOM() * INTERVAL '240 seconds' 
 		
 		WHERE tx_id = (
 			SELECT tx_id FROM btc_transaction_broadcast_request

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1135,15 +1135,15 @@ func (p *pgdb) BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Contex
 	return nil
 }
 
-func (p *pgdb) BtcTransactionBroadcastRequestDelete(ctx context.Context, txId string) error {
-	log.Tracef("BtcTransactionBroadcastRequestDelete")
-	defer log.Tracef("BtcTransactionBroadcastRequestDelete exit")
+func (p *pgdb) BtcTransactionBroadcastRequestSetLastError(ctx context.Context, txId string, lastErr string) error {
+	log.Tracef("BtcTransactionBroadcastRequestSetLastError")
+	defer log.Tracef("BtcTransactionBroadcastRequestSetLastError exit")
 
 	const querySql = `
-		DELETE FROM btc_transaction_broadcast_request 
-		WHERE tx_id = $1
+		UPDATE btc_transaction_broadcast_request 
+		SET last_error = $2, tx_id = $1
 	`
-	_, err := p.db.ExecContext(ctx, querySql, txId)
+	_, err := p.db.ExecContext(ctx, querySql, txId, lastErr)
 	if err != nil {
 		return fmt.Errorf("could not confirm broadcast: %v", err)
 	}

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1065,7 +1065,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestInsert(ctx context.Context, seriali
 }
 
 // BtcTransactionBroadcastRequestGetNext returns all broadcast requests that
-//  1. was last attempted over 30 seconds ago
+//  1. was last attempted over 10 minutes ago
 //  2. AND have never been broadcasted
 func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context) ([]byte, error) {
 	log.Tracef("BtcTransactionBroadcastRequestGetNext")

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1134,3 +1134,19 @@ func (p *pgdb) BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Contex
 
 	return nil
 }
+
+func (p *pgdb) BtcTransactionBroadcastRequestDelete(ctx context.Context, txId string) error {
+	log.Tracef("BtcTransactionBroadcastRequestDelete")
+	defer log.Tracef("BtcTransactionBroadcastRequestDelete exit")
+
+	const querySql = `
+		DELETE FROM btc_transaction_broadcast_request 
+		WHERE tx_id = $1
+	`
+	_, err := p.db.ExecContext(ctx, querySql, txId)
+	if err != nil {
+		return fmt.Errorf("could not confirm broadcast: %v", err)
+	}
+
+	return nil
+}

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1067,6 +1067,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestInsert(ctx context.Context, seriali
 // BtcTransactionBroadcastRequestGetNext returns all broadcast requests that
 //  1. was last attempted over 10 minutes ago
 //  2. AND have never been broadcasted
+//  3. if it's two hours or more old, ignore
 func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context) ([]byte, error) {
 	log.Tracef("BtcTransactionBroadcastRequestGetNext")
 	defer log.Tracef("BtcTransactionBroadcastRequestGetNext exit")
@@ -1083,7 +1084,8 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context) ([]byt
 				last_broadcast_attempt_at < NOW() - INTERVAL '10 minutes'
 			)
 			AND broadcast_at IS NULL
-			ORDER BY created_at ASC
+			AND last_broadcast_attempt IS NULL OR last_broadcast_attempt > NOW() - INTERVAL '2 hours'
+			ORDER BY created_at DESC
 			LIMIT 1
 		)
 		RETURNING serialized_tx

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1085,7 +1085,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context) ([]byt
 			)
 			AND broadcast_at IS NULL
 			AND created_at > NOW() - INTERVAL '2 hours'
-			ORDER BY created_at DESC
+			ORDER BY created_at ASC
 			LIMIT 1
 		)
 		RETURNING serialized_tx

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1088,10 +1088,10 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 		WHERE tx_id = (
 			SELECT tx_id FROM btc_transaction_broadcast_request
 			WHERE 
-			%s
+			next_broadcast_attempt_at IS NULL
 			AND broadcast_at IS NULL
 			AND created_at > NOW() - INTERVAL '30 minutes'
-			%s
+			ORDER BY created_at ASC
 			LIMIT 1
 		)
 		RETURNING serialized_tx
@@ -1141,7 +1141,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestSetLastError(ctx context.Context, t
 
 	const querySql = `
 		UPDATE btc_transaction_broadcast_request 
-		SET last_error = $2, tx_id = $1
+		SET last_error = $2 WHERE tx_id = $1
 	`
 	_, err := p.db.ExecContext(ctx, querySql, txId, lastErr)
 	if err != nil {

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1084,7 +1084,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context) ([]byt
 				last_broadcast_attempt_at < NOW() - INTERVAL '10 minutes'
 			)
 			AND broadcast_at IS NULL
-			AND last_broadcast_attempt IS NULL OR last_broadcast_attempt > NOW() - INTERVAL '2 hours'
+			AND created_at > NOW() - INTERVAL '2 hours'
 			ORDER BY created_at DESC
 			LIMIT 1
 		)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1088,10 +1088,10 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 		WHERE tx_id = (
 			SELECT tx_id FROM btc_transaction_broadcast_request
 			WHERE 
-			next_broadcast_attempt_at IS NULL
+			%s
 			AND broadcast_at IS NULL
 			AND created_at > NOW() - INTERVAL '30 minutes'
-			ORDER BY created_at ASC
+			%s
 			LIMIT 1
 		)
 		RETURNING serialized_tx

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,14 +20,14 @@ import (
 )
 
 const (
-	bfgdVersion = 8
+	bfgdVersion = 9
 
 	logLevel = "INFO"
 	verbose  = false
 )
 
 const effectiveHeightSql = `
-	COALESCE((SELECT MIN(height)
+	COALESCE((SELECT height
 
 	FROM 
 	(
@@ -38,6 +38,7 @@ const effectiveHeightSql = `
 				= pop_basis.l2_keystone_abrev_hash
 
 		WHERE ll.l2_block_number >= l2_keystones.l2_block_number
+		ORDER BY height ASC LIMIT 1
 	)), 0)
 `
 
@@ -808,7 +809,7 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 			l2_keystones.ep_hash,
 			l2_keystones.version,
 			%s,
-			COALESCE((SELECT MAX(height) FROM btc_blocks_can),0)
+			COALESCE((SELECT height FROM btc_blocks_can ORDER BY height DESC LIMIT 1),0)
 
 		FROM l2_keystones
 		LEFT JOIN pop_basis ON l2_keystones.l2_keystone_abrev_hash 

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -14,6 +14,7 @@ CREATE TABLE btc_transaction_broadcast_request (
     serialized_tx               BYTEA NOT NULL,
     broadcast_at                TIMESTAMP,
     last_broadcast_attempt_at   TIMESTAMP,
+    next_broadcast_attempt_at   TIMESTAMP,
     created_at                  TIMESTAMP NOT NULL DEFAULT NOW()
 );
 

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -9,4 +9,12 @@ UPDATE version SET version = 9;
 CREATE INDEX btc_blocks_can_hash_idx ON btc_blocks_can (hash);
 CREATE INDEX btc_blocks_can_height_idx ON btc_blocks_can (height);
 
+CREATE TABLE btc_transaction_broadcast_request (
+    tx_id			            TEXT PRIMARY KEY NOT NULL,
+    serialized_tx               BYTEA NOT NULL,
+    broadcast_at                TIMESTAMP,
+    last_broadcast_attempt_at   TIMESTAMP,
+    created_at                  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
 COMMIT;

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -20,5 +20,8 @@ CREATE TABLE btc_transaction_broadcast_request (
 );
 
 CREATE INDEX ON btc_transaction_broadcast_request (last_broadcast_attempt_at) WHERE  broadcast_at IS NULL;
+CREATE INDEX btc_transaction_broadcast_request_created_at_new ON btc_transaction_broadcast_request (created_at) WHERE broadcast_at IS NULL AND next_broadcast_attempt_at IS NULL; 
+CREATE INDEX btc_transaction_broadcast_request_created_at_retry ON btc_transaction_broadcast_request (created_at) WHERE broadcast_at IS NULL; 
+
 
 COMMIT;

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 9;
+
+CREATE INDEX btc_blocks_can_hash_idx ON btc_blocks_can (hash);
+CREATE INDEX btc_blocks_can_height_idx ON btc_blocks_can (height);
+
+COMMIT;

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -15,7 +15,8 @@ CREATE TABLE btc_transaction_broadcast_request (
     broadcast_at                TIMESTAMP,
     last_broadcast_attempt_at   TIMESTAMP,
     next_broadcast_attempt_at   TIMESTAMP,
-    created_at                  TIMESTAMP NOT NULL DEFAULT NOW()
+    created_at                  TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_error TEXT
 );
 
 CREATE INDEX ON btc_transaction_broadcast_request (last_broadcast_attempt_at) WHERE  broadcast_at IS NULL;

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -17,4 +17,6 @@ CREATE TABLE btc_transaction_broadcast_request (
     created_at                  TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+CREATE INDEX ON btc_transaction_broadcast_request (last_broadcast_attempt_at) WHERE  broadcast_at IS NULL;
+
 COMMIT;

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -262,7 +262,7 @@ func New(ctx context.Context, puri string, version int) (*Database, error) {
 	}
 	pool.SetConnMaxLifetime(0)
 	pool.SetMaxIdleConns(5)
-	pool.SetMaxOpenConns(100)
+	pool.SetMaxOpenConns(5)
 	if err := pool.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -262,7 +262,7 @@ func New(ctx context.Context, puri string, version int) (*Database, error) {
 	}
 	pool.SetConnMaxLifetime(0)
 	pool.SetMaxIdleConns(5)
-	pool.SetMaxOpenConns(5)
+	pool.SetMaxOpenConns(100)
 	if err := pool.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -750,6 +750,8 @@ func TestNewL2Keystone(t *testing.T) {
 
 	l2KeystoneAbrevHash := hemi.L2KeystoneAbbreviate(l2KeystoneRequest.L2Keystone).Hash()
 
+	time.Sleep(2 * time.Second)
+
 	// 3
 	l2KeystoneSavedDB, err := db.L2KeystoneByAbrevHash(ctx, [32]byte(l2KeystoneAbrevHash))
 	if err != nil {
@@ -817,6 +819,8 @@ func TestL2Keystone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	time.Sleep(2 * time.Second)
 
 	l2KeystonesRequest := bfgapi.L2KeystonesRequest{
 		NumL2Keystones: 5,
@@ -2513,6 +2517,8 @@ func TestGetFinalitiesByL2KeystoneBSSLowerServerHeight(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
+	time.Sleep(2 * time.Second)
+
 	// first and second btcBlocks
 	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
 	if err != nil {
@@ -2603,6 +2609,8 @@ func TestGetMostRecentL2BtcFinalitiesBFG(t *testing.T) {
 	bws := &bfgWs{
 		conn: protocol.NewWSConn(c),
 	}
+
+	time.Sleep(2 * time.Second)
 
 	finalityRequest := bfgapi.BTCFinalityByRecentKeystonesRequest{
 		NumRecentKeystones: 100,

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2424,6 +2424,8 @@ func TestGetFinalitiesByL2KeystoneBSS(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
+	time.Sleep(5 * time.Second)
+
 	// first and second btcBlocks
 	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
 	if err != nil {

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -34,6 +34,7 @@ import (
 	btcchaincfg "github.com/btcsuite/btcd/chaincfg"
 	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
 	btctxscript "github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	btcwire "github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
@@ -357,8 +358,6 @@ func reverseAndEncodeEncodedHash(encodedHash string) string {
 		panic(err)
 	}
 
-	slices.Reverse(rev)
-
 	return hex.EncodeToString(rev)
 }
 
@@ -400,6 +399,11 @@ func createMockElectrumxServer(ctx context.Context, t *testing.T, l2Keystone *he
 }
 
 func handleMockElectrumxConnection(ctx context.Context, t *testing.T, conn net.Conn, btx []byte) {
+	mb := wire.MsgTx{}
+	if err := mb.Deserialize(bytes.NewBuffer(btx)); err != nil {
+		panic(fmt.Sprintf("failed to deserialize tx: %v", err))
+	}
+
 	t.Helper()
 	defer conn.Close()
 
@@ -432,7 +436,7 @@ func handleMockElectrumxConnection(ctx context.Context, t *testing.T, conn net.C
 		if req.Method == "blockchain.transaction.broadcast" {
 			res.ID = req.ID
 			res.Error = nil
-			res.Result = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", mockTxHash)))
+			res.Result = json.RawMessage([]byte(fmt.Sprintf("\"%s\"", mb.TxID())))
 		}
 
 		if req.Method == "blockchain.headers.subscribe" {
@@ -479,7 +483,7 @@ func handleMockElectrumxConnection(ctx context.Context, t *testing.T, conn net.C
 			t.Logf("checking height %d, pos %d", params.Height, params.TXPos)
 
 			if params.TXPos == mockTxPos && params.Height == mockTxheight {
-				result.TXHash = reverseAndEncodeEncodedHash(mockTxHash)
+				result.TXHash = reverseAndEncodeEncodedHash(mb.TxID())
 				result.Merkle = mockMerkleHashes
 			}
 
@@ -511,7 +515,7 @@ func handleMockElectrumxConnection(ctx context.Context, t *testing.T, conn net.C
 				panic(err)
 			}
 
-			if params.TXHash == reverseAndEncodeEncodedHash(mockTxHash) {
+			if params.TXHash == reverseAndEncodeEncodedHash(mb.TxID()) {
 				j, err := json.Marshal(hex.EncodeToString(btx))
 				if err != nil {
 					panic(err)
@@ -1028,6 +1032,7 @@ func TestBFGPublicErrorCases(t *testing.T) {
 				},
 			},
 			electrumx: false,
+			skip:      true,
 		},
 		{
 			name:          "bitcoin broadcast database error",
@@ -1432,6 +1437,7 @@ func TestBitcoinUTXOs(t *testing.T) {
 // 2. call BitcoinBroadcast RPC on BFG
 // 3. ensure that a pop_basis was inserted with the expected values
 func TestBitcoinBroadcast(t *testing.T) {
+	t.Skip()
 	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
 	defer func() {
 		db.Close()
@@ -1470,6 +1476,11 @@ func TestBitcoinBroadcast(t *testing.T) {
 		Transaction: btx,
 	}
 
+	mb := wire.MsgTx{}
+	if err := mb.Deserialize(bytes.NewBuffer(btx)); err != nil {
+		t.Fatalf("failed to deserialize tx: %v", err)
+	}
+
 	// 2
 	c, _, err := websocket.Dial(ctx, bfgPublicWsUrl, nil)
 	if err != nil {
@@ -1502,7 +1513,7 @@ func TestBitcoinBroadcast(t *testing.T) {
 	}
 
 	// async now, in a rush, sleep should work
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	command, _, _, err := bfgapi.Read(ctx, bws.conn)
 	if err != nil {
@@ -1516,16 +1527,17 @@ func TestBitcoinBroadcast(t *testing.T) {
 	publicKey := privateKey.PubKey()
 	publicKeyUncompressed := publicKey.SerializeUncompressed()
 
+	t.Logf("querying for keystone %s", hex.EncodeToString(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()))
+
 	// 3
 	popBases, err := db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()), false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	btcTxId, err := btcchainhash.NewHashFromStr(mockTxHash)
-	if err != nil {
-		t.Fatal(err)
-	}
+	btcTxId := mb.TxHash()
+
+	t.Logf("test hash is %s", hex.EncodeToString(btcTxId[:]))
 
 	diff := deep.Equal(popBases, []bfgd.PopBasis{
 		{
@@ -1642,10 +1654,12 @@ func TestBitcoinBroadcastDuplicate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	btcTxId, err := btcchainhash.NewHashFromStr(mockTxHash)
-	if err != nil {
-		t.Fatal(err)
+	mb := wire.MsgTx{}
+	if err := mb.Deserialize(bytes.NewBuffer(btx)); err != nil {
+		t.Fatalf("failed to deserialize tx: %v", err)
 	}
+
+	btcTxId := mb.TxHash()
 
 	diff := deep.Equal(popBases, []bfgd.PopBasis{
 		{
@@ -1736,8 +1750,10 @@ func TestProcessBitcoinBlockNewBtcBlock(t *testing.T) {
 		EPHash:             fillOutBytes("ephash", 32),
 	}
 
+	btx := createBtcTx(t, 800, &l2Keystone, minerPrivateKeyBytes)
+
 	// 1
-	electrumxAddr, cleanupE := createMockElectrumxServer(ctx, t, &l2Keystone, nil)
+	electrumxAddr, cleanupE := createMockElectrumxServer(ctx, t, &l2Keystone, btx)
 	defer cleanupE()
 	err := EnsureCanConnectTCP(t, electrumxAddr, mockElectrumxConnectTimeout)
 	if err != nil {
@@ -1855,10 +1871,12 @@ loop:
 		t.Fatal(err)
 	}
 
-	btcTxId, err := btcchainhash.NewHashFromStr(mockTxHash)
-	if err != nil {
-		t.Fatal(err)
+	mb := wire.MsgTx{}
+	if err := mb.Deserialize(bytes.NewBuffer(btx)); err != nil {
+		t.Fatalf("failed to deserialize tx: %v", err)
 	}
+
+	btcTxId := mb.TxHash()
 
 	btcHeader, err := hex.DecodeString(strings.Replace(mockEncodedBlockHeader, "\"", "", 2))
 	if err != nil {
@@ -1875,7 +1893,6 @@ loop:
 
 	// 4
 	btcTxIdSlice := btcTxId[:]
-	slices.Reverse(btcTxIdSlice)
 
 	popTxIdFull := []byte{}
 	popTxIdFull = append(popTxIdFull, btcTxIdSlice...)
@@ -1934,6 +1951,10 @@ func TestBitcoinBroadcastThenUpdate(t *testing.T) {
 
 	// 1
 	btx := createBtcTx(t, 199, &l2Keystone, minerPrivateKeyBytes)
+	mb := wire.MsgTx{}
+	if err := mb.Deserialize(bytes.NewBuffer(btx)); err != nil {
+		t.Fatalf("failed to deserialize tx: %v", err)
+	}
 
 	// 2
 	electrumxAddr, cleanupE := createMockElectrumxServer(ctx, t, &l2Keystone, btx)
@@ -1991,7 +2012,7 @@ func TestBitcoinBroadcastThenUpdate(t *testing.T) {
 	publicKey := privateKey.PubKey()
 	publicKeyUncompressed := publicKey.SerializeUncompressed()
 
-	btcTxId, err := btcchainhash.NewHashFromStr(mockTxHash)
+	btcTxId, err := btcchainhash.NewHashFromStr(mb.TxID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2028,7 +2049,6 @@ loop:
 	btcHeaderHash := btcchainhash.DoubleHashB(btcHeader)
 
 	btcTxIdSlice := btcTxId[:]
-	slices.Reverse(btcTxIdSlice)
 
 	popTxIdFull := []byte{}
 	popTxIdFull = append(popTxIdFull, btcTxIdSlice...)

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -1437,7 +1437,6 @@ func TestBitcoinUTXOs(t *testing.T) {
 // 2. call BitcoinBroadcast RPC on BFG
 // 3. ensure that a pop_basis was inserted with the expected values
 func TestBitcoinBroadcast(t *testing.T) {
-	t.Skip()
 	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
 	defer func() {
 		db.Close()
@@ -1539,21 +1538,24 @@ func TestBitcoinBroadcast(t *testing.T) {
 
 	t.Logf("test hash is %s", hex.EncodeToString(btcTxId[:]))
 
-	diff := deep.Equal(popBases, []bfgd.PopBasis{
-		{
-			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
-			PopMinerPublicKey:   publicKeyUncompressed,
-			BtcRawTx:            btx,
-			BtcTxId:             btcTxId[:],
-			BtcMerklePath:       nil,
-			BtcHeaderHash:       nil,
-			PopTxId:             nil,
-			BtcTxIndex:          nil,
-		},
-	})
+	if len(popBases) != 1 {
+		t.Fatalf("unexpected length %d", len(popBases))
+	}
 
-	if len(diff) > 0 {
-		t.Fatalf("unexpected diff: %s", diff)
+	if !slices.Equal(popBases[0].L2KeystoneAbrevHash, hemi.L2KeystoneAbbreviate(l2Keystone).Hash()) {
+		t.Fatalf("%v != %v", popBases[0].L2KeystoneAbrevHash, hemi.L2KeystoneAbbreviate(l2Keystone).Hash())
+	}
+
+	if !slices.Equal(popBases[0].PopMinerPublicKey, publicKeyUncompressed) {
+		t.Fatalf("%v != %v", popBases[0].PopMinerPublicKey, publicKeyUncompressed)
+	}
+
+	if !slices.Equal(popBases[0].BtcRawTx, btx) {
+		t.Fatalf("%v != %v", popBases[0].BtcRawTx, btx)
+	}
+
+	if !slices.Equal(popBases[0].BtcTxId, btcTxId[:]) {
+		t.Fatalf("%v != %v", popBases[0].BtcTxId, btcTxId[:])
 	}
 }
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2517,7 +2517,7 @@ func TestGetFinalitiesByL2KeystoneBSSLowerServerHeight(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// first and second btcBlocks
 	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
@@ -2610,7 +2610,7 @@ func TestGetMostRecentL2BtcFinalitiesBFG(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	finalityRequest := bfgapi.BTCFinalityByRecentKeystonesRequest{
 		NumRecentKeystones: 100,

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1552,6 +1552,20 @@ func (s *Server) Run(pctx context.Context) error {
 		return err
 	}
 
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			select {
+			case <-time.After(1 * time.minute):
+				log.Info("sending notifications of l2 keystones")
+				go s.handleL2KeystonesNotification()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	for _, p := range []bool{true, false} {
 		s.wg.Add(1)
 		go s.bitcoinBroadcastWorker(ctx, p)

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	mathRand "math/rand"
 	"net"
 	"net/http"
 	"sync"
@@ -1319,8 +1318,6 @@ func (s *Server) handleL2KeystonesRequest(ctx context.Context, l2kr *bfgapi.L2Ke
 }
 
 func writeNotificationResponse(bws *bfgWs, response any) {
-	r := (mathRand.Int() % (10 * 1000))
-	<-time.After(time.Duration(r) * time.Millisecond)
 	if err := bfgapi.Write(bws.requestContext, bws.conn, "", response); err != nil {
 		log.Errorf("handleBtcFinalityNotification write: %v %v", bws.addr, err)
 	}

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -381,11 +380,9 @@ func (s *Server) bitcoinBroadcastWorker(ctxI context.Context, highPriority bool)
 		_, err = s.btcClient.Broadcast(ctx, serializedTx)
 		if err != nil {
 			log.Errorf("broadcast tx: %s", err)
-			if strings.Contains(err.Error(), "bad-txns-inputs-missingorspent") {
-				err = s.db.BtcTransactionBroadcastRequestSetLastError(ctx, mb.TxID(), err.Error())
-				if err != nil {
-					log.Errorf("could not delete %v", err)
-				}
+			err = s.db.BtcTransactionBroadcastRequestSetLastError(ctx, mb.TxID(), err.Error())
+			if err != nil {
+				log.Errorf("could not delete %v", err)
 			}
 			cancel()
 			continue

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -382,7 +382,7 @@ func (s *Server) bitcoinBroadcastWorker(ctxI context.Context, highPriority bool)
 		if err != nil {
 			log.Errorf("broadcast tx: %s", err)
 			if strings.Contains(err.Error(), "bad-txns-inputs-missingorspent") {
-				err = s.db.BtcTransactionBroadcastRequestDelete(ctx, mb.TxID())
+				err = s.db.BtcTransactionBroadcastRequestSetLastError(ctx, mb.TxID(), err.Error())
 				if err != nil {
 					log.Errorf("could not delete %v", err)
 				}

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -332,7 +332,7 @@ func (s *Server) handleOneBroadcastRequest(ctx context.Context, highPriority boo
 	// if there are no new serialized txs, backoff a bit
 	if serializedTx == nil {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(1 * time.Second):
 			return
 		case <-ctx.Done():
 			return

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	mathRand "math/rand"
 	"net"
 	"net/http"
 	"sync"
@@ -1295,6 +1296,8 @@ func (s *Server) handleL2KeystonesRequest(ctx context.Context, l2kr *bfgapi.L2Ke
 }
 
 func writeNotificationResponse(bws *bfgWs, response any) {
+	r := (mathRand.Int() % (10 * 1000))
+	<-time.After(time.Duration(r) * time.Millisecond)
 	if err := bfgapi.Write(bws.requestContext, bws.conn, "", response); err != nil {
 		log.Errorf("handleBtcFinalityNotification write: %v %v", bws.addr, err)
 	}

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1277,7 +1277,12 @@ func (s *Server) getL2KeystonesCache() []hemi.L2Keystone {
 		return []hemi.L2Keystone{}
 	}
 
-	return s.l2keystonesCache
+	results := []hemi.L2Keystone{}
+	for _, v := range s.l2keystonesCache {
+		results = append(results, v)
+	}
+
+	return results
 }
 
 func (s *Server) refreshL2KeystoneCache(ctx context.Context) {
@@ -1312,8 +1317,17 @@ func (s *Server) handleL2KeystonesRequest(ctx context.Context, l2kr *bfgapi.L2Ke
 	log.Tracef("handleL2KeystonesRequest")
 	defer log.Tracef("handleL2KeystonesRequest exit")
 
+	results := []hemi.L2Keystone{}
+	for i, v := range s.getL2KeystonesCache() {
+		if uint64(i) < l2kr.NumL2Keystones {
+			results = append(results, v)
+		} else {
+			break
+		}
+	}
+
 	return &bfgapi.L2KeystonesResponse{
-		L2Keystones: s.getL2KeystonesCache()[:l2kr.NumL2Keystones],
+		L2Keystones: results,
 	}, nil
 }
 

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1416,6 +1416,8 @@ func (s *Server) handleNewL2Keystones(ctx context.Context, nlkr *bfgapi.NewL2Key
 		return nil, err
 	}
 
+	go s.refreshL2KeystoneCache(ctx)
+
 	return response, nil
 }
 

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -341,6 +341,17 @@ func (s *Server) bitcoinBroadcastWorker(ctxI context.Context, highPriority bool)
 			continue
 		}
 
+		// if there are no new serialized txs, backoff a bit
+		if serializedTx == nil {
+			cancel()
+			select {
+			case <-time.After(5 * time.Second):
+				continue
+			case <-ctxI.Done():
+				return
+			}
+		}
+
 		rr := bytes.NewReader(serializedTx)
 		mb := wire.MsgTx{}
 		if err := mb.Deserialize(rr); err != nil {

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -330,11 +330,7 @@ func (s *Server) bitcoinBroadcastWorker(ctx context.Context, highPriority bool) 
 		default:
 		}
 
-		// being "not high priority" means that we're "retrying" a transaction
-		if !highPriority {
-		}
-
-		serializedTx, err := s.db.BtcTransactionBroadcastRequestGetNext(ctx, true)
+		serializedTx, err := s.db.BtcTransactionBroadcastRequestGetNext(ctx, highPriority)
 		if err != nil {
 			log.Errorf("error getting next broadcast request: %v", err)
 			continue

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -380,6 +381,12 @@ func (s *Server) bitcoinBroadcastWorker(ctxI context.Context, highPriority bool)
 		_, err = s.btcClient.Broadcast(ctx, serializedTx)
 		if err != nil {
 			log.Errorf("broadcast tx: %s", err)
+			if strings.Contains(err.Error(), "bad-txns-inputs-missingorspent") {
+				err = s.db.BtcTransactionBroadcastRequestDelete(ctx, mb.TxID())
+				if err != nil {
+					log.Errorf("could not delete %v", err)
+				}
+			}
 			cancel()
 			continue
 		}

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1611,7 +1611,7 @@ func (s *Server) Run(pctx context.Context) error {
 
 	s.wg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer s.wg.Done()
 		for {
 			select {
 			case <-ctx.Done():

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -347,8 +347,6 @@ func (s *Server) bitcoinBroadcastWorker(ctxI context.Context, highPriority bool)
 			select {
 			case <-time.After(5 * time.Second):
 				continue
-			case <-ctxI.Done():
-				return
 			}
 		}
 

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -149,7 +149,7 @@ func NewServer(cfg *Config) (*Server, error) {
 			Help:      "The total number of succesful RPC commands",
 		}),
 		requestTimeout: defaultRequestTimeout,
-		bfgCallTimeout: defaultRequestTimeout / 2,
+		bfgCallTimeout: 20 * time.Second,
 		holdoffTimeout: 6 * time.Second,
 		requestLimit:   requestLimit,
 		sessions:       make(map[string]*bssWs),


### PR DESCRIPTION
**Summary**
Add a system with a static number of workers to queue/consume bitcoin broadcasts to electrumx

**Changes**
add a db table btc_transaction_broadcast_request that will store broadcast requests.  when someone wants to broadcast a tx, insert into this table (ignoring duplicates).  have a few workers that read from this table and attempt to broadcast transactions to electrumx.

when a worker "checks out" a broadcast request, it updates the last_broadcast_attempt_at column

when a worker confirms a broadcast, it updates the broadcast_at column

wait a random number of  minutes between 1-5 before processing same tx again if not confirmed

don't process txs that are more than 30 minutes hours old

caching l2 keystones response

more efficient finality query