### PR TITLE
ci: update and pin actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,10 +40,10 @@ jobs:
           --health-retries 5
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Setup Go ${{ matrix.go-version }}"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ matrix.go-version }}"
           cache: true
@@ -54,7 +54,7 @@ jobs:
         run: echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_OUTPUT"
 
       - name: "Setup GOPATH/bin cache"
-        uses: actions/cache@v4
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: "${{ steps.retrieve.outputs.GOPATH }}/bin/"
           key: "${{ runner.os }}-${{ runner.arch }}-gobin-go${{ env.GO_VERSION }}-${{ hashFiles('**/Makefile') }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,4 +15,4 @@ jobs:
       pull-requests: write
     steps:
       - name: "Label pull requests"
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -23,10 +23,10 @@ jobs:
         go-version: [ "1.23.x" ]
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Setup Go ${{ matrix.go-version }}"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ matrix.go-version }}"
           cache: true

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -28,22 +28,22 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Setup Go ${{ env.GO_VERSION }}"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
           check-latest: true
 
       - name: "Setup pnpm ${{ env.PNPM_VERSION }}"
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
         with:
           version: "${{ env.PNPM_VERSION }}"
 
       - name: "Setup Node"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: "web/.nvmrc"
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,22 +65,22 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Setup Go ${{ env.GO_VERSION }}"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
           check-latest: true
 
       - name: "Setup pnpm ${{ env.PNPM_VERSION }}"
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
         with:
           version: "${{ env.PNPM_VERSION }}"
 
       - name: "Setup Node"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: "web/.nvmrc"
           check-latest: true
@@ -139,44 +139,44 @@ jobs:
       packages: write
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: "Setup Go ${{ env.GO_VERSION }}"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
           check-latest: true
 
       - name: "Install cosign"
-        uses: sigstore/cosign-installer@v3.6.0
+        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409 # v3.7.0
 
       - name: "Install Syft"
-        uses: anchore/sbom-action/download-syft@v0.17.0
+        uses: anchore/sbom-action/download-syft@1ca97d9028b51809cf6d3c934c3e160716e1b605 # v0.17.5
 
       - name: "Setup QEMU"
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
       - name: "Setup Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: "Login to DockerHub"
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
 
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: "ghcr.io"
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "Release"
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: "goreleaser"
           version: "~> v2"


### PR DESCRIPTION
**Summary**
Update the GitHub Actions used in this repository, and pin them to commit hashes.

The `go.yml` and `release.yml` workflows are rather specialised for this repository, however at some point in the near  future, it would be nice to move some of these workflows to https://github.com/hemilabs/actions.

**Changes**
- Pin `actions/cache` to v4.1.2 (`6849a6489940f00c2f30c0fb92c6274307ccb58a`)
- Pin `actions/checkout` to v4.2.2 (`11bd71901bbe5b1630ceea73d27597364c9af683`)
- Pin `actions/labeler` to v5.0.0 (`8558fd74291d67161a8a78ce36a881fa63b766a9`)
- Pin `actions/setup-go` to v5.1.0 (`41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed`)
- Pin `actions/setup-node` to v4.1.0 (`39370e3970a6d050c480ffad4ff0ed4d3fdee5af`)
- Pin `docker/login-action` to v3.3.0 (`9780b0c442fbb1117ed29e0efdff1e18412f7567`)
- Pin `docker/setup-buildx-action` to v3.7.1 (`c47758b77c9736f4b2ef4073d4d51994fabfe349`)
- Pin `docker/setup-qemu-action` to v3.2.0 (`49b3bc8e6bdd4a60e6116a5414239cba5943d3cf`)
- Pin `goreleaser/goreleaser-action` to v6.0.0 (`286f3b13b1b49da4ac219696163fb8c1c93e1200`)
- Pin `pnpm/action-setup` to v4.0.0 (`0c17529a66aca453f9227af23103ed11469b1e47`)
- Update and pin `anchore/sbom-action/download-syft` to v0.17.5 (`1ca97d9028b51809cf6d3c934c3e160716e1b605`) (from v0.17.0)
- Update and pin `sigstore/cosign-installer` to v3.7.0 (`1aa8e0f2454b781fbf0fbf306a4c9533a0c57409`) (from v3.6.0)
