### PR TITLE
popm/wasm: make automaticFees default to enabled

### DIFF
--- a/web/popminer/dispatch.go
+++ b/web/popminer/dispatch.go
@@ -424,7 +424,7 @@ func newMiner(config js.Value) (*Miner, *automaticFeeOptions, error) {
 	// Automatic fee options
 	autoFeeConfig := config.Get("automaticFees")
 	autoFees := &automaticFeeOptions{
-		enabled:         autoFeeConfig.Truthy(),
+		enabled:         autoFeeConfig.IsUndefined() || autoFeeConfig.Truthy(),
 		feeType:         RecommendedFeeTypeEconomy,
 		refreshInterval: 5 * time.Minute,
 	}


### PR DESCRIPTION
**Summary**
The documentation for `@hemilabs/pop-miner` states that `automaticFees` defaults to `true`:
```typescript
  /**
   * Whether to do automatic fee estimation using the mempool.space API.
   * Defaults to true. If disabled, then only the staticFee will be used.
   *
   * When the value is true, the 'economy' recommended fee type will be used.
   */
  automaticFees?: boolean | RecommendedFeeType;
```

This makes the code behave as documented.

**Changes**
- Enable automatic fees in the WebAssembly PoP Miner when `automaticFees` is `undefined`.
