### PR TITLE
tbc: fix log using %w verb

### DIFF
--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1144,7 +1144,7 @@ func (s *Server) blockExpired(ctx context.Context, key any, value any) {
 			if err := p.close(); err != nil {
 				log.Errorf("block expired: %v %v", p, err)
 			}
-			log.Errorf("block expired: %v %w", p, err)
+			log.Errorf("block expired: %v %v", p, err)
 		}
 	}
 }


### PR DESCRIPTION
**Summary**
Fix use of `%w` formatting verb in `log.Errorf` in TBC.

**Changes**
- Replace `%w` with `%v` in `log.Errorf` call.