### PR TITLE
electrumx: move conn metrics into clientConn

### DIFF
--- a/hemi/electrumx/conn.go
+++ b/hemi/electrumx/conn.go
@@ -212,7 +212,7 @@ func (c *clientConn) Close() error {
 
 	if c.conn == nil {
 		// Already closed.
-		return nil
+		return net.ErrClosed
 	}
 
 	if c.onClose != nil {

--- a/hemi/electrumx/conn_pool.go
+++ b/hemi/electrumx/conn_pool.go
@@ -69,10 +69,6 @@ func (p *connPool) newConn() (*clientConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	if p.metrics != nil {
-		p.metrics.connsOpened.Inc()
-		p.metrics.connsOpen.Inc()
-	}
 	return newClientConn(c, p.metrics, p.onClose), nil
 }
 
@@ -91,12 +87,8 @@ func (p *connPool) onClose(conn *clientConn) {
 	removed := len(p.pool) != l
 	p.poolMx.Unlock()
 
-	if p.metrics != nil {
-		if removed {
-			p.metrics.connsIdle.Dec()
-		}
-		p.metrics.connsClosed.Inc()
-		p.metrics.connsOpen.Dec()
+	if p.metrics != nil && removed {
+		p.metrics.connsIdle.Dec()
 	}
 }
 


### PR DESCRIPTION
**Summary**
Move ElectrumX connection metric handling (`connections_opened`, `connections_open`, `connections_closed`) into the individual connection handling code.

This aims to fix an inconsistency where if multiple attempts are made to close a connection, `connections_open` can be decremented multiple times for the one connection, causing the number to potentially be lower than the real number (and possibly negative).

**Changes**
- Move handling for ElectrumX metrics `connections_opened`, `connections_open` and `connections_closed` to the `clientConn` struct in `conn.go`.
- Set `(*clientConn).conn` to `nil` when `(*clientConn).Close()` is called and the connection has been closed, preventing attempts to close the connection multiple times (`net.ErrClosed` will be returned).
- Return `net.ErrClosed` in `(*clientConn).call` if `(*clientConn).conn` is `nil` due to the connection being closed.
