### PR TITLE
fragile test fixes + random bitcoind port during tests

### DIFF
--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2830,8 +2830,13 @@ func TestGetFinalitiesByL2KeystoneBFGWithPagination(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if v.Header.Command != bfgapi.CmdBTCFinalityByKeystonesResponse {
-			t.Fatalf("received unexpected command: %s", v.Header.Command)
+		// filter out notifications
+		for v.Header.Command != bfgapi.CmdBTCFinalityByKeystonesResponse {
+			t.Logf("received unexpected command: %s", v.Header.Command)
+			err = wsjson.Read(ctx, c, &v)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		finalityResponse := bfgapi.BTCFinalityByRecentKeystonesResponse{}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/coder/websocket v1.8.12
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
-	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ethereum/go-ethereum v1.14.8
@@ -48,6 +47,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -61,10 +61,6 @@ const (
 var (
 	zeroHash = new(chainhash.Hash) // used to check if a hash is invalid
 
-	localnetSeeds = []string{
-		"127.0.0.1:18444",
-	}
-
 	ErrTxAlreadyBroadcast = errors.New("tx already broadcast")
 	ErrTxBroadcastNoPeers = errors.New("can't broadcast tx, no peers")
 )


### PR DESCRIPTION
**Summary**
 fragile test fixes, including random port for test bitcoind


**Changes**
fix a fragile test by filtering out incorrect commands, rather than failing on the first incorrect.  we get notifications this way, so it is sometimes expected to get a "notification".

also, expose bitoind on random ports during tests for tbc to avoid port collisions
