### PR TITLE
Fix disconnects caused by ReadDeadline.

### DIFF
--- a/service/tbc/peer_manager.go
+++ b/service/tbc/peer_manager.go
@@ -311,7 +311,7 @@ func (pm *PeerManager) randomPeer(ctx context.Context, slot int) (*peer, error) 
 	for k := range pm.good {
 		if _, ok := pm.peers[k]; ok {
 			// Address is in use
-			log.Errorf("address already on peers list: %v", k)
+			log.Debugf("address already on peers list: %v", k)
 			continue
 		}
 		if _, ok := pm.bad[k]; ok {


### PR DESCRIPTION
Go's ReadDealine has surprising side effects that caused a functional connection to be terminated prior to actually expiring. By setting the ReadDeadline to 0 the peer read never times out. This is ok because there are a bunch of other commands being written that will cause the read to fail if they do not complete. Simply rely on the chatter to cause a connection close instead of trying to be clever and detect which error type the close path received.

**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->

**Changes**
<!-- A list of changes made by this pull request. -->
