### PR TITLE
api,popmd: improve perf and remove redundant bitcoinBalance call

### DIFF
--- a/api/bfgapi/bfgapi.go
+++ b/api/bfgapi/bfgapi.go
@@ -7,7 +7,6 @@ package bfgapi
 import (
 	"context"
 	"fmt"
-	"maps"
 	"reflect"
 
 	"github.com/hemilabs/heminetwork/api"
@@ -222,40 +221,42 @@ var commands = map[protocol.Command]reflect.Type{
 
 type bfgAPI struct{}
 
+var protocolAPI = new(bfgAPI)
+
 func (a *bfgAPI) Commands() map[protocol.Command]reflect.Type {
 	return commands
 }
 
 func APICommands() map[protocol.Command]reflect.Type {
-	return maps.Clone(commands)
+	return commands
 }
 
 // Write is the low level primitive of a protocol Write. One should generally
 // not use this function and use WriteConn and Call instead.
 func Write(ctx context.Context, c protocol.APIConn, id string, payload any) error {
-	return protocol.Write(ctx, c, &bfgAPI{}, id, payload)
+	return protocol.Write(ctx, c, protocolAPI, id, payload)
 }
 
 // Read is the low level primitive of a protocol Read. One should generally
 // not use this function and use ReadConn instead.
 func Read(ctx context.Context, c protocol.APIConn) (protocol.Command, string, any, error) {
-	return protocol.Read(ctx, c, &bfgAPI{})
+	return protocol.Read(ctx, c, protocolAPI)
 }
 
 // Call is a blocking call. One should use ReadConn when using Call or else the
 // completion will end up in the Read instead of being completed as expected.
 func Call(ctx context.Context, c *protocol.Conn, payload any) (protocol.Command, string, any, error) {
-	return c.Call(ctx, &bfgAPI{}, payload)
+	return c.Call(ctx, protocolAPI, payload)
 }
 
 // WriteConn writes to Conn. It is equivalent to Write but exists for symmetry
 // reasons.
 func WriteConn(ctx context.Context, c *protocol.Conn, id string, payload any) error {
-	return c.Write(ctx, &bfgAPI{}, id, payload)
+	return c.Write(ctx, protocolAPI, id, payload)
 }
 
 // ReadConn reads from Conn and performs callbacks. One should use ReadConn over
 // Read when mixing Write, WriteConn and Call.
 func ReadConn(ctx context.Context, c *protocol.Conn) (protocol.Command, string, any, error) {
-	return c.Read(ctx, &bfgAPI{})
+	return c.Read(ctx, protocolAPI)
 }

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -88,53 +88,6 @@ func commandFromPayload(payload any, api API) (Command, bool) {
 	return "", false
 }
 
-// fixupStruct iterates over a struct in order to fix up nil slices.
-func fixupStruct(v reflect.Value) {
-	if v.Type().Kind() != reflect.Struct {
-		return
-	}
-	for i := range v.NumField() {
-		fv := v.Field(i)
-		fk := fv.Type().Kind()
-		if fk == reflect.Ptr {
-			if fv.IsNil() {
-				continue
-			}
-			fv = reflect.Indirect(fv)
-			fk = fv.Type().Kind()
-		}
-		switch fk {
-		case reflect.Slice:
-			fixupNilSlice(fv)
-		case reflect.Struct:
-			fixupStruct(fv)
-		}
-	}
-}
-
-// fixupNilSlice changes a nil slice to an empty slice if it is setable.
-func fixupNilSlice(v reflect.Value) {
-	if v.Type().Kind() != reflect.Slice {
-		return
-	}
-	if !v.IsNil() || !v.CanSet() {
-		return
-	}
-	v.Set(reflect.MakeSlice(v.Type(), 0, 0))
-}
-
-// fixupNilSlices fixes up nil slices to empty slices in a struct and any
-// nested structs.
-func fixupNilSlices(i any) {
-	v := reflect.Indirect(reflect.ValueOf(i))
-	switch v.Type().Kind() {
-	case reflect.Slice:
-		fixupNilSlice(v)
-	case reflect.Struct:
-		fixupStruct(v)
-	}
-}
-
 type API interface {
 	Commands() map[Command]reflect.Type
 }

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -164,25 +164,12 @@ func Write(ctx context.Context, c APIConn, api API, id string, payload interface
 		return fmt.Errorf("command unknown for payload %T", payload)
 	}
 
-	// Go's JSON encoder encodes a nil slice as "null" and an empty
-	// array as "[]" - react does not cope with this, so convert nil
-	// slices to empty slices. In order to do this we need to copy
-	// the payload so as not to modify the original. Yay.
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-	clone := reflect.New(reflect.TypeOf(payload)).Interface()
-	if err := json.Unmarshal(b, clone); err != nil {
-		return err
-	}
-	fixupNilSlices(clone)
-
 	msg := &Message{
 		Header: Header{Command: cmd, ID: id},
 	}
-	msg.Payload, err = json.Marshal(clone)
-	if err != nil {
+
+	var err error
+	if msg.Payload, err = json.Marshal(payload); err != nil {
 		return err
 	}
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -386,15 +386,6 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 	feePerKB := 1024 * m.Fee()
 	feeAmount := (int64(txLen) * int64(feePerKB)) / 1024
 
-	// Retrieve the current balance for the miner.
-	confirmed, unconfirmed, err := m.bitcoinBalance(ctx, scriptHash[:])
-	if err != nil {
-		return fmt.Errorf("get Bitcoin balance: %w", err)
-	}
-
-	log.Tracef("Miner has Bitcoin balance: %v confirmed, %v unconfirmed",
-		confirmed, unconfirmed)
-
 	// Retrieve available UTXOs for the miner.
 	log.Tracef("Looking for UTXOs for script hash %v", scriptHash)
 	utxos, err := m.bitcoinUTXOs(ctx, scriptHash[:])

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -195,28 +195,6 @@ func (m *Miner) SetFee(fee uint) {
 	m.txFee.Store(uint32(fee))
 }
 
-func (m *Miner) bitcoinBalance(ctx context.Context, scriptHash []byte) (uint64, int64, error) {
-	br := &bfgapi.BitcoinBalanceRequest{
-		ScriptHash: scriptHash,
-	}
-
-	res, err := m.callBFG(ctx, m.requestTimeout, br)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	bResp, ok := res.(*bfgapi.BitcoinBalanceResponse)
-	if !ok {
-		return 0, 0, fmt.Errorf("not a BitcoinBalanceResponse %T", res)
-	}
-
-	if bResp.Error != nil {
-		return 0, 0, bResp.Error
-	}
-
-	return bResp.Confirmed, bResp.Unconfirmed, nil
-}
-
 func (m *Miner) bitcoinBroadcast(ctx context.Context, tx []byte) ([]byte, error) {
 	bbr := &bfgapi.BitcoinBroadcastRequest{
 		Transaction: tx,

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -1014,7 +1014,6 @@ func TestConnectToBFGAndPerformMineWithAuth(t *testing.T) {
 		EventConnected,
 		bfgapi.CmdL2KeystonesRequest,
 		bfgapi.CmdBitcoinInfoRequest,
-		bfgapi.CmdBitcoinBalanceRequest,
 		bfgapi.CmdBitcoinUTXOsRequest,
 		bfgapi.CmdBitcoinBroadcastRequest,
 	}
@@ -1078,7 +1077,6 @@ func TestConnectToBFGAndPerformMine(t *testing.T) {
 		EventConnected,
 		bfgapi.CmdL2KeystonesRequest,
 		bfgapi.CmdBitcoinInfoRequest,
-		bfgapi.CmdBitcoinBalanceRequest,
 		bfgapi.CmdBitcoinUTXOsRequest,
 		bfgapi.CmdBitcoinBroadcastRequest,
 	}
@@ -1142,7 +1140,6 @@ func TestConnectToBFGAndPerformMineMultiple(t *testing.T) {
 		EventConnected:                    1,
 		bfgapi.CmdL2KeystonesRequest:      1,
 		bfgapi.CmdBitcoinInfoRequest:      2,
-		bfgapi.CmdBitcoinBalanceRequest:   2,
 		bfgapi.CmdBitcoinUTXOsRequest:     2,
 		bfgapi.CmdBitcoinBroadcastRequest: 2,
 	}
@@ -1207,7 +1204,6 @@ func TestConnectToBFGAndPerformMineALot(t *testing.T) {
 		EventConnected:                    1,
 		bfgapi.CmdL2KeystonesRequest:      1,
 		bfgapi.CmdBitcoinInfoRequest:      l2KeystonesMaxSize,
-		bfgapi.CmdBitcoinBalanceRequest:   l2KeystonesMaxSize,
 		bfgapi.CmdBitcoinUTXOsRequest:     l2KeystonesMaxSize,
 		bfgapi.CmdBitcoinBroadcastRequest: l2KeystonesMaxSize,
 	}


### PR DESCRIPTION
**Summary**
Remove (very expensive) redundant `bitcoinBalance` API call from `mineKeystone`. The result of this API call is logged at the `trace` level, and is not necessary.

Additionally, this includes a few performance improvements for `bfgapi` and `protocol`:
- In `bfgapi`, instead of creating a new `&bfgAPI{}` when reading or writing a message, have one global `bfgAPI` instance which is reused.
- In `bfgapi`, make `APICommands()` return the map directly instead of cloning it.
- In `protocol`, avoid marshaling -> unmarshaling -> marshaling -> marshaling when writing every message. This was done to avoid having `null` arrays in JSON, which some languages *cough JavaScript* don't handle very well, and is not needed here.
