### PR TITLE
go.mod: use toolchain go1.23.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hemilabs/heminetwork
 
 go 1.23
 
-toolchain go1.23.0
+toolchain go1.23.3
 
 // Temporary replace until we upstream our ws_js patch.
 replace github.com/coder/websocket v1.8.12 => github.com/hemilabs/websocket v0.0.0-20240813101919-bf33653e9aa5


### PR DESCRIPTION
**Summary**
Use Go 1.23.3 as the toolchain in `go.mod`.

**Changes**
- Change toolchain in `go.mod` to `go1.23.3`.