### PR TITLE
Add mechanism to recover from forks at runtime

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1100,7 +1100,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 
 	rows, err := p.db.QueryContext(ctx, querySql)
 	if err != nil {
-		return nil, fmt.Errorf("could not get next btc_transaction_broadcast_request: %v", err)
+		return nil, fmt.Errorf("could not get next btc_transaction_broadcast_request: %w", err)
 	}
 
 	defer rows.Close()
@@ -1130,7 +1130,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Contex
 	`
 	_, err := p.db.ExecContext(ctx, querySql, txId)
 	if err != nil {
-		return fmt.Errorf("could not confirm broadcast: %v", err)
+		return fmt.Errorf("could not confirm broadcast: %w", err)
 	}
 
 	return nil
@@ -1146,7 +1146,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestSetLastError(ctx context.Context, t
 	`
 	_, err := p.db.ExecContext(ctx, querySql, txId, lastErr)
 	if err != nil {
-		return fmt.Errorf("could not confirm broadcast: %v", err)
+		return fmt.Errorf("could not confirm broadcast: %w", err)
 	}
 
 	return nil
@@ -1162,7 +1162,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestTrim(ctx context.Context) error {
 	`
 	_, err := p.db.ExecContext(ctx, querySql)
 	if err != nil {
-		return fmt.Errorf("could not trim broadcast: %v", err)
+		return fmt.Errorf("could not trim broadcast: %w", err)
 	}
 
 	return nil

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -61,6 +61,7 @@ type Database interface {
 
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)
+	BlockMissingDelete(ctx context.Context, height int64, hash *chainhash.Hash) error
 	BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error)
 	// BlocksInsert(ctx context.Context, bs []*btcutil.Block) (int64, error)
 	BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error)

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -57,7 +57,7 @@ type Database interface {
 
 	// Block headers
 	BlockHeadersByHeight(ctx context.Context, height uint64) ([]BlockHeader, error)
-	BlockHeadersInsert(ctx context.Context, bhs [][80]byte) (InsertType, *BlockHeader, *BlockHeader, int, error)
+	BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders) (InsertType, *BlockHeader, *BlockHeader, int, error)
 
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)
@@ -380,6 +380,17 @@ func B2H(header []byte) (*wire.BlockHeader, error) {
 		return nil, fmt.Errorf("deserialize block header: %w", err)
 	}
 	return &bh, nil
+}
+
+func H2B(wbh *wire.BlockHeader) [80]byte {
+	var b bytes.Buffer
+	err := wbh.Serialize(&b)
+	if err != nil {
+		panic(err)
+	}
+	var bh [80]byte
+	copy(bh[:], b.Bytes())
+	return bh
 }
 
 // HeaderHash return the block hash from a raw block header.

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -57,7 +57,7 @@ type Database interface {
 
 	// Block headers
 	BlockHeadersByHeight(ctx context.Context, height uint64) ([]BlockHeader, error)
-	BlockHeadersInsert(ctx context.Context, bhs [][80]byte) (InsertType, *BlockHeader, *BlockHeader, error)
+	BlockHeadersInsert(ctx context.Context, bhs [][80]byte) (InsertType, *BlockHeader, *BlockHeader, int, error)
 
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -62,8 +62,7 @@ type Database interface {
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)
 	BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error)
-	// XXX replace BlockInsert with plural version
-	// BlocksInsert(ctx context.Context, bs []*Block) (int64, error)
+	// BlocksInsert(ctx context.Context, bs []*btcutil.Block) (int64, error)
 	BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error)
 
 	// Transactions
@@ -369,45 +368,4 @@ func TxIdBlockHashFromTxKey(txKey TxKey) (*chainhash.Hash, *chainhash.Hash, erro
 		return nil, nil, fmt.Errorf("invalid block hash: %w", err)
 	}
 	return txId, blockHash, nil
-}
-
-// Helper functions
-
-// B2H converts a raw block header to a wire block header structure.
-func B2H(header []byte) (*wire.BlockHeader, error) {
-	var bh wire.BlockHeader
-	if err := bh.Deserialize(bytes.NewReader(header)); err != nil {
-		return nil, fmt.Errorf("deserialize block header: %w", err)
-	}
-	return &bh, nil
-}
-
-func H2B(wbh *wire.BlockHeader) [80]byte {
-	var b bytes.Buffer
-	err := wbh.Serialize(&b)
-	if err != nil {
-		panic(err)
-	}
-	var bh [80]byte
-	copy(bh[:], b.Bytes())
-	return bh
-}
-
-// HeaderHash return the block hash from a raw block header.
-func HeaderHash(header []byte) *chainhash.Hash {
-	h, err := B2H(header)
-	if err != nil {
-		panic(err)
-	}
-	hash := h.BlockHash()
-	return &hash
-}
-
-// HeaderHash return the parent block hash from a raw block header.
-func HeaderParentHash(header []byte) *chainhash.Hash {
-	h, err := B2H(header)
-	if err != nil {
-		panic(err)
-	}
-	return &h.PrevBlock
 }

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -53,7 +53,7 @@ type Database interface {
 	// Block header
 	BlockHeaderBest(ctx context.Context) (*BlockHeader, error) // return canonical
 	BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*BlockHeader, error)
-	BlockHeaderGenesisInsert(ctx context.Context, bh [80]byte) error
+	BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader) error
 
 	// Block headers
 	BlockHeadersByHeight(ctx context.Context, height uint64) ([]BlockHeader, error)

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -744,7 +744,7 @@ func (l *ldb) BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.B
 	}
 	b, err := btcutil.NewBlockFromBytes(eb)
 	if err != nil {
-		return nil, fmt.Errorf("block decode: %w", err)
+		panic(fmt.Errorf("block decode data corruption: %w", err))
 	}
 	if l.cfg.BlockCache > 0 {
 		l.blockCache.Add(string(hash[:]), b)

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -723,6 +723,21 @@ func (l *ldb) BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error) 
 	return int64(bh.Height), nil
 }
 
+func (l *ldb) BlockMissingDelete(ctx context.Context, height int64, hash *chainhash.Hash) error {
+	log.Tracef("BlockMissingDelete")
+	defer log.Tracef("BlockMissingDelete exit")
+
+	key := heightHashToKey(uint64(height), hash[:])
+	bmDB := l.pool[level.BlocksMissingDB]
+	if err := bmDB.Delete(key, nil); err != nil {
+		// Ignore not found, it was deleted prior to this call.
+		if !errors.Is(err, leveldb.ErrNotFound) {
+			return fmt.Errorf("block missing delete: %w", err)
+		}
+	}
+	return nil
+}
+
 func (l *ldb) BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error) {
 	log.Tracef("BlockByHash")
 	defer log.Tracef("BlockByHash exit")

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -469,11 +469,10 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders) (tbc
 			return tbcd.ITInvalid, nil, nil, 0,
 				fmt.Errorf("block headers insert has: %w", err)
 		}
-		if has {
-			x++
-		} else {
+		if !has {
 			break
 		}
+		x++
 	}
 	bhs.Headers = bhs.Headers[x:]
 	if len(bhs.Headers) == 0 {

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -95,8 +95,8 @@ func b2h(header []byte) (*wire.BlockHeader, error) {
 	return &bh, nil
 }
 
-// HeaderHash return the block hash from a raw block header.
-func HeaderHash(header []byte) *chainhash.Hash {
+// headerHash return the block hash from a raw block header.
+func headerHash(header []byte) *chainhash.Hash {
 	h, err := b2h(header)
 	if err != nil {
 		panic(err)
@@ -330,7 +330,7 @@ func encodeBlockHeader(height uint64, header [80]byte, difficulty *big.Int) (ebh
 // XXX should we have a function that does not call the expensive headerHash function?
 func decodeBlockHeader(ebh []byte) *tbcd.BlockHeader {
 	bh := &tbcd.BlockHeader{
-		Hash:   HeaderHash(ebh[8:88]),
+		Hash:   headerHash(ebh[8:88]),
 		Height: binary.BigEndian.Uint64(ebh[0:8]),
 	}
 	// copy the values to prevent slicing reentrancy problems.

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -563,6 +563,7 @@ func (s *Server) UtxoIndexerWind(ctx context.Context, startBH, endBH *tbcd.Block
 		if err = s.db.BlockUtxoUpdate(ctx, 1, utxos); err != nil {
 			return fmt.Errorf("block tx update: %w", err)
 		}
+
 		// leveldb does all kinds of allocations, force GC to lower
 		// memory preassure.
 		logMemStats()
@@ -1111,7 +1112,7 @@ func (s *Server) IndexIsLinear(ctx context.Context, startHash, endHash *chainhas
 		return 0, ErrNotLinear
 	}
 	for {
-		//log.Infof("sod %v %v", x, h)
+		// log.Infof("sod %v %v", x, h)
 		bh, err := s.db.BlockHeaderByHash(ctx, h)
 		if err != nil {
 			return -1, fmt.Errorf("block header by hash: %w", err)
@@ -1180,7 +1181,6 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 		}
 	}()
 
-	log.Infof("Syncing indexes to: %v", hash)
 	log.Debugf("Syncing indexes to: %v", hash)
 
 	// UTXOs

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1147,7 +1147,7 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 		// unquiesce
 		s.mtx.Lock()
 		s.quiesced = false
-		actualHeight, bhb, err := s.RawBlockHeaderBest(ctx)
+		bhb, err := s.db.BlockHeaderBest(ctx)
 		if err != nil {
 			s.mtx.Unlock()
 			log.Errorf("sync indexers best: %v", err)
@@ -1166,10 +1166,8 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 		// continue getting headers, XXX this does not belong here either
 		// XXX if bh download fails we will get jammed. We need a queued "must execute this command" added to peer/service.
 		// XXX we may not want to do this when in special "driver mode"
-		log.Infof("resuming block header download at: %v", actualHeight)
-		var bh [80]byte
-		copy(bh[:], bhb)
-		if err = s.getHeaders(ctx, p, bh); err != nil {
+		log.Infof("resuming block header download at: %v", bhb.Height)
+		if err = s.getHeaders(ctx, p, bhb.BlockHash()); err != nil {
 			log.Errorf("sync indexers: %v", err)
 			return
 		}

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1092,18 +1092,16 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 	defer log.Tracef("SyncIndexersToHash exit")
 
 	s.mtx.Lock()
-	if s.indexing {
+	if s.quiesced {
 		s.mtx.Unlock()
 		return errors.New("already indexing")
 	}
-	s.indexing = true
 	s.mtx.Unlock()
 
 	defer func() {
 		// unquiesce
 		s.mtx.Lock()
 		s.quiesced = false
-		s.indexing = false
 		actualHeight, bhb, err := s.RawBlockHeaderBest(ctx)
 		if err != nil {
 			log.Errorf("sync indexers best: %v", err)

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -470,8 +470,9 @@ func (s *Server) UtxoIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Blo
 
 	// XXX dedup with TxIndexedWind; it's basically the same code but with the direction, start anf endhas flipped
 	s.mtx.Lock()
-	if !s.quiesced {
+	if s.quiesced {
 		// XXX this prob should be an error but pusnish bad callers for now
+		s.mtx.Unlock()
 		panic("UtxoIndexerUnwind not quiesced")
 	}
 	s.mtx.Unlock()
@@ -529,8 +530,9 @@ func (s *Server) UtxoIndexerWind(ctx context.Context, startBH, endBH *tbcd.Block
 	defer log.Tracef("UtxoIndexerWind exit")
 
 	s.mtx.Lock()
-	if !s.quiesced {
+	if s.quiesced {
 		// XXX this prob should be an error but pusnish bad callers for now
+		s.mtx.Unlock()
 		panic("UtxoIndexerWind not quiesced")
 	}
 	s.mtx.Unlock()
@@ -588,8 +590,9 @@ func (s *Server) UtxoIndexer(ctx context.Context, endHash *chainhash.Hash) error
 	defer log.Tracef("UtxoIndexer exit")
 
 	s.mtx.Lock()
-	if !s.quiesced {
+	if s.quiesced {
 		// XXX this prob should be an error but pusnish bad callers for now
+		s.mtx.Unlock()
 		panic("UtxoIndexer not quiesced")
 	}
 	s.mtx.Unlock()
@@ -849,8 +852,9 @@ func (s *Server) TxIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Block
 	// XXX dedup with TxIndexedWind; it's basically the same code but with the direction, start anf endhas flipped
 
 	s.mtx.Lock()
-	if !s.quiesced {
+	if s.quiesced {
 		// XXX this prob should be an error but pusnish bad callers for now
+		s.mtx.Unlock()
 		panic("TxIndexerUnwind not quiesced")
 	}
 	s.mtx.Unlock()
@@ -907,8 +911,9 @@ func (s *Server) TxIndexerWind(ctx context.Context, startBH, endBH *tbcd.BlockHe
 	defer log.Tracef("TxIndexerWind exit")
 
 	s.mtx.Lock()
-	if !s.quiesced {
+	if s.quiesced {
 		// XXX this prob should be an error but pusnish bad callers for now
+		s.mtx.Unlock()
 		panic("TxIndexerWind not quiesced")
 	}
 	s.mtx.Unlock()
@@ -969,8 +974,9 @@ func (s *Server) TxIndexer(ctx context.Context, endHash *chainhash.Hash) error {
 	// XXX this is basically duplicate from TxIndexIsLinear
 
 	s.mtx.Lock()
-	if !s.quiesced {
+	if s.quiesced {
 		// XXX this prob should be an error but pusnish bad callers for now
+		s.mtx.Unlock()
 		panic("TxIndexer not quiesced")
 	}
 	s.mtx.Unlock()
@@ -1143,15 +1149,15 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 		s.quiesced = false
 		actualHeight, bhb, err := s.RawBlockHeaderBest(ctx)
 		if err != nil {
-			log.Errorf("sync indexers best: %v", err)
 			s.mtx.Unlock()
+			log.Errorf("sync indexers best: %v", err)
 			return
 		}
 		// get a random peer
 		p, err := s.randomPeer(ctx)
 		if err != nil {
-			log.Errorf("sync indexers random peer: %v", err)
 			s.mtx.Unlock()
+			log.Errorf("sync indexers random peer: %v", err)
 			return
 		}
 		s.mtx.Unlock()

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1112,7 +1112,7 @@ func (s *Server) IndexIsLinear(ctx context.Context, startHash, endHash *chainhas
 		return 0, ErrNotLinear
 	}
 	for {
-		log.Infof("sod %v", h)
+		log.Debugf("sod %v", h)
 		bh, err := s.db.BlockHeaderByHash(ctx, h)
 		if err != nil {
 			return -1, fmt.Errorf("block header by hash: %w", err)

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -197,7 +197,7 @@ func (s *Server) unprocessUtxos(ctx context.Context, txs []*btcutil.Tx, utxos ma
 				txIn.PreviousOutPoint.Index)
 			pkScript, value, err := s.scriptValue(ctx, op)
 			if err != nil {
-				return fmt.Errorf("script value: %v", err)
+				return fmt.Errorf("script value: %w", err)
 			}
 			// XXX this should not happen. We are keeping it for
 			// now to ensure it indeed does not happen. Remove in a
@@ -627,7 +627,7 @@ func (s *Server) UtxoIndexer(ctx context.Context, endHash *chainhash.Hash) error
 	}
 	direction, err := s.UtxoIndexIsLinear(ctx, endHash)
 	if err != nil {
-		return fmt.Errorf("UtxoIndexIsLinear: %w", err)
+		return fmt.Errorf("utxo index is linear: %w", err)
 	}
 	switch direction {
 	case 1:
@@ -1010,7 +1010,7 @@ func (s *Server) TxIndexer(ctx context.Context, endHash *chainhash.Hash) error {
 	}
 	direction, err := s.TxIndexIsLinear(ctx, endHash)
 	if err != nil {
-		return fmt.Errorf("TxIndexIsLinear: %w", err)
+		return fmt.Errorf("tx index is linear: %w", err)
 	}
 	switch direction {
 	case 1:
@@ -1117,13 +1117,13 @@ func (s *Server) IndexIsLinear(ctx context.Context, startHash, endHash *chainhas
 		if err != nil {
 			return -1, fmt.Errorf("block header by hash: %w", err)
 		}
-		//bhs, err := s.db.BlockHeadersByHeight(ctx, bh.Height)
-		//if err != nil {
+		// bhs, err := s.db.BlockHeadersByHeight(ctx, bh.Height)
+		// if err != nil {
 		//	return -1, fmt.Errorf("block header by height: %w", err)
-		//}
-		//if len(bhs) != 1 {
+		// }
+		// if len(bhs) != 1 {
 		//	panic(fmt.Sprintf("%v", spew.Sdump(bhs)))
-		//}
+		// }
 		h = bh.ParentHash()
 		if h.IsEqual(e) {
 			return direction, nil

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -379,7 +379,7 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 	return blocksProcessed, last, nil
 }
 
-// unindexUtxosInBlocks unindexes iutxos from the last processed block until the
+// unindexUtxosInBlocks unindexes utxos from the last processed block until the
 // provided end hash, inclusive. It returns the number of blocks processed and
 // the last hash it has processedd.
 func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash, utxos map[tbcd.Outpoint]tbcd.CacheOutput) (int, *HashHeight, error) {

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -379,7 +379,7 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 	return blocksProcessed, last, nil
 }
 
-// unindexUTxosInBlocks unindexes txs from the last processed block until the
+// unindexUtxosInBlocks unindexes iutxos from the last processed block until the
 // provided end hash, inclusive. It returns the number of blocks processed and
 // the last hash it has processedd.
 func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash, utxos map[tbcd.Outpoint]tbcd.CacheOutput) (int, *HashHeight, error) {

--- a/service/tbc/peer.go
+++ b/service/tbc/peer.go
@@ -135,6 +135,8 @@ func (p *peer) handshake(ctx context.Context, conn net.Conn) error {
 
 		switch msg.(type) {
 		case *wire.MsgVerAck:
+			log.Debugf("handshake: %v %v %v %v",
+				p, v.UserAgent, v.ProtocolVersion, v.LastBlock)
 			return nil
 		case *wire.MsgSendAddrV2:
 			p.addrV2 = true

--- a/service/tbc/peer.go
+++ b/service/tbc/peer.go
@@ -62,14 +62,19 @@ func (p *peer) String() string {
 
 func (p *peer) write(timeout time.Duration, msg wire.Message) error {
 	p.conn.SetWriteDeadline(time.Now().Add(timeout))
+	// XXX contexts would be nice
 	_, err := wire.WriteMessageWithEncodingN(p.conn, msg, p.protocolVersion,
 		p.network, wire.LatestEncoding)
 	return err
 }
 
-func (p *peer) read() (wire.Message, error) {
+func (p *peer) read(timeout time.Duration) (wire.Message, error) {
+	if timeout == 0 {
+		p.conn.SetReadDeadline(time.Time{}) // never timeout on reads
+	} else {
+		p.conn.SetReadDeadline(time.Now().Add(timeout))
+	}
 	// XXX contexts would be nice
-	p.conn.SetReadDeadline(time.Time{}) // never timeout on reads
 	_, msg, _, err := wire.ReadMessageWithEncodingN(p.conn, p.protocolVersion,
 		p.network, wire.LatestEncoding)
 	return msg, err

--- a/service/tbc/peer.go
+++ b/service/tbc/peer.go
@@ -68,16 +68,16 @@ func (p *peer) write(timeout time.Duration, msg wire.Message) error {
 	return err
 }
 
-func (p *peer) read(timeout time.Duration) (wire.Message, error) {
+func (p *peer) read(timeout time.Duration) (wire.Message, []byte, error) {
 	if timeout == 0 {
 		p.conn.SetReadDeadline(time.Time{}) // never timeout on reads
 	} else {
 		p.conn.SetReadDeadline(time.Now().Add(timeout))
 	}
 	// XXX contexts would be nice
-	_, msg, _, err := wire.ReadMessageWithEncodingN(p.conn, p.protocolVersion,
+	_, msg, buf, err := wire.ReadMessageWithEncodingN(p.conn, p.protocolVersion,
 		p.network, wire.LatestEncoding)
-	return msg, err
+	return msg, buf, err
 }
 
 func (p *peer) handshake(ctx context.Context, conn net.Conn) error {

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -5,6 +5,7 @@
 package tbc
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -26,6 +27,15 @@ import (
 	"github.com/hemilabs/heminetwork/database"
 	"github.com/hemilabs/heminetwork/database/tbcd/level"
 )
+
+func tx2Bytes(tx *wire.MsgTx) ([]byte, error) {
+	var b bytes.Buffer
+	if err := tx.Serialize(&b); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
 
 type tbcWs struct {
 	wg             sync.WaitGroup

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -121,7 +121,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Logf(spew.Sdump(bh))
+	t.Log(spew.Sdump(bh))
 
 	if response.Error != nil {
 		t.Errorf("got unwanted error: %v", response.Error)
@@ -311,7 +311,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Logf(spew.Sdump(bh))
+	t.Log(spew.Sdump(bh))
 
 	if response.Error != nil {
 		t.Errorf("got unwanted error: %v", response.Error)

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -5,14 +5,17 @@
 package tbc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/davecgh/go-spew/spew"
@@ -25,6 +28,41 @@ import (
 	"github.com/hemilabs/heminetwork/api/tbcapi"
 	"github.com/hemilabs/heminetwork/bitcoin"
 )
+
+func bytes2Tx(b []byte) (*wire.MsgTx, error) {
+	var w wire.MsgTx
+	if err := w.Deserialize(bytes.NewReader(b)); err != nil {
+		return nil, err
+	}
+
+	return &w, nil
+}
+
+func header2Slice(wbh *wire.BlockHeader) ([]byte, error) {
+	var b bytes.Buffer
+	err := wbh.Serialize(&b)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func header2Array(wbh *wire.BlockHeader) ([80]byte, error) {
+	sb, err := header2Slice(wbh)
+	if err != nil {
+		return [80]byte{}, err
+	}
+	return [80]byte(sb), nil
+}
+
+func slice2Header(header []byte) (*wire.BlockHeader, error) {
+	var bh wire.BlockHeader
+	err := bh.Deserialize(bytes.NewReader(header[:]))
+	if err != nil {
+		return nil, fmt.Errorf("deserialize block header: %w", err)
+	}
+	return &bh, nil
+}
 
 func TestBlockHeadersByHeightRaw(t *testing.T) {
 	skipIfNoDocker(t)

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1509,11 +1509,7 @@ func indexAll(ctx context.Context, t *testing.T, tbcServer *Server) {
 
 	hash := bh.BlockHash()
 
-	if err := tbcServer.TxIndexer(ctx, &hash); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := tbcServer.UtxoIndexer(ctx, &hash); err != nil {
+	if err := tbcServer.SyncIndexersToHash(ctx, &hash); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1204,7 +1204,6 @@ func (s *Server) handleHeaders(ctx context.Context, p *peer, msg *wire.MsgHeader
 	// There really is no good way of determining if we can escape the
 	// expensive calls so we just eat it.
 	var pbhHash *chainhash.Hash
-	headers := make([][80]byte, len(msg.Headers))
 	for k := range msg.Headers {
 		if pbhHash != nil && pbhHash.IsEqual(&msg.Headers[k].PrevBlock) {
 			log.Errorf("cannot connect %v index %v",
@@ -1212,11 +1211,9 @@ func (s *Server) handleHeaders(ctx context.Context, p *peer, msg *wire.MsgHeader
 			p.close() // get rid of this misbehaving peer
 			return
 		}
-
-		copy(headers[k][0:80], h2b(msg.Headers[k])) // XXX don't double copy
 		pbhHash = &msg.Headers[k].PrevBlock
 	}
-	it, cbh, lbh, n, err := s.db.BlockHeadersInsert(ctx, headers)
+	it, cbh, lbh, n, err := s.db.BlockHeadersInsert(ctx, msg)
 	if err != nil {
 		// This ends the race between peers during IBD.
 		if errors.Is(database.ErrDuplicate, err) {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1398,7 +1398,6 @@ func (s *Server) handlePong(ctx context.Context, p *peer, pong *wire.MsgPong) er
 }
 
 func (s *Server) downloadBlock(ctx context.Context, p *peer, ch *chainhash.Hash) error {
-	log.Infof("downloadBlock %v %v", p, ch)
 	log.Tracef("downloadBlock")
 	defer log.Tracef("downloadBlock exit")
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1012,7 +1012,7 @@ func (s *Server) handleAddr(_ context.Context, p *peer, msg *wire.MsgAddr) error
 	}
 
 	if err := s.pm.PeersInsert(peers); err != nil {
-		return fmt.Errorf("Insert peers: %w", err)
+		return fmt.Errorf("insert peers: %w", err)
 	}
 
 	return nil

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1033,7 +1033,7 @@ func (s *Server) handleAddrV2(_ context.Context, p *peer, msg *wire.MsgAddrV2) e
 	}
 
 	if err := s.pm.PeersInsert(peers); err != nil {
-		return fmt.Errorf("Insert peers: %w", err)
+		return fmt.Errorf("insert peers: %w", err)
 	}
 
 	return nil

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1527,7 +1527,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 		}
 		go func() {
 			if err = s.SyncIndexersToHash(ctx, bhb.BlockHash()); err != nil {
-				log.Errorf("sync blocks: %v", err)
+				panic(fmt.Errorf("sync blocks: %v", err))
 				return
 			}
 		}()

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1033,13 +1033,12 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 	}
 
 	// First one here sets sodComplete
-	once := sync.OnceFunc(func() {
+	s.mtx.Lock()
+	if !s.soddingComplete {
 		log.Infof("SOD complete")
-		s.mtx.Lock()
-		s.soddingComplete = true
-		s.mtx.Unlock()
-	})
-	once()
+	}
+	s.soddingComplete = true
+	s.mtx.Unlock()
 
 	// Only now can we consider the peer connected
 	log.Debugf("Peer connected: %v", p)

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -687,6 +687,11 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 
 	// Before we can consider a peer connected we must ensure we receive
 	// headers and ensure we are not sitting on a fork.
+
+	// XXX I truly hate having two main loops. We need to create a
+	// start-of-day function where we connect to 3 or so peers and then we
+	// reconcile potential forks at startup. Once that phase is complete we
+	// go into the main loop.
 	for headersSeen := false; !headersSeen; {
 		// See if we were interrupted, for the love of pete add ctx to wire
 		select {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1359,7 +1359,7 @@ func (s *Server) handleBlock(ctx context.Context, p *peer, msg *wire.MsgBlock, r
 		err := blockchain.CheckBlockSanity(block, s.chainParams.PowLimit,
 			s.timeSource)
 		if err != nil {
-			return fmt.Errorf("handle block unable to validate block hash %v: %v",
+			return fmt.Errorf("handle block unable to validate block hash %v: %w",
 				bhs, err)
 		}
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1275,7 +1275,7 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 			// This seems to resolve itself when we restart because
 			// then we resume where we were at.
 			s.mtx.Unlock()
-			log.Infof("indexing %v", s.indexing)
+			//log.Infof("indexing %v", s.indexing)
 			// log.Infof("indexing %v sodding %v soddingComplete %v",
 			//	s.indexing, s.sodding, s.soddingComplete)
 			continue

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -602,7 +602,7 @@ func (s *Server) pollP2P(ctx context.Context, d time.Duration, p *peer, cmd wire
 		default:
 		}
 
-		delta := d - time.Now().Sub(start)
+		delta := d - time.Since(start)
 		if delta <= 0 {
 			return nil, errors.New("poll p2p: timeout")
 		}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1206,7 +1206,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 		go func() {
 			if err = s.SyncIndexersToHash(ctx, bhb.BlockHash()); err != nil {
 				// XXX this a panic?
-				panic(fmt.Errorf("sync blocks: %v", err))
+				panic(fmt.Errorf("sync blocks: %w", err))
 			}
 		}()
 		return

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1287,7 +1287,7 @@ func (s *Server) handleHeaders(ctx context.Context, p *peer, msg *wire.MsgHeader
 			return nil
 		}
 		// Real error, abort header fetch
-		return fmt.Errorf("block headers insert: %v", err)
+		return fmt.Errorf("block headers insert: %w", err)
 	}
 
 	// Note that BlockHeadersInsert always returns the canonical

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1268,7 +1268,7 @@ func (s *Server) handleHeaders(ctx context.Context, p *peer, msg *wire.MsgHeader
 	it, cbh, lbh, n, err := s.db.BlockHeadersInsert(ctx, msg)
 	if err != nil {
 		// This ends the race between peers during IBD.
-		if errors.Is(database.ErrDuplicate, err) {
+		if errors.Is(err, database.ErrDuplicate) {
 			// XXX for now don't do parallel blockheader downloads.
 			// Seems to really slow the process down.
 			//

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -901,14 +901,18 @@ func (s *Server) sod(ctx context.Context, p *peer) (*chainhash.Hash, error) {
 		return nil, fmt.Errorf("find canonical: %v %v", p, err)
 	}
 	if hash.IsEqual(bhb.Hash) {
-		// Found self, utxo index is on canonical chain.
+		// Found self, on canonical chain.
 		return bhb.Hash, nil
 	}
-
-	log.Infof("sod: %v", p.remoteVersion.LastBlock)
+	if bhb.Height > uint64(p.remoteVersion.LastBlock) {
+		// XXX debug
+		// XXX should we look at cumulative difficulty?
+		// XXX unwind indexes?
+		log.Infof("sod: %v our tip is greater %v > %v",
+			p, bhb.Height, p.remoteVersion.LastBlock)
+		return bhb.Hash, nil
+	}
 	log.Infof("tip not canonical: %v %v common: %v", bhb.Height, bhb, hash)
-
-	// XXX we probably should delete all orphaned block headers from missing db.
 
 	return hash, nil
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -40,8 +40,6 @@ import (
 	"github.com/hemilabs/heminetwork/ttl"
 )
 
-type phase int
-
 const (
 	logLevel = "INFO"
 
@@ -58,14 +56,6 @@ const (
 	defaultCmdTimeout          = 4 * time.Second
 	defaultPingTimeout         = 3 * time.Second
 	defaultBlockPendingTimeout = 13 * time.Second
-
-	// Phase transitions 0 -> 1 -> 2 -> 3
-	// Once we reach phase 3 we go back and forth between 3 and 4
-	phaseStartOfDay      phase = 0 // tbc launched, no peers
-	phaseFixingUpIndexes phase = 1 // verify indexes are canonical
-	phaseFixingUpTip     phase = 2 // verify canonical tip
-	phaseRunning         phase = 3 // fully running
-	phaseIndexing        phase = 4 // fully running + indexing
 )
 
 var (
@@ -94,22 +84,6 @@ var log = loggo.GetLogger("tbc")
 
 func init() {
 	loggo.ConfigureLoggers(logLevel)
-}
-
-func (p phase) String() string {
-	switch p {
-	case phaseStartOfDay:
-		return "start of day"
-	case phaseFixingUpIndexes:
-		return "fixing up indexes"
-	case phaseFixingUpTip:
-		return "fixing up canonical tip"
-	case phaseRunning:
-		return "running"
-	case phaseIndexing:
-		return "indexing"
-	}
-	return "invalid"
 }
 
 type Config struct {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -202,8 +202,7 @@ type Server struct {
 	blocks *ttl.TTL // outstanding block downloads [hash]when/where
 	pings  *ttl.TTL // outstanding pings
 
-	quiesced bool // when set do not accept blockheaders and/or blocks.
-	indexing bool // prevent re-entrant indexing
+	quiesced bool // when set do not accept blockheaders and/or blocks and prevent indexing.
 
 	db tbcd.Database
 
@@ -732,8 +731,6 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 			continue
 
 		case *wire.MsgHeaders:
-			// XXX we must be past this step before coming "online"
-			// start with indexing and quiesced set to true
 			if len(m.Headers) > 0 {
 				// We must check the initial get headers
 				// response. If we asked for an unknown tip
@@ -1111,7 +1108,7 @@ func (s *Server) handleHeaders(ctx context.Context, p *peer, msg *wire.MsgHeader
 	if err != nil {
 		// This ends the race between peers during IBD.
 		if errors.Is(database.ErrDuplicate, err) {
-			// XXX for now don't do paralle blockheader downloads.
+			// XXX for now don't do parallel blockheader downloads.
 			// Seems to really slow the process down.
 			//
 			// We already have these headers. Ask for best headers

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -943,8 +943,8 @@ func (s *Server) peerConnect(ctx context.Context, peerC chan string, p *peer) {
 		// When quiesced do not handle other p2p commands.
 		s.mtx.Lock()
 		if s.indexing {
-			s.mtx.Unlock()
 			log.Debugf("indexing %v", s.indexing)
+			s.mtx.Unlock()
 			continue
 		}
 		s.mtx.Unlock()

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -726,7 +726,7 @@ func runBitcoinCommand(ctx context.Context, t *testing.T, bitcoindContainer test
 	if err != nil {
 		return "", err
 	}
-	t.Logf(buf.String())
+	t.Log(buf.String())
 
 	if exitCode != 0 {
 		return "", fmt.Errorf("error code received: %d", exitCode)
@@ -938,7 +938,7 @@ func cliBlockHeaderToWire(t *testing.T, header *BtcCliBlockHeader) *wire.BlockHe
 // the raw byte representation of the block header.
 func cliBlockHeaderToRaw(t *testing.T, cliBlockHeader *BtcCliBlockHeader) []api.ByteSlice {
 	blockHeader := cliBlockHeaderToWire(t, cliBlockHeader)
-	t.Logf(spew.Sdump(blockHeader))
+	t.Log(spew.Sdump(blockHeader))
 
 	bytes, err := header2Slice(blockHeader)
 	if err != nil {
@@ -952,7 +952,7 @@ func cliBlockHeaderToRaw(t *testing.T, cliBlockHeader *BtcCliBlockHeader) []api.
 // the [tbcapi.BlockHeader] representation of the block header.
 func cliBlockHeaderToTBC(t *testing.T, btcCliBlockHeader *BtcCliBlockHeader) []*tbcapi.BlockHeader {
 	blockHeader := cliBlockHeaderToWire(t, btcCliBlockHeader)
-	t.Logf(spew.Sdump(blockHeader))
+	t.Log(spew.Sdump(blockHeader))
 	return wireBlockHeadersToTBC([]*wire.BlockHeader{blockHeader})
 }
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -416,7 +416,7 @@ func (b *btcNode) handleRPC(ctx context.Context, conn net.Conn) error {
 		default:
 		}
 
-		msg, err := p.read()
+		msg, err := p.read(5 * time.Second)
 		if err != nil {
 			if errors.Is(err, wire.ErrUnknownMessage) {
 				// ignore unknown

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -46,7 +46,7 @@ func newBlock(params *chaincfg.Params, name string, b *btcutil.Block) *block {
 	}
 	err := processTxs(b.Hash(), b.Transactions(), blk.txs)
 	if err != nil {
-		panic(fmt.Errorf("processTxs: %v", err))
+		panic(fmt.Errorf("processTxs: %w", err))
 	}
 
 	return blk

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -416,7 +416,7 @@ func (b *btcNode) handleRPC(ctx context.Context, conn net.Conn) error {
 		default:
 		}
 
-		msg, err := p.read(5 * time.Second)
+		msg, _, err := p.read(5 * time.Second)
 		if err != nil {
 			if errors.Is(err, wire.ErrUnknownMessage) {
 				// ignore unknown

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1224,6 +1224,7 @@ func TestIndexNoFork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_ = si
 	// t.Logf("%v: %v", b1.b.Transactions()[0].Hash(), spew.Sdump(si))
 	si, err = s.SpentOutputsByTxId(ctx, b2.b.Transactions()[1].Hash())
 	if err != nil {

--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -9,9 +9,20 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	"github.com/juju/loggo"
 )
 
-var ErrNotFound = errors.New("not found")
+var (
+	logLevel = "INFO"
+	log      = loggo.GetLogger("ttl")
+
+	ErrNotFound = errors.New("not found")
+)
+
+func init() {
+	loggo.ConfigureLoggers(logLevel)
+}
 
 // value wraps a value stored in the TTL map and includes additional metadata.
 type value struct {
@@ -66,8 +77,8 @@ func (tm *TTL) ttl(ctx context.Context, key any) {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		// expired
+		v.timeoutExpired = true
 		if v.expired != nil {
-			v.timeoutExpired = true
 			go v.expired(key, v.value)
 		}
 

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-func callback(key any, value any) {
+func callback(ctx context.Context, key any, value any) {
 	v, ok := value.(*sync.WaitGroup)
 	if !ok {
 		panic(fmt.Sprintf("invalid value type: %T", value))
@@ -23,7 +23,7 @@ func callback(key any, value any) {
 	v.Done()
 }
 
-func callbackPanic(key any, value any) {
+func callbackPanic(ctx context.Context, key any, value any) {
 	panic(fmt.Sprintf("unexpected callback: %v", spew.Sdump(key)))
 }
 


### PR DESCRIPTION
**Summary**
During runtime we quiesce p2p when indexing to prevent index corruption. When tbc unquiesces several p2p commands may have happened, including a forking event, which wasn't tracked. When tbc tries to recover it may end up with a chain geometry it currently cannot process.

**Changes**
- Remove index flag and overload that into the quiesce flag
- Add a function that can determine the common ancestor between two blocks.
- Add a function that determines the current chain state and unwinds indexes to a common ancestor and then winds them back to tip.