### PR TITLE
add tx id to broadcast error log so we can trace it

### DIFF
--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -387,7 +387,7 @@ func (s *Server) handleOneBroadcastRequest(ctx context.Context, highPriority boo
 
 	_, err = s.btcClient.Broadcast(ctx, serializedTx)
 	if err != nil {
-		log.Errorf("broadcast tx: %s", err)
+		log.Errorf("broadcast tx %s: %s", mb.TxID(), err)
 		err = s.db.BtcTransactionBroadcastRequestSetLastError(ctx, mb.TxID(), err.Error())
 		if err != nil {
 			log.Errorf("could not delete %v", err)


### PR DESCRIPTION
**Summary**
when debugging by looking through logs, it's useful to be able to associate a log with a tx id, we currently don't do this on broadcast errors

**Changes**
add tx id to broadcast error
