### PR TITLE
electrumx: fix open/closed/idle metrics for conn pool

### DIFF
--- a/hemi/electrumx/conn_pool.go
+++ b/hemi/electrumx/conn_pool.go
@@ -91,7 +91,10 @@ func (p *connPool) onClose(conn *clientConn) {
 	removed := len(p.pool) != l
 	p.poolMx.Unlock()
 
-	if p.metrics != nil && removed {
+	if p.metrics != nil {
+		if removed {
+			p.metrics.connsIdle.Dec()
+		}
 		p.metrics.connsClosed.Inc()
 		p.metrics.connsOpen.Dec()
 	}


### PR DESCRIPTION
**Summary**
Fix ElectrumX connection pool open/closed/idle metrics.

Previously, the `open` metric and `closed_total` metrics weren't handled properly when a connection is closed.
They would only be changed if the connection was also removed from the connection pool, which is false in most cases.

Additionally, the `connsIdle` metric needs to be decremented when a connection in the pool is removed and closed.

**Changes**
- Decrement connsIdle if a connection is removed from the pool in onClose.
- Always decrement connsOpen when a connection is closed.
- Always increment connsClosed when a connection is closed.
