### PR TITLE
make localnet tests more robust

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "-rpcallowip=0.0.0.0/0"
       - "-rpcbind=0.0.0.0:18443"
       - "-txindex=1"
+      - "-rpcworkqueue=400"
     ports:
       - "18443:18443"
       - "18444:18444"

--- a/e2e/monitor/main.go
+++ b/e2e/monitor/main.go
@@ -64,7 +64,8 @@ func monitor(dumpJsonAfterMs uint) string {
 		bitcoinBlockCount: 0,
 	}
 	mtx := sync.Mutex{}
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	t := table.NewWriter()
 	writer := uilive.New()
 	writer.Start()


### PR DESCRIPTION
**Summary**
 make localnet tests more robust

prior, localnet would wait a certain period of time, then check if we reached certain values of different resoruces in our local chain (ex. HEMI balance, pop txs mined).  this was problematic because there was no guarantee that we would reach those within the given amount of time for various reasons.

we could simply increase the time we wait, but then we would have to wait that amount of time per test.

**Changes**
now, set a max timeout of 10 minutes for the test + 2 minute warm up.  poll the network every 10 seconds for values reaching a reasonable threshold.  if we reach this threshold within the timeout, success! otherwise failure.
