### PR TITLE
version: bump version to 0.5.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -22,8 +22,8 @@ const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst
 // GoReleaser for releases.
 var (
 	Major = "0"
-	Minor = "3"
-	Patch = "0"
+	Minor = "5"
+	Patch = "1"
 )
 
 // PreRelease contains the prerelease name of the application. It is a variable,


### PR DESCRIPTION
**Summary**
Update the version variables in the `version` package to version v0.5.1.
Ideally we should keep these variables set to the next planned version, so that development binaries always have the next planned version.

GoReleaser will always change these in release binaries, so this only affects binaries not built with GoReleaser.

**Changes**
- Change `version.Minor` to `5`.
- Change `version.Patch` to `1`.
