### PR TITLE
bound height to 100 from canonical tip as to not have to scan large portion of index

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -38,6 +38,7 @@ const effectiveHeightSql = `
 				= pop_basis.l2_keystone_abrev_hash
 
 		WHERE ll.l2_block_number >= l2_keystones.l2_block_number
+		AND height > (SELECT height FROM btc_blocks_can ORDER BY height DESC LIMIT 1) - 100
 		ORDER BY height ASC LIMIT 1
 	)), 0)
 `


### PR DESCRIPTION
**Summary**
When getting the "effective height", we were not bounding the possible heights, this causes the query to scan over an entire index until it finds a height that is satisfactory to the rest of the query.

We use "effective height" in our "finality" calculation:

Finality = Min(100, (Canonical Tip Height - Effective Height - 9 + 1))

Since Finality cannot be more than 100, it is futile to look for an effective height that would be >= 100 blocks from the tip.

So we should only be concerned with effective heights >= tip - 100.

**Changes**
Bound the effective height calculation to 100 blocks from the tip to ensure that we don't scan over needless parts of the height index.

**Important Note:** if no results are returned, then the effective height gets "coalesced" to 0 which would result in and effective height of 0, and thus a finality of 100, which is expected.