### PR TITLE
popm/wasm: add automatic fees

### DIFF
--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -105,6 +105,29 @@ func TestNewMiner(t *testing.T) {
 	}
 }
 
+func TestFees(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.StaticFee = 5
+	cfg.BTCPrivateKey = "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641"
+
+	m, err := NewMiner(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create new miner: %v", err)
+	}
+
+	// Make sure that the static fee is used.
+	if m.Fee() != cfg.StaticFee {
+		t.Errorf("got fee %d, want %d", m.Fee(), cfg.StaticFee)
+	}
+
+	// Make sure the fee can be changed with SetFee.
+	const newFee = 8
+	m.SetFee(newFee)
+	if m.Fee() != newFee {
+		t.Errorf("got fee %d, want %d", m.Fee(), newFee)
+	}
+}
+
 // TestProcessReceivedKeystones ensures that we store the latest keystone
 // correctly as well as data stored in slices within the struct
 func TestProcessReceivedKeystones(t *testing.T) {

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -332,6 +332,17 @@ export declare function removeEventListener(
 ): Promise<void>;
 
 /**
+ * The type of recommended fee to use when doing automatic fees using
+ * the mempool.space REST API.
+ */
+export type RecommendedFeeType =
+  | 'fastest'
+  | 'halfHour'
+  | 'hour'
+  | 'economy'
+  | 'minimum';
+
+/**
  * @see startPoPMiner
  */
 export type MinerStartArgs = {
@@ -359,7 +370,22 @@ export type MinerStartArgs = {
   logLevel?: string;
 
   /**
-   * The number of stats/vB the PoP Miner will pay for fees.
+   * Whether to do automatic fee estimation using the mempool.space API.
+   * Defaults to true. If disabled, then only the staticFee will be used.
+   *
+   * When the value is true, the 'economy' recommended fee type will be used.
+   */
+  automaticFees?: boolean | RecommendedFeeType;
+
+  /**
+   * The duration between refreshing recommended fee data from the
+   * mempool.space API, in seconds. Defaults to 300 seconds (5 minutes).
+   */
+  automaticFeeRefreshSeconds?: number;
+
+  /**
+   * The number of sats/vB the PoP Miner will pay for fees. If automaticFees
+   * is enabled, then this will be used as a fallback fee value.
    */
   staticFee: number;
 };
@@ -392,6 +418,11 @@ export type MinerStatusResult = {
    * Whether the PoP miner is currently connected to a BFG server.
    */
   readonly connected: boolean;
+
+  /**
+   * The current fee used by the PoP miner for PoP transactions, in sats/vB.
+   */
+  readonly fee: number;
 };
 
 /**

--- a/web/popminer/api.go
+++ b/web/popminer/api.go
@@ -7,6 +7,8 @@
 package main
 
 import (
+	"fmt"
+	"strings"
 	"syscall/js"
 
 	"github.com/hemilabs/heminetwork/service/popm"
@@ -140,6 +142,36 @@ type BitcoinAddressToScriptHashResult struct {
 	ScriptHash string `json:"scriptHash"`
 }
 
+// RecommendedFeeType is the type of recommended fee to use when doing automatic
+// fees using the mempool.space REST API.
+type RecommendedFeeType string
+
+const (
+	RecommendedFeeTypeFastest  RecommendedFeeType = "fastest"
+	RecommendedFeeTypeHalfHour RecommendedFeeType = "halfHour"
+	RecommendedFeeTypeHour     RecommendedFeeType = "hour"
+	RecommendedFeeTypeEconomy  RecommendedFeeType = "economy"
+	RecommendedFeeTypeMinimum  RecommendedFeeType = "minimum"
+)
+
+// ParseRecommendedFeeType parses the given string as a RecommendedFeeType.
+func ParseRecommendedFeeType(s string) (RecommendedFeeType, error) {
+	switch strings.ToLower(s) {
+	case "fastest":
+		return RecommendedFeeTypeFastest, nil
+	case "halfHour":
+		return RecommendedFeeTypeHalfHour, nil
+	case "hour":
+		return RecommendedFeeTypeHour, nil
+	case "economy":
+		return RecommendedFeeTypeEconomy, nil
+	case "minimum":
+		return RecommendedFeeTypeMinimum, nil
+	default:
+		return "", fmt.Errorf("unknown recommended fee type: %q", s)
+	}
+}
+
 // MinerStatusResult contains information about the status of the PoP miner.
 // Returned by MethodMinerStatus.
 type MinerStatusResult struct {
@@ -149,6 +181,10 @@ type MinerStatusResult struct {
 	// Connecting is whether the PoP miner is currently connected to a BFG
 	// server.
 	Connected bool `json:"connected"`
+
+	// Fee is the current fee used by the PoP miner for PoP transactions,
+	// in sats/vB.
+	Fee uint `json:"fee"`
 }
 
 // PingResult contains information when pinging the BFG server.

--- a/web/popminer/fee.go
+++ b/web/popminer/fee.go
@@ -1,3 +1,9 @@
+// Copyright (c) 2024 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+//go:build js && wasm
+
 package main
 
 import (

--- a/web/popminer/fee.go
+++ b/web/popminer/fee.go
@@ -47,6 +47,11 @@ func (m *Miner) automaticFees(fee RecommendedFeeType, refresh time.Duration) {
 	defer log.Tracef("automaticFees exit")
 	defer m.wg.Done()
 
+	if m.mempoolSpaceURL == "" {
+		// Not supported for this network.
+		return
+	}
+
 	for {
 		m.updateFee(m.ctx, fee)
 

--- a/web/popminer/fee.go
+++ b/web/popminer/fee.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	versionPkg "github.com/hemilabs/heminetwork/version"
+)
+
+const mempoolRecommendedFees = "/api/v1/fees/recommended"
+
+// recommendedFees is the result from the mempool.space API.
+type recommendedFees struct {
+	FastestFee  uint `json:"fastestFee"`
+	HalfHourFee uint `json:"halfHourFee"`
+	HourFee     uint `json:"hourFee"`
+	EconomyFee  uint `json:"economyFee"`
+	MinimumFee  uint `json:"minimumFee"`
+}
+
+// pick returns the recommended fee value for the specified type.
+func (r recommendedFees) pick(f RecommendedFeeType) uint {
+	switch f {
+	case RecommendedFeeTypeFastest:
+		return r.FastestFee
+	case RecommendedFeeTypeHalfHour:
+		return r.HalfHourFee
+	case RecommendedFeeTypeHour:
+		return r.HourFee
+	case RecommendedFeeTypeEconomy:
+		return r.EconomyFee
+	case RecommendedFeeTypeMinimum:
+		return r.MinimumFee
+	default:
+		panic("bug: unknown recommended fee type")
+	}
+}
+
+// automaticFees runs a loop to refresh the fee used by the PoP Miner using
+// the recommended fee of the specified type from the mempool.space REST API.
+func (m *Miner) automaticFees(fee RecommendedFeeType, refresh time.Duration) {
+	log.Tracef("automaticFees")
+	defer log.Tracef("automaticFees exit")
+	defer m.wg.Done()
+
+	for {
+		m.updateFee(m.ctx, fee)
+
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-time.After(refresh):
+		}
+	}
+}
+
+// updateFee requests the recommended fees from mempool.space and updates the
+// fee being used by the PoP Miner.
+func (m *Miner) updateFee(ctx context.Context, fee RecommendedFeeType) {
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+
+	// Retrieve recommended fees from mempool.space.
+	fees, err := m.getRecommendedFees(ctx)
+	if err != nil {
+		log.Warningf("Failed to fetch recommended fees: %v", err)
+		return
+	}
+
+	// Update fee used by the miner.
+	m.SetFee(fees.pick(fee))
+}
+
+// getRecommendedFees requests the recommended fees from the mempool.space
+// REST API.
+func (m *Miner) getRecommendedFees(ctx context.Context) (*recommendedFees, error) {
+	log.Debugf("Requesting recommended fees from mempool.space...")
+
+	// Join API path.
+	apiPath, err := url.JoinPath(m.mempoolSpaceURL, mempoolRecommendedFees)
+	if err != nil {
+		return nil, fmt.Errorf("join mempool.space URL path: %w", err)
+	}
+
+	// Create HTTP GET request.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create recommended fees request: %w", err)
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", versionPkg.UserAgent())
+
+	// Make HTTP request.
+	res, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request recommended fees: %w", err)
+	}
+	defer res.Body.Close()
+
+	// Make sure status code is 200.
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request recommended fees: %s", res.Status)
+	}
+
+	// Decode response.
+	var fees recommendedFees
+	if err = json.NewDecoder(res.Body).Decode(&fees); err != nil {
+		return nil, fmt.Errorf("decode recommended fees response: %w", err)
+	}
+	return &fees, nil
+}

--- a/web/popminer/fee.go
+++ b/web/popminer/fee.go
@@ -13,8 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"time"
-
-	versionPkg "github.com/hemilabs/heminetwork/version"
 )
 
 const mempoolRecommendedFees = "/api/v1/fees/recommended"
@@ -103,7 +101,6 @@ func (m *Miner) getRecommendedFees(ctx context.Context) (*recommendedFees, error
 		return nil, fmt.Errorf("create recommended fees request: %w", err)
 	}
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("User-Agent", versionPkg.UserAgent())
 
 	// Make HTTP request.
 	res, err := m.httpClient.Do(req)

--- a/web/popminer/network.go
+++ b/web/popminer/network.go
@@ -15,24 +15,32 @@ const (
 	rpcHemiMainnet = "wss://rpc.hemi.network"
 
 	bfgRoute = "/v1/ws/public"
+
+	mempoolSpaceURL = "https://mempool.space"
 )
 
 type networkOptions struct {
 	bfgURL       string
 	btcChainName string
+
+	// mempoolSpaceURL is the base URL for mempool.space for this network.
+	mempoolSpaceURL string
 }
 
 var networks = map[string]networkOptions{
 	"testnet": {
-		bfgURL:       rpcHemiTestnet + bfgRoute,
-		btcChainName: btcChainTestnet3,
+		bfgURL:          rpcHemiTestnet + bfgRoute,
+		btcChainName:    btcChainTestnet3,
+		mempoolSpaceURL: mempoolSpaceURL + "/testnet",
 	},
 	"devnet": {
-		bfgURL:       rpcHemiDevnet + bfgRoute,
-		btcChainName: btcChainTestnet3,
+		bfgURL:          rpcHemiDevnet + bfgRoute,
+		btcChainName:    btcChainTestnet3,
+		mempoolSpaceURL: "",
 	},
 	"mainnet": {
-		bfgURL:       rpcHemiMainnet + bfgRoute,
-		btcChainName: btcChainMainnet,
+		bfgURL:          rpcHemiMainnet + bfgRoute,
+		btcChainName:    btcChainMainnet,
+		mempoolSpaceURL: mempoolSpaceURL,
 	},
 }

--- a/web/popminer/popminer.go
+++ b/web/popminer/popminer.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -91,6 +92,14 @@ type Miner struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	*popm.Miner
+
+	// httpClient is the HTTP client used for accessing the mempool.space API
+	// if automaticFees is enabled.
+	httpClient *http.Client
+
+	// mempoolSpaceURL is the base URL for mempool.space, for the current
+	// network.
+	mempoolSpaceURL string
 
 	errCh chan error
 	wg    sync.WaitGroup

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -62,6 +62,14 @@
       <input id="StartPopMinerPrivateKeyInput" type="password">
       <label for="StartPopMinerPrivateKeyInput">bitcoin private key (must be funded)</label>
       <br>
+      <input id="StartPopMinerAutomaticFeesInput" value="economy">
+      <label for="StartPopMinerAutomaticFeesInput">
+          Whether to do automatic fees (set to 'false' to disable), and which type of recommended fee to use.
+      </label>
+      <br>
+      <input id="StartPopMinerAutomaticFeeRefreshInput" value="300">
+      <label for="StartPopMinerAutomaticFeeRefreshInput">Interval to refresh recommended fees from mempool.space API</label>
+      <br>
       <input id="StartPopMinerStaticFeeInput" value="50">
       <label for="StartPopMinerStaticFeeInput">Fee to pay for PoP Mining (sat/vB)</label>
       <br>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -103,11 +103,17 @@ const StartPopMinerShow = document.querySelector('.StartPopMinerShow');
 
 async function StartPopMiner() {
   try {
+    let automaticFees = StartPopMinerAutomaticFeesInput.value;
+    if (automaticFees === 'false' || automaticFees === 'true') {
+      automaticFees = automaticFees === 'true';
+    }
     const result = await dispatch({
       method: 'startPoPMiner',
       network: StartPopMinerNetworkInput.value,
       logLevel: StartPopMinerLogLevelInput.value,
       privateKey: StartPopMinerPrivateKeyInput.value,
+      automaticFees: automaticFees,
+      automaticFeeRefreshSeconds: Number(StartPopMinerAutomaticFeeRefreshInput.value),
       staticFee: Number(StartPopMinerStaticFeeInput.value),
     });
     StartPopMinerShow.innerText = JSON.stringify(result, null, 2);


### PR DESCRIPTION
**Summary**
Add an automatic fee system to the WASM PoP Miner.
When enabled, the recommended fees are fetched from mempool.space's REST API.

Fees are re-fetched at a configured interval (default 5 minutes). The `economyFee` value will be used by default, however this can be configured with by setting `automaticFees` to a `RecommendedFeeType` value (`fastest`, `halfHour`, `hour`, `economy`, `minimum`).

**Changes**
- Add ability to change fees during runtime in the PoP Miner (`(*Miner).Fee() uint` and `(*Miner).SetFee(uint)`).
- Add `automaticFees?: boolean | RecommendedFeeType` and `automaticFeeRefreshSeconds?: number` to `MinerStartArgs`.
- Add `fee: number` to `MinerStatusResult`.