### PR TITLE
bfgapi: remove additional slash from default urls (fix #260)

### DIFF
--- a/api/bfgapi/bfgapi.go
+++ b/api/bfgapi/bfgapi.go
@@ -54,8 +54,8 @@ var (
 	DefaultPrivateListen    = "localhost:8080"
 	DefaultPublicListen     = "localhost:8383"
 	DefaultPrometheusListen = "localhost:2112"
-	DefaultPrivateURL       = "ws://" + DefaultPrivateListen + "/" + RouteWebsocketPrivate
-	DefaultPublicURL        = "ws://" + DefaultPublicListen + "/" + RouteWebsocketPublic
+	DefaultPrivateURL       = "ws://" + DefaultPrivateListen + RouteWebsocketPrivate
+	DefaultPublicURL        = "ws://" + DefaultPublicListen + RouteWebsocketPublic
 	DefaultRequestLimit     = 10000 // XXX this is a bandaid
 	DefaultRequestTimeout   = 9     // XXX PNOOMA
 )


### PR DESCRIPTION
**Summary**
Remove an additional slash from the default URLs in `bfgapi`.
Fixes #260 reported by @NorthernWinter.

**Changes**
- Remove an additional slash from the default URLs in `bfgapi`.