### PR TITLE
Allow connection of BFG to another BFG for L2 Keystone Notifications/Querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ When running BFG, you'll want the following env variables set:
 * `BFG_BTC_START_HEIGHT`: when your db is empty, bfgd will need a starting point to parse btc blocks at, set this to the tip of the bitcoin chain at first deploy
 * `BFG_EXBTC_ADDRESS`: your electrs rpc address
 
-then you may connect your local `popmd` to your aforementioned local `bfgd` via the `POPM_BFG_URL` env variable
+you may then connect your local `popmd` to your aforementioned local `bfgd` via the `POPM_BFG_URL` env variable
 
 ## ▶️ Running bssd
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ When running BFG, you'll want the following env variables set:
 * `BFG_BTC_START_HEIGHT`: when your db is empty, bfgd will need a starting point to parse btc blocks at, set this to the tip of the bitcoin chain at first deploy
 * `BFG_EXBTC_ADDRESS`: your electrs rpc address
 
-you may then connect your local `popmd` to your aforementioned local `bfgd` via the `POPM_BFG_URL` env variable
+You may then connect your local `popmd` to your aforementioned local `bfgd` via the `POPM_BFG_URL` env variable
 
 ## ▶️ Running bssd
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ go run ./integrationtest
 - A **PostgreSQL database**, bfgd expects the sql scripts in `./database/bfgd/scripts/` to be run to set up your schema.
 - A **connection to an Electrs node** on the proper Bitcoin network (testnet or mainnet).
 
-### Running your own bfgd and PoP mining with it
+### Running your own Bitcoin Finality Governor (bfgd) and PoP mining with it
 
 If you'd like to run your own `bfgd` and don't want to rely on Hemi Labs (or any third party) for _broadcasting transactions_, you may run `bfgd` and connect it to a _trusted_ `bfgd` run by a third party to _receive l2 keystones only_ (l2 keystones represent l2 state and are what are mined in PoP transactions).  In this case, the third party `bfgd` will only send you l2 keystones, your `bfgd` can notify your local pop miner and this will broadcast them to your Electrs+bitcoind setup so you don't rely on Hemi Labs--or any third party--which may be congested.
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ go run ./integrationtest
 - A **PostgreSQL database**, bfgd expects the sql scripts in `./database/bfgd/scripts/` to be run to set up your schema.
 - A **connection to an Electrs node** on the proper Bitcoin network (testnet or mainnet).
 
+### Running your own bfgd and PoP mining with it
+
+If you'd like to run your own `bfgd` and don't want to rely on Hemi Labs (or any third party) for _broadcasting transactions_, you may run `bfgd` and connect it to a _trusted_ `bfgd` run by a third party to _receive l2 keystones only_ (l2 keystones represent l2 state and are what are mined in PoP transactions).  In this case, the third party `bfgd` will only send you l2 keystones, your `bfgd` can notify your local pop miner and this will broadcast them to your Electrs+bitcoind setup so you don't rely on Hemi Labs--or any third party--which may be congested.
+
+If you'd like to do so, use the following environment variables when running bfgd:
+
+* `BFG_BFG_URL`: the _trusted_ `bfgd`'s websocket url that you will connect to
+* `BFG_BTC_PRIVKEY`: your btc private key.  note that this can be an unfunded private key and you'll still receive l2 keystones to mine
+
+then you may connect your local `popmd` to your aforementioned local `bfgd`
+
 ## ▶️ Running bssd
 
 ### 🏁 Prerequisites

--- a/README.md
+++ b/README.md
@@ -144,12 +144,23 @@ go run ./integrationtest
 
 If you'd like to run your own `bfgd` and don't want to rely on Hemi Labs (or any third party) for _broadcasting transactions_, you may run `bfgd` and connect it to a _trusted_ `bfgd` run by a third party to _receive l2 keystones only_ (l2 keystones represent l2 state and are what are mined in PoP transactions).  In this case, the third party `bfgd` will only send you l2 keystones, your `bfgd` can notify your local pop miner and this will broadcast them to your Electrs+bitcoind setup so you don't rely on Hemi Labs--or any third party--which may be congested.
 
-If you'd like to do so, use the following environment variables when running bfgd:
+You'll need the following running to do this:
+* bitcoind
+* electrs
+* postgres
+* bfgd
+
+_Note: make sure you run all of the *.sql files for bfg in `database/bfgd/postgres/scripts`_
+
+When running BFG, you'll want the following env variables set:
 
 * `BFG_BFG_URL`: the _trusted_ `bfgd`'s websocket url that you will connect to
 * `BFG_BTC_PRIVKEY`: your btc private key.  note that this can be an unfunded private key and you'll still receive l2 keystones to mine
