### PR TITLE
Add InsertBlock RPC

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -64,6 +64,12 @@ const (
 
 	CmdTxBroadcastRawRequest  = "tbcapi-tx-broadcast-raw-request"
 	CmdTxBroadcastRawResponse = "tbcapi-tx-broadcast-raw-response"
+
+	CmdBlockInsertRequest  = "tbcapi-block-insert-request"
+	CmdBlockInsertResponse = "tbcapi-block-insert-response"
+
+	CmdBlockInsertRawRequest  = "tbcapi-block-insert-raw-request"
+	CmdBlockInsertRawResponse = "tbcapi-block-insert-raw-response"
 )
 
 var (
@@ -259,6 +265,24 @@ type TxBroadcastRawResponse struct {
 	Error *protocol.Error `json:"error,omitempty"`
 }
 
+type BlockInsertRequest struct {
+	Block *wire.MsgBlock `json:"block"`
+}
+
+type BlockInsertResponse struct {
+	BlockHash *chainhash.Hash `json:"block_hash"`
+	Error     *protocol.Error `json:"error,omitempty"`
+}
+
+type BlockInsertRawRequest struct {
+	Block api.ByteSlice `json:"block"`
+}
+
+type BlockInsertRawResponse struct {
+	BlockHash *chainhash.Hash `json:"block_hash"`
+	Error     *protocol.Error `json:"error,omitempty"`
+}
+
 var commands = map[protocol.Command]reflect.Type{
 	CmdPingRequest:                     reflect.TypeOf(PingRequest{}),
 	CmdPingResponse:                    reflect.TypeOf(PingResponse{}),
@@ -288,6 +312,10 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdTxBroadcastResponse:             reflect.TypeOf(TxBroadcastResponse{}),
 	CmdTxBroadcastRawRequest:           reflect.TypeOf(TxBroadcastRawRequest{}),
 	CmdTxBroadcastRawResponse:          reflect.TypeOf(TxBroadcastRawResponse{}),
+	CmdBlockInsertRequest:              reflect.TypeOf(BlockInsertRequest{}),
+	CmdBlockInsertResponse:             reflect.TypeOf(BlockInsertResponse{}),
+	CmdBlockInsertRawRequest:           reflect.TypeOf(BlockInsertRawRequest{}),
+	CmdBlockInsertRawResponse:          reflect.TypeOf(BlockInsertRawResponse{}),
 }
 
 type tbcAPI struct{}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
@@ -159,6 +160,20 @@ func (s *Server) handleWebsocketRead(ctx context.Context, ws *tbcWs) {
 			handler := func(ctx context.Context) (any, error) {
 				req := payload.(*tbcapi.TxBroadcastRawRequest)
 				return s.handleTxBroadcastRawRequest(ctx, req)
+			}
+
+			go s.handleRequest(ctx, ws, id, cmd, handler)
+		case tbcapi.CmdBlockInsertRequest:
+			handler := func(ctx context.Context) (any, error) {
+				req := payload.(*tbcapi.BlockInsertRequest)
+				return s.handleBlockInsertRequest(ctx, req)
+			}
+
+			go s.handleRequest(ctx, ws, id, cmd, handler)
+		case tbcapi.CmdBlockInsertRawRequest:
+			handler := func(ctx context.Context) (any, error) {
+				req := payload.(*tbcapi.BlockInsertRawRequest)
+				return s.handleBlockInsertRawRequest(ctx, req)
 			}
 
 			go s.handleRequest(ctx, ws, id, cmd, handler)
@@ -545,7 +560,43 @@ func (s *Server) handleTxBroadcastRawRequest(ctx context.Context, req *tbcapi.Tx
 		return &tbcapi.TxBroadcastResponse{Error: e.ProtocolError()}, e
 	}
 
-	return &tbcapi.TxBroadcastResponse{TxID: txid}, nil
+	return &tbcapi.TxBroadcastRawResponse{TxID: txid}, nil
+}
+
+func (s *Server) handleBlockInsertRequest(ctx context.Context, req *tbcapi.BlockInsertRequest) (any, error) {
+	log.Tracef("handleBlockInsertRequest")
+	defer log.Tracef("handleBlockInsertRequest exit")
+
+	_, err := s.db.BlockInsert(ctx, btcutil.NewBlock(req.Block))
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockInsertResponse{Error: e.ProtocolError()}, e
+	}
+
+	hash := req.Block.Header.BlockHash()
+	return &tbcapi.BlockInsertResponse{BlockHash: &hash}, nil
+}
+
+func (s *Server) handleBlockInsertRawRequest(ctx context.Context, req *tbcapi.BlockInsertRawRequest) (any, error) {
+	log.Tracef("handleBlockInsertRawRequest")
+	defer log.Tracef("handleBlockInsertRawRequest exit")
+
+	b := wire.NewMsgBlock(nil)
+	err := b.Deserialize(bytes.NewBuffer(req.Block))
+	if err != nil {
+		return &tbcapi.BlockInsertResponse{
+			Error: protocol.RequestError(err),
+		}, nil
+	}
+
+	_, err = s.db.BlockInsert(ctx, btcutil.NewBlock(b))
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockInsertResponse{Error: e.ProtocolError()}, e
+	}
+
+	hash := b.Header.BlockHash()
+	return &tbcapi.BlockInsertRawResponse{BlockHash: &hash}, nil
 }
 
 func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -528,6 +528,13 @@ func (s *Server) handleTxBroadcastRequest(ctx context.Context, req *tbcapi.TxBro
 	log.Tracef("handleTxBroadcastRequest")
 	defer log.Tracef("handleTxBroadcastRequest exit")
 
+	if req.Tx == nil {
+		err := errors.New("no tx provided")
+		return &tbcapi.TxBroadcastResponse{
+			Error: protocol.RequestError(err),
+		}, err
+	}
+
 	txid, err := s.TxBroadcast(ctx, req.Tx, req.Force)
 	if err != nil {
 		if errors.Is(err, ErrTxAlreadyBroadcast) || errors.Is(err, ErrTxBroadcastNoPeers) {
@@ -566,6 +573,13 @@ func (s *Server) handleTxBroadcastRawRequest(ctx context.Context, req *tbcapi.Tx
 func (s *Server) handleBlockInsertRequest(ctx context.Context, req *tbcapi.BlockInsertRequest) (any, error) {
 	log.Tracef("handleBlockInsertRequest")
 	defer log.Tracef("handleBlockInsertRequest exit")
+
+	if req.Block == nil {
+		err := errors.New("no block provided")
+		return &tbcapi.BlockInsertResponse{
+			Error: protocol.RequestError(err),
+		}, err
+	}
 
 	_, err := s.db.BlockInsert(ctx, btcutil.NewBlock(req.Block))
 	if err != nil {


### PR DESCRIPTION
When TBC is used inside other services we may need to insert blocks. The use case is an op-geth that has seen a block in the past yet tbc does not know it because it isn't canonical. Now that block may be needed for an index since it *was* canonical at some point in the past. It's a bit of a hack but there is no harm in having blocks sitting in the database that have been reorged out.