### PR TITLE
bfg: fix issues reported by staticcheck

### DIFF
--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -723,7 +723,7 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 			// that something else has inserted the row before us
 			// (i.e. a race condition), this is ok, as it should
 			// have the same values, so we no-op
-			if err != nil && !errors.Is(database.ErrDuplicate, err) {
+			if err != nil && !errors.Is(err, database.ErrDuplicate) {
 				return err
 			}
 		}

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1527,7 +1527,7 @@ func (s *Server) handleAccessPublicKeys(table string, action string, payload, pa
 	for _, v := range s.sessions {
 		// if public key does not exist on session, it's not an authenticated
 		// session so we don't close it because it didn't use a public key
-		if v.publicKey == nil || len(v.publicKey) == 0 {
+		if len(v.publicKey) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
**Summary**
Fix a couple issues reported by Staticcheck in BFG.

**Changes**
- Fix order of arguments in call to `errors.Is` in `processBitcoinBlock`, the correct order is `(err, target)` (SA1032).
- Omit nil check for `v.publicKey` in `handleAccessPublicKeys`, as `len(nilSlice)` is zero (S1009).
