### PR TITLE
remove insertion of pop_basis during broadcast

### DIFF
--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -1540,41 +1540,6 @@ func TestBitcoinBroadcast(t *testing.T) {
 			break
 		}
 	}
-
-	publicKey := privateKey.PubKey()
-	publicKeyUncompressed := publicKey.SerializeUncompressed()
-
-	t.Logf("querying for keystone %s", hex.EncodeToString(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()))
-
-	// 3
-	popBases, err := db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()), false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	btcTxId := mb.TxHash()
-
-	t.Logf("test hash is %s", hex.EncodeToString(btcTxId[:]))
-
-	if len(popBases) != 1 {
-		t.Fatalf("unexpected length %d", len(popBases))
-	}
-
-	if !slices.Equal(popBases[0].L2KeystoneAbrevHash, hemi.L2KeystoneAbbreviate(l2Keystone).Hash()) {
-		t.Fatalf("%v != %v", popBases[0].L2KeystoneAbrevHash, hemi.L2KeystoneAbbreviate(l2Keystone).Hash())
-	}
-
-	if !slices.Equal(popBases[0].PopMinerPublicKey, publicKeyUncompressed) {
-		t.Fatalf("%v != %v", popBases[0].PopMinerPublicKey, publicKeyUncompressed)
-	}
-
-	if !slices.Equal(popBases[0].BtcRawTx, btx) {
-		t.Fatalf("%v != %v", popBases[0].BtcRawTx, btx)
-	}
-
-	if !slices.Equal(popBases[0].BtcTxId, btcTxId[:]) {
-		t.Fatalf("%v != %v", popBases[0].BtcTxId, btcTxId[:])
-	}
 }
 
 // TestBitcoinBroadcastDuplicate calls BitcoinBroadcast twice with the same

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -366,22 +366,13 @@ func (s *Server) handleOneBroadcastRequest(ctx context.Context, highPriority boo
 		return
 	}
 
-	publicKeyUncompressed, err := pop.ParsePublicKeyFromSignatureScript(mb.TxIn[0].SignatureScript)
+	_, err = pop.ParsePublicKeyFromSignatureScript(mb.TxIn[0].SignatureScript)
 	if err != nil {
 		log.Errorf("could not parse public key from signature script: %v", err)
 		return
 	}
 
 	hash := mb.TxHash()
-
-	if err := s.db.PopBasisInsertPopMFields(ctx, &bfgd.PopBasis{
-		BtcTxId:             hash[:],
-		BtcRawTx:            database.ByteArray(serializedTx),
-		PopMinerPublicKey:   publicKeyUncompressed,
-		L2KeystoneAbrevHash: tl2.L2Keystone.Hash(),
-	}); err != nil {
-		log.Infof("inserting pop basis: %s", err)
-	}
 
 	_, err = s.btcClient.Broadcast(ctx, serializedTx)
 	if err != nil {


### PR DESCRIPTION
we (potentially) insert pop_basis twice, once when broadcasting, another when parsing btc blocks.  we don't need the former at this point, remove it so we take stress off of the db.

**Summary**
we (potentially) insert pop_basis twice, once when broadcasting, another when parsing btc blocks.  we don't need the former at this point

**Changes**
remove the first insert so we take stress off of the db