+* `BFG_POSTGRES_URI`: the connection URI for your postgres instance
+* `BFG_BTC_START_HEIGHT`: when your db is empty, bfgd will need a starting point to parse btc blocks at, set this to the tip of the bitcoin chain at first deploy
+* `BFG_EXBTC_ADDRESS`: your electrs rpc address
 
-then you may connect your local `popmd` to your aforementioned local `bfgd`
+then you may connect your local `popmd` to your aforementioned local `bfgd` via the `POPM_BFG_URL` env variable
 
 ## ▶️ Running bssd
 

--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -123,6 +123,18 @@ var (
 			Help:         "list of headers used to obtain the client IP address (requires trusted proxies)",
 			Print:        config.PrintAll,
 		},
+		"BFG_BFG_URL": config.Config{
+			Value:        &cfg.BFGURL,
+			DefaultValue: "",
+			Help:         "public websocket address of another BFG you'd like to receive L2Keystones from",
+			Print:        config.PrintAll,
+		},
+		"BFG_BTC_PRIVKEY": config.Config{
+			Value:        &cfg.BTCPrivateKey,
+			DefaultValue: "",
+			Help:         "your btc private key, this is only needed when connecting to another BFG",
+			Print:        config.PrintSecret,
+		},
 	}
 )
 

--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -132,7 +132,7 @@ var (
 		"BFG_BTC_PRIVKEY": config.Config{
 			Value:        &cfg.BTCPrivateKey,
 			DefaultValue: "",
-			Help:         "your btc private key, this is only needed when connecting to another BFG",
+			Help:         "a btc private key, this is only needed when connecting to another BFG",
 			Print:        config.PrintSecret,
 		},
 	}

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -133,10 +133,12 @@ func (p *pgdb) L2KeystonesInsert(ctx context.Context, l2ks []bfgd.L2Keystone) er
 		)
 
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+
+		ON CONFLICT DO NOTHING
 	`
 
 	for _, v := range l2ks {
-		result, err := tx.ExecContext(ctx, qInsertL2Keystone, v.Hash,
+		_, err := tx.ExecContext(ctx, qInsertL2Keystone, v.Hash,
 			v.L1BlockNumber, v.L2BlockNumber, v.ParentEPHash,
 			v.PrevKeystoneEPHash, v.StateRoot, v.EPHash, v.Version)
 		if err != nil {
@@ -155,13 +157,6 @@ func (p *pgdb) L2KeystonesInsert(ctx context.Context, l2ks []bfgd.L2Keystone) er
 				return database.DuplicateError(fmt.Sprintf("constraint error: %s", pgErr))
 			}
 			return fmt.Errorf("insert l2 keystone: %w", err)
-		}
-		rows, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("insert l2 keystone rows affected: %w", err)
-		}
-		if rows < 1 {
-			return fmt.Errorf("insert l2 keystone rows: %v", rows)
 		}
 	}
 

--- a/service/bfg/bfg_test.go
+++ b/service/bfg/bfg_test.go
@@ -6,6 +6,7 @@ package bfg
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -701,5 +702,21 @@ func TestSingleCIDR(t *testing.T) {
 					tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestErrorIfNotPrivKeyConnectingToBFG(t *testing.T) {
+	_, err := NewServer(&Config{
+		RequestLimit:   1,
+		RequestTimeout: 4,
+		BFGURL:         "something",
+	})
+
+	if err == nil {
+		t.Fatalf("expecting error")
+	}
+
+	if !errors.Is(err, ErrBTCPrivateKeyMissing) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
**Summary**
We want to make BFGs easier to run.  This PR will do so by allow a BFG (ex. run by a PoP miner) to receive l2 keystones from another, trusted BFG (example Hemi Labs) and use a local Electrs+bitcoind to broadcast the transaction instead of Hemi Labs (or any third party).  This will avoid congestion during: btc balance retrieval, btc utxos retrieval, btc height retrieval, and btc broadcasting.

fixes #261 

**Changes**
allow a BFG to connect to another BFG.  the client BFG will receive L2 Keystone notifications via the public websocket endpoint, it will then query for new keystones when it gets a notification.

you must use BFG_BFG_URL + BFG_BTC_PRIVKEY to connect to another BFG.

BFG will request the latest 3 keystones upon each notification then save them in the DB and broadcast the keystones to its connected clients

add ON CONFLICT DO NOTHING to no-op with keystones we've already received

updated readme
