### PR TITLE
goreleaser: fix typo in release repo name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -497,7 +497,7 @@ changelog:
 release:
   github:
     owner: "hemilabs"
-    name: "network"
+    name: "heminetwork"
   replace_existing_draft: true
   prerelease: "auto"
   make_latest: true


### PR DESCRIPTION
**Summary**
Fix repository name in GoReleaser config (`hemilabs/network` -> `hemilabs/heminetwork`).

**Changes**
- Change `release.github.name` to `heminetwork` in `.goreleaser.yaml`.