### PR TITLE
tbcd: revisit block header cache

### DIFF
--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -25,6 +25,7 @@ const (
 	defaultLogLevel = daemonName + "=INFO;tbc=INFO;level=INFO"
 	defaultNetwork  = "testnet3" // XXX make this mainnet
 	defaultHome     = "~/." + daemonName
+	bhsDefault      = int(1e6) // enough for mainnet; overridden for testnet3
 )
 
 var (
@@ -53,7 +54,7 @@ var (
 		},
 		"TBC_BLOCKHEADER_CACHE": config.Config{
 			Value:        &cfg.BlockheaderCache,
-			DefaultValue: int(1e6),
+			DefaultValue: bhsDefault,
 			Help:         "number of cached blockheaders",
 			Print:        config.PrintAll,
 		},
@@ -153,6 +154,14 @@ func _main() error {
 
 	loggo.ConfigureLoggers(cfg.LogLevel)
 	log.Infof("%v", welcome)
+
+	// Override blockheader cache based on network
+	switch cfg.Network {
+	case "testnet3":
+		if cfg.BlockheaderCache == bhsDefault {
+			cfg.BlockheaderCache = 35000000
+		}
+	}
 
 	pc := config.PrintableConfig(cm)
 	for k := range pc {

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -25,7 +25,7 @@ const (
 	defaultLogLevel = daemonName + "=INFO;tbc=INFO;level=INFO"
 	defaultNetwork  = "testnet3" // XXX make this mainnet
 	defaultHome     = "~/." + daemonName
-	bhsDefault      = int(1e6) // enough for mainnet; overridden for testnet3
+	bhsDefault      = int(1e6) // enough for mainnet
 )
 
 var (
@@ -154,15 +154,6 @@ func _main() error {
 
 	loggo.ConfigureLoggers(cfg.LogLevel)
 	log.Infof("%v", welcome)
-
-	// Override blockheader cache based on network
-	switch cfg.Network {
-	case "testnet3":
-		bhs := os.Getenv("TBC_BLOCKHEADER_CACHE")
-		if bhs == "" {
-			cfg.BlockheaderCache = 35000000
-		}
-	}
 
 	pc := config.PrintableConfig(cm)
 	for k := range pc {

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -158,7 +158,8 @@ func _main() error {
 	// Override blockheader cache based on network
 	switch cfg.Network {
 	case "testnet3":
-		if cfg.BlockheaderCache == bhsDefault {
+		bhs := os.Getenv("TBC_BLOCKHEADER_CACHE")
+		if bhs == "" {
 			cfg.BlockheaderCache = 35000000
 		}
 	}

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -88,7 +88,7 @@ type Database interface {
 // BlockHeader contains the first 80 raw bytes of a bitcoin block plus its
 // location information (hash+height) and the cumulative difficulty.
 type BlockHeader struct {
-	Hash       *chainhash.Hash
+	Hash       chainhash.Hash
 	Height     uint64
 	Header     [80]byte
 	Difficulty big.Int
@@ -121,7 +121,7 @@ func (bh BlockHeader) Wire() (*wire.BlockHeader, error) {
 }
 
 func (bh BlockHeader) BlockHash() *chainhash.Hash {
-	return bh.Hash
+	return &bh.Hash
 }
 
 func (bh BlockHeader) ParentHash() *chainhash.Hash {

--- a/database/tbcd/level/headercache.go
+++ b/database/tbcd/level/headercache.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2024 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
 package level
 
 import (
@@ -20,8 +24,7 @@ func (l *lowIQMap) Put(v *tbcd.BlockHeader) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	k := v.Hash
-	if _, ok := l.m[*k]; ok {
+	if _, ok := l.m[v.Hash]; ok {
 		return
 	}
 
@@ -33,7 +36,7 @@ func (l *lowIQMap) Put(v *tbcd.BlockHeader) {
 		}
 	}
 
-	l.m[*k] = v
+	l.m[v.Hash] = v
 }
 
 func (l *lowIQMap) Get(k *chainhash.Hash) (*tbcd.BlockHeader, bool) {

--- a/database/tbcd/level/headercache.go
+++ b/database/tbcd/level/headercache.go
@@ -1,0 +1,52 @@
+package level
+
+import (
+	"sync"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+
+	"github.com/hemilabs/heminetwork/database/tbcd"
+)
+
+type lowIQMap struct {
+	mtx sync.RWMutex
+
+	count int
+
+	m map[chainhash.Hash]*tbcd.BlockHeader
+}
+
+func (l *lowIQMap) Put(v *tbcd.BlockHeader) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	k := v.Hash
+	if _, ok := l.m[*k]; ok {
+		return
+	}
+
+	if len(l.m) >= l.count {
+		// evict entry
+		for k := range l.m {
+			delete(l.m, k)
+			break
+		}
+	}
+
+	l.m[*k] = v
+}
+
+func (l *lowIQMap) Get(k *chainhash.Hash) (*tbcd.BlockHeader, bool) {
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
+
+	bh, ok := l.m[*k]
+	return bh, ok
+}
+
+func lowIQMapNew(count int) *lowIQMap {
+	return &lowIQMap{
+		count: count,
+		m:     make(map[chainhash.Hash]*tbcd.BlockHeader, count),
+	}
+}

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -113,9 +113,9 @@ type Config struct {
 
 func NewConfig(home string) *Config {
 	return &Config{
-		Home:             home,     // require user to set home.
-		BlockCache:       250,      // max 4GB on mainnet
-		BlockheaderCache: int(1e6), // Cache all blockheaders on mainnet
+		Home:             home, // require user to set home.
+		BlockCache:       250,  // max 4GB on mainnet
+		BlockheaderCache: 1e6,  // Cache all blockheaders on mainnet
 	}
 }
 
@@ -328,7 +328,7 @@ func encodeBlockHeader(height uint64, header [80]byte, difficulty *big.Int) (ebh
 // XXX should we have a function that does not call the expensive headerHash function?
 func decodeBlockHeader(ebh []byte) *tbcd.BlockHeader {
 	bh := &tbcd.BlockHeader{
-		Hash:   headerHash(ebh[8:88]),
+		Hash:   *headerHash(ebh[8:88]),
 		Height: binary.BigEndian.Uint64(ebh[0:8]),
 	}
 	// copy the values to prevent slicing reentrancy problems.
@@ -560,7 +560,7 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders) (tbc
 	}
 
 	cbh := &tbcd.BlockHeader{
-		Hash:       &bhash,
+		Hash:       bhash,
 		Height:     height,
 		Difficulty: *cdiff,
 		Header:     lastBlockHeader,

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -72,7 +72,7 @@ var (
 )
 
 type HashHeight struct {
-	Hash   *chainhash.Hash
+	Hash   chainhash.Hash
 	Height uint64
 }
 
@@ -95,7 +95,7 @@ func (s *Server) mdHashHeight(ctx context.Context, key []byte) (*HashHeight, err
 	if err != nil {
 		return nil, fmt.Errorf("metadata block header: %w", err)
 	}
-	return &HashHeight{Hash: ch, Height: bh.Height}, nil
+	return &HashHeight{Hash: *ch, Height: bh.Height}, nil
 }
 
 // UtxoIndexHash returns the last hash that has been been UTxO indexed.
@@ -439,7 +439,7 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 			return 0, last, fmt.Errorf("utxo index hash: %w", err)
 		}
 		utxoHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
@@ -451,7 +451,7 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 		log.Debugf("indexing utxos: %v", hh)
 
 		hash := hh.Hash
-		bh, err := s.db.BlockHeaderByHash(ctx, hash)
+		bh, err := s.db.BlockHeaderByHash(ctx, &hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block header %v: %w", hash, err)
 		}
@@ -491,7 +491,7 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 		}
 
 		// Exit if we processed the provided end hash
-		if endHash.IsEqual(hash) {
+		if endHash.IsEqual(&hash) {
 			last = hh
 			break
 		}
@@ -513,7 +513,7 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 			return 0, last, fmt.Errorf("%v does not connect to: %v",
 				bhs[index], hash)
 		}
-		hh.Hash = bhs[index].BlockHash()
+		hh.Hash = *bhs[index].BlockHash()
 		hh.Height = bhs[index].Height
 	}
 
@@ -538,7 +538,7 @@ func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Ha
 			return 0, last, fmt.Errorf("utxo index hash: %w", err)
 		}
 		utxoHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
@@ -550,13 +550,13 @@ func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Ha
 		log.Debugf("unindexing utxos: %v", hh)
 
 		hash := hh.Hash
-		bh, err := s.db.BlockHeaderByHash(ctx, hash)
+		bh, err := s.db.BlockHeaderByHash(ctx, &hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block header %v: %w", hash, err)
 		}
 
 		// Exit if we processed the provided end hash
-		if endHash.IsEqual(hash) {
+		if endHash.IsEqual(&hash) {
 			last = hh
 			break
 		}
@@ -601,7 +601,7 @@ func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Ha
 			return 0, last, fmt.Errorf("block headers by height %v: %w",
 				height, err)
 		}
-		hh.Hash = pbh.BlockHash()
+		hh.Hash = *pbh.BlockHash()
 		hh.Height = pbh.Height
 	}
 
@@ -661,7 +661,7 @@ func (s *Server) UtxoIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Blo
 			return fmt.Errorf("metadata utxo hash: %w", err)
 		}
 
-		if endHash.IsEqual(last.Hash) {
+		if endHash.IsEqual(&last.Hash) {
 			break
 		}
 	}
@@ -721,7 +721,7 @@ func (s *Server) UtxoIndexerWind(ctx context.Context, startBH, endBH *tbcd.Block
 		if err != nil {
 			return fmt.Errorf("metadata utxo hash: %w", err)
 		}
-		if endHash.IsEqual(last.Hash) {
+		if endHash.IsEqual(&last.Hash) {
 			break
 		}
 	}
@@ -758,13 +758,13 @@ func (s *Server) UtxoIndexer(ctx context.Context, endHash *chainhash.Hash) error
 			return fmt.Errorf("utxo indexer: %w", err)
 		}
 		utxoHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
 
 	// XXX make sure there is no gap between start and end or vice versa.
-	startBH, err := s.db.BlockHeaderByHash(ctx, utxoHH.Hash)
+	startBH, err := s.db.BlockHeaderByHash(ctx, &utxoHH.Hash)
 	if err != nil {
 		return fmt.Errorf("blockheader hash: %w", err)
 	}
@@ -829,7 +829,7 @@ func (s *Server) indexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, 
 			return 0, last, fmt.Errorf("tx index hash: %w", err)
 		}
 		txHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
@@ -841,7 +841,7 @@ func (s *Server) indexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, 
 		log.Debugf("indexing txs: %v", hh)
 
 		hash := hh.Hash
-		bh, err := s.db.BlockHeaderByHash(ctx, hash)
+		bh, err := s.db.BlockHeaderByHash(ctx, &hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block header %v: %w", hash, err)
 		}
@@ -873,7 +873,7 @@ func (s *Server) indexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, 
 		}
 
 		// Exit if we processed the provided end hash
-		if endHash.IsEqual(hash) {
+		if endHash.IsEqual(&hash) {
 			last = hh
 			break
 		}
@@ -895,7 +895,7 @@ func (s *Server) indexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, 
 			return 0, last, fmt.Errorf("%v does not connect to: %v",
 				bhs[index], hash)
 		}
-		hh.Hash = bhs[index].BlockHash()
+		hh.Hash = *bhs[index].BlockHash()
 		hh.Height = bhs[index].Height
 	}
 
@@ -920,7 +920,7 @@ func (s *Server) unindexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash
 			return 0, last, fmt.Errorf("tx index hash: %w", err)
 		}
 		txHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
@@ -934,12 +934,12 @@ func (s *Server) unindexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash
 		hash := hh.Hash
 
 		// Exit if we processed the provided end hash
-		if endHash.IsEqual(hash) {
+		if endHash.IsEqual(&hash) {
 			last = hh
 			break
 		}
 
-		bh, err := s.db.BlockHeaderByHash(ctx, hash)
+		bh, err := s.db.BlockHeaderByHash(ctx, &hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block header %v: %w", hash, err)
 		}
@@ -986,7 +986,7 @@ func (s *Server) unindexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash
 			return 0, last, fmt.Errorf("block headers by height %v: %w",
 				height, err)
 		}
-		hh.Hash = pbh.BlockHash()
+		hh.Hash = *pbh.BlockHash()
 		hh.Height = pbh.Height
 	}
 
@@ -1046,7 +1046,7 @@ func (s *Server) TxIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Block
 			return fmt.Errorf("metadata tx hash: %w", err)
 		}
 
-		if endHash.IsEqual(last.Hash) {
+		if endHash.IsEqual(&last.Hash) {
 			break
 		}
 
@@ -1106,7 +1106,7 @@ func (s *Server) TxIndexerWind(ctx context.Context, startBH, endBH *tbcd.BlockHe
 			return fmt.Errorf("metadata tx hash: %w", err)
 		}
 
-		if endHash.IsEqual(last.Hash) {
+		if endHash.IsEqual(&last.Hash) {
 			break
 		}
 
@@ -1145,13 +1145,13 @@ func (s *Server) TxIndexer(ctx context.Context, endHash *chainhash.Hash) error {
 			return fmt.Errorf("tx indexer: %w", err)
 		}
 		txHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
 
 	// Make sure there is no gap between start and end or vice versa.
-	startBH, err := s.db.BlockHeaderByHash(ctx, txHH.Hash)
+	startBH, err := s.db.BlockHeaderByHash(ctx, &txHH.Hash)
 	if err != nil {
 		return fmt.Errorf("blockheader hash: %w", err)
 	}
@@ -1183,12 +1183,12 @@ func (s *Server) UtxoIndexIsLinear(ctx context.Context, endHash *chainhash.Hash)
 			return 0, fmt.Errorf("tx indexer: %w", err)
 		}
 		utxoHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
 
-	return s.IndexIsLinear(ctx, utxoHH.Hash, endHash)
+	return s.IndexIsLinear(ctx, &utxoHH.Hash, endHash)
 }
 
 func (s *Server) TxIndexIsLinear(ctx context.Context, endHash *chainhash.Hash) (int, error) {
@@ -1202,12 +1202,12 @@ func (s *Server) TxIndexIsLinear(ctx context.Context, endHash *chainhash.Hash) (
 			return 0, fmt.Errorf("tx indexer: %w", err)
 		}
 		txHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
 
-	return s.IndexIsLinear(ctx, txHH.Hash, endHash)
+	return s.IndexIsLinear(ctx, &txHH.Hash, endHash)
 }
 
 func (s *Server) IndexIsLinear(ctx context.Context, startHash, endHash *chainhash.Hash) (int, error) {
@@ -1360,11 +1360,11 @@ func (s *Server) syncIndexersToBest(ctx context.Context) error {
 			return fmt.Errorf("utxo index hash: %w", err)
 		}
 		utxoHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
-	utxoBH, err := s.db.BlockHeaderByHash(ctx, utxoHH.Hash)
+	utxoBH, err := s.db.BlockHeaderByHash(ctx, &utxoHH.Hash)
 	if err != nil {
 		return err
 	}
@@ -1392,11 +1392,11 @@ func (s *Server) syncIndexersToBest(ctx context.Context) error {
 			return fmt.Errorf("tx index hash: %w", err)
 		}
 		txHH = &HashHeight{
-			Hash:   s.chainParams.GenesisHash,
+			Hash:   *s.chainParams.GenesisHash,
 			Height: 0,
 		}
 	}
-	txBH, err := s.db.BlockHeaderByHash(ctx, txHH.Hash)
+	txBH, err := s.db.BlockHeaderByHash(ctx, &txHH.Hash)
 	if err != nil {
 		return err
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -864,23 +864,23 @@ func (s *Server) sod(ctx context.Context, p *peer) (*chainhash.Hash, error) {
 	s.mtx.Lock()
 	if s.sodding {
 		s.mtx.Unlock()
-		return bhb.Hash, nil
+		return &bhb.Hash, nil
 	}
 	s.sodding = true
 	s.mtx.Unlock()
 
-	hash, err := s.findCanonicalP2P(ctx, p, bhb.Hash)
+	hash, err := s.findCanonicalP2P(ctx, p, &bhb.Hash)
 	if err != nil {
 		return nil, fmt.Errorf("find canonical: %v %v", p, err)
 	}
-	if hash.IsEqual(bhb.Hash) {
+	if hash.IsEqual(&bhb.Hash) {
 		// Found self, on canonical chain.
-		return bhb.Hash, nil
+		return &bhb.Hash, nil
 	}
 	if bhb.Height > uint64(p.remoteVersion.LastBlock) {
 		log.Debugf("sod: %v our tip is greater %v > %v",
 			p, bhb.Height, p.remoteVersion.LastBlock)
-		return bhb.Hash, nil
+		return &bhb.Hash, nil
 	}
 	log.Infof("Our tip seems not canonical: %v %v common: %v",
 		bhb.Height, bhb, hash)
@@ -1189,7 +1189,7 @@ func (s *Server) handleBlockExpired(ctx context.Context, key any, value any) err
 	if !canonical {
 		log.Infof("deleting from blocks missing: %v %v %v",
 			p, bhX.Height, bhX)
-		err := s.db.BlockMissingDelete(ctx, int64(bhX.Height), bhX.Hash)
+		err := s.db.BlockMissingDelete(ctx, int64(bhX.Height), &bhX.Hash)
 		if err != nil {
 			return fmt.Errorf("block expired delete missing: %w", err)
 		}
@@ -1866,7 +1866,7 @@ func (s *Server) FeesAtHeight(ctx context.Context, height, count int64) (uint64,
 			panic("fees at height: unsupported fork")
 			// return 0, fmt.Errorf("too many block headers: %v", len(bhs))
 		}
-		b, err := s.db.BlockByHash(ctx, bhs[0].Hash)
+		b, err := s.db.BlockByHash(ctx, &bhs[0].Hash)
 		if err != nil {
 			return 0, fmt.Errorf("block by hash: %w", err)
 		}
@@ -1912,10 +1912,10 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 	}
 	// Ensure we have genesis or the Synced flag will be true if metadata
 	// does not exist.
-	if zeroHash.IsEqual(bhb.Hash) {
+	if zeroHash.IsEqual(&bhb.Hash) {
 		panic("no genesis")
 	}
-	si.BlockHeader.Hash = bhb.Hash
+	si.BlockHeader.Hash = &bhb.Hash
 	si.BlockHeader.Height = bhb.Height
 
 	// utxo index
@@ -1932,7 +1932,7 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 	}
 	si.Tx = *txHH
 
-	if utxoHH.Hash.IsEqual(bhb.Hash) && txHH.Hash.IsEqual(bhb.Hash) &&
+	if utxoHH.Hash.IsEqual(&bhb.Hash) && txHH.Hash.IsEqual(&bhb.Hash) &&
 		!s.indexing && !s.blksMissing(ctx) {
 		si.Synced = true
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1915,7 +1915,7 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 	if zeroHash.IsEqual(&bhb.Hash) {
 		panic("no genesis")
 	}
-	si.BlockHeader.Hash = &bhb.Hash
+	si.BlockHeader.Hash = bhb.Hash
 	si.BlockHeader.Height = bhb.Height
 
 	// utxo index


### PR DESCRIPTION
**Summary**
LRU is too expensive to keep track of hundreds-of-thousands, and certainly too expensive for millions of entries.

**Changes**
This PR replaces the blockheader cache with a simple map. It uses a low-iq eviction strategy that basically is just random. It also lifts the block header cache for testnet3 to 3.5M items which may prove to be too expensive. It roughly translates to 4.5G at runtime if fully used. Mainnet uses about 1G.