### PR TITLE
Replace electrumx with electrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ go run ./integrationtest
 ### 🏁 Prerequisites
 
 - A **PostgreSQL database**, bfgd expects the sql scripts in `./database/bfgd/scripts/` to be run to set up your schema.
-- A **connection to an ElectrumX node** on the proper Bitcoin network (testnet or mainnet).
+- A **connection to an Electrs node** on the proper Bitcoin network (testnet or mainnet).
 
 ## ▶️ Running bssd
 

--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -34,19 +34,19 @@ var (
 		"BFG_EXBTC_ADDRESS": config.Config{
 			Value:        &cfg.EXBTCAddress,
 			DefaultValue: "localhost:18001",
-			Help:         "electrumx endpoint",
+			Help:         "electrs endpoint",
 			Print:        config.PrintAll,
 		},
 		"BFG_EXBTC_INITIAL_CONNECTIONS": config.Config{
 			Value:        &cfg.EXBTCInitialConns,
 			DefaultValue: 5,
-			Help:         "electrumx initial connections",
+			Help:         "electrs initial connections",
 			Print:        config.PrintAll,
 		},
 		"BFG_EXBTC_MAX_CONNECTIONS": config.Config{
 			Value:        &cfg.EXBTCMaxConns,
 			DefaultValue: 100,
-			Help:         "electrumx max connections",
+			Help:         "electrs max connections",
 			Print:        config.PrintAll,
 		},
 		"BFG_PUBLIC_KEY_AUTH": config.Config{

--- a/cmd/extool/extool.go
+++ b/cmd/extool/extool.go
@@ -16,7 +16,7 @@ import (
 
 	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
 
-	"github.com/hemilabs/heminetwork/hemi/electrumx"
+	"github.com/hemilabs/heminetwork/hemi/electrs"
 	"github.com/hemilabs/heminetwork/version"
 )
 
@@ -37,12 +37,12 @@ func main() {
 		log.Fatal("No address specified")
 	}
 
-	c, err := electrumx.NewClient(address, &electrumx.ClientOptions{
+	c, err := electrs.NewClient(address, &electrs.ClientOptions{
 		InitialConnections: 1,
 		MaxConnections:     1,
 	})
 	if err != nil {
-		log.Fatalf("Failed to create electrumx client: %v", err)
+		log.Fatalf("Failed to create electrs client: %v", err)
 	}
 
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/e2e/cookie
+++ b/e2e/cookie
@@ -1,0 +1,1 @@
+user:password

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "-rpcport=18443"
       - "-rpcconnect=bitcoind"
       - "generatetoaddress"
-      - "3000" # need to generate a lot for greater chance to not spend coinbase
+      - "1000" # need to generate a lot for greater chance to not spend coinbase
       - "$BTC_ADDRESS"
     restart: on-failure
 
@@ -55,19 +55,28 @@ services:
       - "1"
       - "$BTC_ADDRESS"
 
-  electrumx:
-    image: "lukechilds/electrumx@sha256:2949784536f8f85af229004e12e5b5c3a1d7428918a492f77b4e958035c2ae2a"
+  electrs:
+    build:
+      context: https://github.com/romanz/electrs.git#1d02f10ec38edbc3b7df6b16bb8989d9bc0aaa0f
     depends_on:
       - "bitcoind"
-    ports:
-      - "50001:8000"
-    environment:
-      DAEMON_URL: "http://user:password@bitcoind:18443"
-      COIN: "Bitcoin"
-      COST_HARD_LIMIT: "0"
-      COST_SOFT_LIMIT: "0"
-      MAX_SEND: "8388608"
-      NET: "regtest"
+    command:
+      - electrs
+      - --electrum-rpc-addr
+      - '0.0.0.0:50001'
+      - --daemon-rpc-addr
+      - "bitcoind:18443"
+      - --daemon-p2p-addr
+      - "bitcoind:18444"
+      - --network
+      - regtest
+      - --cookie-file
+      - "/tmp/.cookie"
+    volumes:
+      - ./cookie:/tmp/.cookie
+    deploy:
+      restart_policy:
+        condition: "on-failure"
 
   bfgd-postgres:
     build:
@@ -96,13 +105,14 @@ services:
         condition: "any"
     depends_on:
       - "bfgd-postgres"
+      - "electrs"
     ports:
       - "8080:8080"
       - "8383:8383"
     environment:
       BFG_POSTGRES_URI: "postgres://postgres@bfgd-postgres:5432/bfg?sslmode=disable"
       BFG_BTC_START_HEIGHT: "1"
-      BFG_EXBTC_ADDRESS: "electrumx:50001"
+      BFG_EXBTC_ADDRESS: "electrs:50001"
       BFG_LOG_LEVEL: "INFO"
       BFG_PUBLIC_ADDRESS: ":8383"
       BFG_PRIVATE_ADDRESS: ":8080"

--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -16,7 +16,7 @@ import (
 // after 5 minutes and check that it has progressed at least to a certain
 // point
 func TestMonitor(t *testing.T) {
-	ms := 1000 * 60 * 5 // dump after 5 minutes
+	ms := (1000 * 60 * 5) + 25*1000 // dump after 5 minutes + 25 seconds for cushion (1 keystone)
 	output := monitor(uint(ms))
 
 	t.Log(output)
@@ -29,6 +29,7 @@ func TestMonitor(t *testing.T) {
 	// each keystone is 25 seconds, so there are 4 keystones per 100 seconds,
 	// we expect the number of pop txs to be at least once every 25 seconds
 	// for the time we waited
+	// add 25 seconds for cushion
 	seconds := ms / 1000
 	popTxsPer100Seconds := 4
 	expectedPopTxs := popTxsPer100Seconds * (seconds / 100)

--- a/hemi/electrs/conn.go
+++ b/hemi/electrs/conn.go
@@ -24,7 +24,7 @@ const (
 	connPingTimeout  = 5 * time.Second
 )
 
-// clientConn is a connection with an ElectrumX server.
+// clientConn is a connection with an Electrs server.
 type clientConn struct {
 	mx        sync.Mutex
 	conn      net.Conn
@@ -147,7 +147,7 @@ func readResponse(ctx context.Context, r io.Reader, reqID uint64) (*JSONRPCRespo
 
 	if res.ID != reqID {
 		if res.ID == 0 {
-			// ElectrumX may have sent a request, ignore it and try again.
+			// Electrs may have sent a request, ignore it and try again.
 			// TODO(joshuasing): We should probably handle incoming requests by
 			//  having a separate goroutine that handles reading.
 			select {
@@ -155,7 +155,7 @@ func readResponse(ctx context.Context, r io.Reader, reqID uint64) (*JSONRPCRespo
 				return nil, ctx.Err()
 			default:
 			}
-			log.Debugf("Received a response from ElectrumX with ID 0, retrying read response...")
+			log.Debugf("Received a response from Electrs with ID 0, retrying read response...")
 			return readResponse(ctx, r, reqID)
 		}
 		return nil, fmt.Errorf("response ID differs from request ID (%d != %d)", res.ID, reqID)

--- a/hemi/electrs/conn.go
+++ b/hemi/electrs/conn.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
-package electrumx
+package electrs
 
 import (
 	"bufio"

--- a/hemi/electrs/conn_pool.go
+++ b/hemi/electrs/conn_pool.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 )
 
-// connPool represents an ElectrumX connection pool.
+// connPool represents an electrs connection pool.
 type connPool struct {
 	network string
 	address string

--- a/hemi/electrs/conn_pool.go
+++ b/hemi/electrs/conn_pool.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
-package electrumx
+package electrs
 
 import (
 	"errors"

--- a/hemi/electrs/conn_pool_test.go
+++ b/hemi/electrs/conn_pool_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
-package electrumx
+package electrs
 
 import (
 	"context"

--- a/hemi/electrs/conn_test.go
+++ b/hemi/electrs/conn_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
-package electrumx
+package electrs
 
 import (
 	"bufio"

--- a/hemi/electrs/electrs.go
+++ b/hemi/electrs/electrs.go
@@ -135,11 +135,11 @@ var (
 )
 
 type ClientOptions struct {
-	// InitialConnections is the number of initial ElectrumX connections to open
+	// InitialConnections is the number of initial Electrs connections to open
 	// and keep in the pool.
 	InitialConnections int
 
-	// MaxConnections is the maximum number of ElectrumX connections to keep in
+	// MaxConnections is the maximum number of Electrs connections to keep in
 	// the pool.
 	//
 	// If adding a connection back to the pool would result in the pool having
@@ -166,32 +166,32 @@ func newMetrics(namespace string) *metrics {
 			Namespace: namespace,
 			Subsystem: promSubsystem,
 			Name:      "connections_open",
-			Help:      "Number of open ElectrumX connections",
+			Help:      "Number of open Electrs connections",
 		}),
 		connsIdle: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: promSubsystem,
 			Name:      "connections_idle",
-			Help:      "Number of idle ElectrumX connections",
+			Help:      "Number of idle Electrs connections",
 		}),
 		connsOpened: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: promSubsystem,
 			Name:      "connections_opened_total",
-			Help:      "Total number of ElectrumX connections opened",
+			Help:      "Total number of Electrs connections opened",
 		}),
 		connsClosed: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: promSubsystem,
 			Name:      "connections_closed_total",
-			Help:      "Total number of ElectrumX connections closed",
+			Help:      "Total number of Electrs connections closed",
 		}),
 		rpcCallsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Subsystem: promSubsystem,
 				Name:      "rpc_calls_total",
-				Help:      "Total number of ElectrumX RPC calls",
+				Help:      "Total number of Electrs RPC calls",
 			},
 			[]string{"method"},
 		),
@@ -200,7 +200,7 @@ func newMetrics(namespace string) *metrics {
 				Namespace: namespace,
 				Subsystem: promSubsystem,
 				Name:      "rpc_calls_duration_seconds",
-				Help:      "ElectrumX RPC call durations in seconds",
+				Help:      "Electrs RPC call durations in seconds",
 				Buckets:   prometheus.DefBuckets,
 			},
 			[]string{"method"},
@@ -341,9 +341,9 @@ func (c *Client) Broadcast(ctx context.Context, rtx []byte) ([]byte, error) {
 func (c *Client) Height(ctx context.Context) (uint64, error) {
 	// TODO: The way this function is used could be improved.
 	//  "blockchain.headers.subscribe" subscribes to receive notifications from
-	//  the ElectrumX server, however this function appears to be used for
+	//  the Electrs server, however this function appears to be used for
 	//  polling instead, which could be replaced by handling the requests sent
-	//  from the ElectrumX server.
+	//  from the Electrs server.
 	hn := &HeaderNotification{}
 	if err := c.call(ctx, "blockchain.headers.subscribe", nil, hn); err != nil {
 		return 0, err


### PR DESCRIPTION
**Summary**
We want to replace electrumx with electrs, here is how we can do it in heminetwork.

 
**Changes**
* update rpc interface to implement electrs rpc; the main thing here is that parameters are now passed in based on their position, rather than json object key/value pairings
* replace "electrumx" with "electrs" in source code
* update localnet to use electrs
