### PR TITLE
need to select FOR UPDATE to lock row

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1092,6 +1092,7 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 			AND broadcast_at IS NULL
 			AND created_at > NOW() - INTERVAL '30 minutes'
 			%s
+			FOR UPDATE
 			LIMIT 1
 		)
 		RETURNING serialized_tx


### PR DESCRIPTION
**Summary**
prior, when selecting a row to update, we were not locking the row selected so multiple processes could get this row at the same time.

**Changes**
select row `FOR UPDATE` to lock row to ensure only one process gets it
