### PR TITLE
popm/wasm: add automatic fee multiplier, fix auto fee args

### DIFF
--- a/web/packages/pop-miner/src/browser/index.ts
+++ b/web/packages/pop-miner/src/browser/index.ts
@@ -59,6 +59,9 @@ export const startPoPMiner: typeof types.startPoPMiner = (args) => {
     network: args.network,
     privateKey: args.privateKey,
     logLevel: args.logLevel ?? '',
+    automaticFees: args.automaticFees,
+    automaticFeeMultiplier: args.automaticFeeMultiplier,
+    automaticFeeRefreshSeconds: args.automaticFeeRefreshSeconds,
     staticFee: args.staticFee,
   });
 };

--- a/web/packages/pop-miner/src/types.ts
+++ b/web/packages/pop-miner/src/types.ts
@@ -373,9 +373,17 @@ export type MinerStartArgs = {
    * Whether to do automatic fee estimation using the mempool.space API.
    * Defaults to true. If disabled, then only the staticFee will be used.
    *
-   * When the value is true, the 'economy' recommended fee type will be used.
+   * When the value is true, the 'fastest' recommended fee type will be used.
    */
   automaticFees?: boolean | RecommendedFeeType;
+
+  /**
+   * Controls the fee used when automaticFees is enabled. This allows the output
+   * fee to be increased or decreased by a percentage. For example, if the
+   * recommended fee is 500 and the multiplier is 1.1, the output will be 550.
+   * Defaults to 1.1 (+10%).
+   */
+  automaticFeeMultiplier?: number;
 
   /**
    * The duration between refreshing recommended fee data from the

--- a/web/popminer/fee.go
+++ b/web/popminer/fee.go
@@ -83,7 +83,7 @@ func (m *Miner) updateFee(ctx context.Context, fee RecommendedFeeType, multiplie
 
 	// Apply multiplier.
 	recommendedFee := fees.pick(fee)
-	multipliedFee := uint64(math.Ceil(float64(recommendedFee) * multiplier))
+	multipliedFee := math.Ceil(float64(recommendedFee) * multiplier)
 
 	// Bounds check before converting to uint32.
 	switch {
@@ -94,7 +94,7 @@ func (m *Miner) updateFee(ctx context.Context, fee RecommendedFeeType, multiplie
 	}
 
 	log.Debugf("Updating PoP miner fee (%d * %f): %d sats/vB",
-		recommendedFee, multiplier, multipliedFee)
+		recommendedFee, multiplier, uint64(multipliedFee))
 
 	// Update fee used by the miner.
 	m.SetFee(uint(multipliedFee))

--- a/web/popminer/fee.go
+++ b/web/popminer/fee.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"time"
@@ -46,7 +47,7 @@ func (r recommendedFees) pick(f RecommendedFeeType) uint {
 
 // automaticFees runs a loop to refresh the fee used by the PoP Miner using
 // the recommended fee of the specified type from the mempool.space REST API.
-func (m *Miner) automaticFees(fee RecommendedFeeType, refresh time.Duration) {
+func (m *Miner) automaticFees(fee RecommendedFeeType, multiplier float64, refresh time.Duration) {
 	log.Tracef("automaticFees")
 	defer log.Tracef("automaticFees exit")
 	defer m.wg.Done()
@@ -57,7 +58,7 @@ func (m *Miner) automaticFees(fee RecommendedFeeType, refresh time.Duration) {
 	}
 
 	for {
-		m.updateFee(m.ctx, fee)
+		m.updateFee(m.ctx, fee, multiplier)
 
 		select {
 		case <-m.ctx.Done():
@@ -69,7 +70,7 @@ func (m *Miner) automaticFees(fee RecommendedFeeType, refresh time.Duration) {
 
 // updateFee requests the recommended fees from mempool.space and updates the
 // fee being used by the PoP Miner.
-func (m *Miner) updateFee(ctx context.Context, fee RecommendedFeeType) {
+func (m *Miner) updateFee(ctx context.Context, fee RecommendedFeeType, multiplier float64) {
 	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
 	defer cancel()
 
@@ -80,8 +81,23 @@ func (m *Miner) updateFee(ctx context.Context, fee RecommendedFeeType) {
 		return
 	}
 
+	// Apply multiplier.
+	recommendedFee := fees.pick(fee)
+	multipliedFee := uint64(math.Ceil(float64(recommendedFee) * multiplier))
+
+	// Bounds check before converting to uint32.
+	switch {
+	case multipliedFee < 1:
+		multipliedFee = 1
+	case multipliedFee > 1<<32-1:
+		multipliedFee = 1<<32 - 1
+	}
+
+	log.Debugf("Updating PoP miner fee (%d * %f): %d sats/vB",
+		recommendedFee, multiplier, multipliedFee)
+
 	// Update fee used by the miner.
-	m.SetFee(fees.pick(fee))
+	m.SetFee(uint(multipliedFee))
 }
 
 // getRecommendedFees requests the recommended fees from the mempool.space

--- a/web/www/index.html
+++ b/web/www/index.html
@@ -62,10 +62,13 @@
       <input id="StartPopMinerPrivateKeyInput" type="password">
       <label for="StartPopMinerPrivateKeyInput">bitcoin private key (must be funded)</label>
       <br>
-      <input id="StartPopMinerAutomaticFeesInput" value="economy">
+      <input id="StartPopMinerAutomaticFeesInput" value="fastest">
       <label for="StartPopMinerAutomaticFeesInput">
           Whether to do automatic fees (set to 'false' to disable), and which type of recommended fee to use.
       </label>
+      <br>
+      <input id="StartPopMinerAutomaticFeeMultiplierInput" value="1.1">
+      <label for="StartPopMinerAutomaticFeeMultiplierInput">Fee multiplier</label>
       <br>
       <input id="StartPopMinerAutomaticFeeRefreshInput" value="300">
       <label for="StartPopMinerAutomaticFeeRefreshInput">Interval to refresh recommended fees from mempool.space API</label>

--- a/web/www/index.js
+++ b/web/www/index.js
@@ -113,6 +113,7 @@ async function StartPopMiner() {
       logLevel: StartPopMinerLogLevelInput.value,
       privateKey: StartPopMinerPrivateKeyInput.value,
       automaticFees: automaticFees,
+      automaticFeeMultiplier: Number(StartPopMinerAutomaticFeeMultiplierInput.value),
       automaticFeeRefreshSeconds: Number(StartPopMinerAutomaticFeeRefreshInput.value),
       staticFee: Number(StartPopMinerStaticFeeInput.value),
     });


### PR DESCRIPTION
**Summary**
Add `automaticFeeMultiplier` parameter to `MinerStartArgs` in the WebAssembly PoP Miner.

This allows the used fee to be increased or decreased by a percentage. For example, if the recommended fee returned by the `mempool.space` API is `500`, and the multiplier is set to `1.1`, the output fee will be `550` sats/vB.

**Changes**
- Add `automaticFeeMultiplier?: number` to `MinerStartArgs` (defaults to `1.1`, +10%).
- Make `automaticFees: true` use the `fastest` recommended fee by default.
- Add range check for `automaticFeeRefreshSeconds` (if set, must be greater than zero).
