### PR TITLE
do not lock mutex during db query

### DIFF
--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1320,9 +1320,6 @@ func (s *Server) refreshL2KeystoneCache(ctx context.Context) {
 	log.Tracef("refreshL2KeystoneCache")
 	defer log.Tracef("refreshL2KeystoneCache exit")
 
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
 	results, err := s.db.L2KeystonesMostRecentN(ctx, 100)
 	if err != nil {
 		log.Errorf("error getting keystones %v", err)
@@ -1341,6 +1338,9 @@ func (s *Server) refreshL2KeystoneCache(ctx context.Context) {
 			EPHash:             api.ByteSlice(v.EPHash),
 		})
 	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 
 	s.l2keystonesCache = l2Keystones
 }


### PR DESCRIPTION


**Summary**
we lock the mutex lock before we make a db query, which keeps it locked for longer than needed. 

**Changes**
 we only need to lock it before we set the cached value, move it there
