### PR TITLE
added indexes and removed aggregate functions

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,14 +20,14 @@ import (
 )
 
 const (
-	bfgdVersion = 8
+	bfgdVersion = 9
 
 	logLevel = "INFO"
 	verbose  = false
 )
 
 const effectiveHeightSql = `
-	COALESCE((SELECT MIN(height)
+	COALESCE((SELECT height
 
 	FROM 
 	(
@@ -38,6 +38,7 @@ const effectiveHeightSql = `
 				= pop_basis.l2_keystone_abrev_hash
 
 		WHERE ll.l2_block_number >= l2_keystones.l2_block_number
+		ORDER BY height ASC LIMIT 1
 	)), 0)
 `
 
@@ -808,7 +809,7 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 			l2_keystones.ep_hash,
 			l2_keystones.version,
 			%s,
-			COALESCE((SELECT MAX(height) FROM btc_blocks_can),0)
+			COALESCE((SELECT height FROM btc_blocks_can ORDER BY height DESC LIMIT 1),0)
 
 		FROM l2_keystones
 		LEFT JOIN pop_basis ON l2_keystones.l2_keystone_abrev_hash 

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 9;
+
+CREATE INDEX btc_blocks_can_hash_idx ON btc_blocks_can (hash);
+CREATE INDEX btc_blocks_can_height_idx ON btc_blocks_can (height);
+
+COMMIT;


### PR DESCRIPTION
added indexes to btc_blocks_can materialized view, no longer using aggregate functions

**Summary**
performance improvements for l2 keystones by finality

**Changes**
added indexes to btc_blocks_can materialized view, no longer using aggregate functions

without pasting the entire query plan, this reduces the query to the following (a high cost, but fast):
```sql
(cost=19.64..85167.78 rows=394 width=242) (actual time=81.977..81.990 rows=1 loops=1)
```

prior, it was so long that I could not run `analyze`
```sql
 Nested Loop Left Join  (cost=51725.76..472025135.82 rows=394 width=242)
```