### PR TITLE
Make isCanonical call not fail on incorrect height.

### DIFF
--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -199,8 +199,11 @@ func (s *Server) isCanonical(ctx context.Context, bh *tbcd.BlockHeader) (bool, e
 		return false, err
 	}
 	if bhb.Height < bh.Height {
-		return false, fmt.Errorf("best height less than provided height: %v < %v",
+		// We either hit a race or the caller did something wrong.
+		// Either way, it cannot be canonical.
+		log.Debugf("best height less than provided height: %v < %v",
 			bhb.Height, bh.Height)
+		return false, nil
 	}
 	if bhb.Hash.IsEqual(&bh.Hash) {
 		// Self == best


### PR DESCRIPTION
When the caller, for whatever reason, calls isCanonical with a block header that sits higher on the chain than best block header it cannot be canonical. This case did return false but also an error. Remove the error since the block simply is not canonical.

**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->

**Changes**
<!-- A list of changes made by this pull request. -->
