### PR TITLE
popmd: make BFG request timeout configurable

### DIFF
--- a/api/bfgapi/bfgapi.go
+++ b/api/bfgapi/bfgapi.go
@@ -57,7 +57,7 @@ var (
 	DefaultPrivateURL       = "ws://" + DefaultPrivateListen + RouteWebsocketPrivate
 	DefaultPublicURL        = "ws://" + DefaultPublicListen + RouteWebsocketPublic
 	DefaultRequestLimit     = 10000 // XXX this is a bandaid
-	DefaultRequestTimeout   = 9     // XXX PNOOMA
+	DefaultRequestTimeout   = 10    // XXX PNOOMA
 )
 
 type AccessPublicKey struct {

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/juju/loggo"
 
@@ -45,9 +46,18 @@ var (
 		},
 		"POPM_BFG_URL": config.Config{
 			Value:        &cfg.BFGWSURL,
-			DefaultValue: popm.NewDefaultConfig().BFGWSURL,
+			DefaultValue: cfg.BFGWSURL,
 			Help:         "url for BFG (Bitcoin Finality Governor)",
 			Print:        config.PrintAll,
+		},
+		"POPM_BFG_REQUEST_TIMEOUT": config.Config{
+			Value:        &cfg.BFGRequestTimeout,
+			DefaultValue: cfg.BFGRequestTimeout,
+			Help:         "request timeout for BFG (Bitcoin Finality Governor)",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
 		},
 		"POPM_BTC_CHAIN_NAME": config.Config{
 			Value:        &cfg.BTCChainName,

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Help         string    // One line help
 	Print        PrintMode // Print mode
 	Required     bool      // If true, error out with error
+	Parse        func(envValue string) (any, error)
 }
 
 type CfgMap map[string]Config
@@ -58,6 +59,15 @@ func Parse(c CfgMap) error {
 			// Set v.Value to v.DefaultValue
 			reflect.ValueOf(v.Value).Elem().Set(reflect.ValueOf(v.DefaultValue))
 		} else {
+			if v.Parse != nil {
+				val, err := v.Parse(envValue)
+				if err != nil {
+					return fmt.Errorf("invalid value for %v: %v", k, err)
+				}
+				reflect.ValueOf(v.Value).Elem().Set(reflect.ValueOf(val))
+				return nil
+			}
+
 			switch reflect.TypeOf(v.Value).Elem().Kind() {
 			case reflect.Int, reflect.Int8, reflect.Int16,
 				reflect.Int32, reflect.Int64:

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -74,6 +74,8 @@ type Config struct {
 	// hexadecimal digits.
 	BTCPrivateKey string
 
+	BFGRequestTimeout time.Duration
+
 	LogLevel string
 
 	PrometheusListenAddress string
@@ -85,10 +87,13 @@ type Config struct {
 	StaticFee uint
 }
 
+const DefaultBFGRequestTimeout = 15 * time.Second
+
 func NewDefaultConfig() *Config {
 	return &Config{
-		BFGWSURL:     "http://localhost:8383/v1/ws/public",
-		BTCChainName: "testnet3",
+		BFGWSURL:          "http://localhost:8383/v1/ws/public",
+		BFGRequestTimeout: DefaultBFGRequestTimeout,
+		BTCChainName:      "testnet3",
 	}
 }
 
@@ -138,12 +143,15 @@ func NewMiner(cfg *Config) (*Miner, error) {
 	if cfg == nil {
 		cfg = NewDefaultConfig()
 	}
+	if cfg.BFGRequestTimeout <= 0 {
+		cfg.BFGRequestTimeout = DefaultBFGRequestTimeout
+	}
 
 	m := &Miner{
 		cfg:            cfg,
 		bfgCmdCh:       make(chan bfgCmd, 10),
 		holdoffTimeout: 5 * time.Second,
-		requestTimeout: 5 * time.Second,
+		requestTimeout: cfg.BFGRequestTimeout,
 		mineNowCh:      make(chan struct{}, 1),
 		l2Keystones:    make(map[string]L2KeystoneProcessingContainer, l2KeystonesMaxSize),
 	}


### PR DESCRIPTION
**Summary**
Make the BFG request timeout in the PoP miner configurable, and increase the default to 15 seconds.
It is configurable in BFG as well, the default has been changed to 10 seconds (previously 9).

This should help increase the number of successful requests. More BFG-side changes will be in follow-up PRs.

**Changes**
- Add `POPM_BFG_REQUEST_TIMEOUT` environment variable to popmd
- Increase the default PoP Miner BFG request timeout to 15 seconds
- Increase the default BFG request timeout to 10 seconds

