### PR TITLE
Add External Header Mode to TBC + Misc Regular Node Updates

### DIFF
--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/hemilabs/heminetwork/database"
 )
@@ -52,25 +53,23 @@ const (
 	RTChainFork    RemoveType = 3 // Removal walked canonical chain backwards far enough that another chain is now canonical
 )
 
-var (
-	rtStrings = map[RemoveType]string{
-		RTInvalid:      "invalid",
-		RTChainDescend: "canonical chain descend",
-		RTForkDescend:  "fork chain descend",
-		RTChainFork:    "canonical descend changed canonical",
-	}
-
-	DefaultUpstreamStateId = [32]byte{
-		0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00,
-		0x44, 0x45, 0x46, 0x41, 0x55, 0x4C, 0x54, 0x55, 0x50, 0x53, // DEFAULTUPS
-		0x54, 0x52, 0x45, 0x41, 0x4D, 0x53, 0x54, 0x41, 0x54, 0x45, // TREAMSTATE
-		0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF,
-	}
-)
+var rtStrings = map[RemoveType]string{
+	RTInvalid:      "invalid",
+	RTChainDescend: "canonical chain descend",
+	RTForkDescend:  "fork chain descend",
+	RTChainFork:    "canonical descend changed canonical",
+}
 
 func (rt RemoveType) String() string {
 	return rtStrings[rt]
 }
+
+type Transaction struct {
+	Batch       *leveldb.Batch
+	Transaction *leveldb.Transaction
+}
+
+type PostHook func(ctx context.Context, transactions map[string]Transaction) error
 
 type Database interface {
 	database.Database
@@ -85,14 +84,10 @@ type Database interface {
 	BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*BlockHeader, error)
 	BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader, height uint64, diff *big.Int) error
 
-	// Upstream state id
-	UpstreamStateId(ctx context.Context) (*[32]byte, error)
-	SetUpstreamStateId(ctx context.Context, upstreamStateId *[32]byte) error
-
 	// Block headers
 	BlockHeadersByHeight(ctx context.Context, height uint64) ([]BlockHeader, error)
-	BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, upstreamStateId *[32]byte) (InsertType, *BlockHeader, *BlockHeader, int, error)
-	BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, upstreamStateId *[32]byte) (RemoveType, *BlockHeader, error)
+	BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, postHook PostHook) (InsertType, *BlockHeader, *BlockHeader, int, error)
+	BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, postHook PostHook) (RemoveType, *BlockHeader, error)
 
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -42,6 +42,36 @@ func (it InsertType) String() string {
 	return itStrings[it]
 }
 
+// Canonical chain geometry changes resulting from header removal
+type RemoveType int
+
+const (
+	RTInvalid      RemoveType = 0 // Invalid removal for generic reason (ex: no headers to remove)
+	RTChainDescend RemoveType = 1 // Removal walked the canonical chain backwards, but existing chain is still canonical
+	RTForkDescend  RemoveType = 2 // Removal walked a non-canonical chain backwards, no change to canonical chain remaining canonical
+	RTChainFork    RemoveType = 3 // Removal walked canonical chain backwards far enough that another chain is now canonical
+)
+
+var (
+	rtStrings = map[RemoveType]string{
+		RTInvalid:      "invalid",
+		RTChainDescend: "canonical chain descend",
+		RTForkDescend:  "fork chain descend",
+		RTChainFork:    "canonical descend changed canonical",
+	}
+
+	DefaultUpstreamStateId = [32]byte{
+		0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+		0x44, 0x45, 0x46, 0x41, 0x55, 0x4C, 0x54, 0x55, 0x50, 0x53, // DEFAULTUPS
+		0x54, 0x52, 0x45, 0x41, 0x4D, 0x53, 0x54, 0x41, 0x54, 0x45, // TREAMSTATE
+		0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF,
+	}
+)
+
+func (rt RemoveType) String() string {
+	return rtStrings[rt]
+}
+
 type Database interface {
 	database.Database
 
@@ -53,11 +83,16 @@ type Database interface {
 	// Block header
 	BlockHeaderBest(ctx context.Context) (*BlockHeader, error) // return canonical
 	BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*BlockHeader, error)
-	BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader) error
+	BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader, height uint64, diff *big.Int) error
+
+	// Upstream state id
+	UpstreamStateId(ctx context.Context) (*[32]byte, error)
+	SetUpstreamStateId(ctx context.Context, upstreamStateId *[32]byte) error
 
 	// Block headers
 	BlockHeadersByHeight(ctx context.Context, height uint64) ([]BlockHeader, error)
-	BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders) (InsertType, *BlockHeader, *BlockHeader, int, error)
+	BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, upstreamStateId *[32]byte) (InsertType, *BlockHeader, *BlockHeader, int, error)
+	BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, upstreamStateId *[32]byte) (RemoveType, *BlockHeader, error)
 
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -46,7 +46,6 @@ const (
 	verbose  = false
 
 	bhsCanonicalTipKey = "canonicaltip"
-	upstreamStateIdKey = "upstreamstateid" // Key used for storing upstream state IDs representing a unique state of an upstream system driving TBC state
 )
 
 type IteratorError error
@@ -207,71 +206,6 @@ func (l *ldb) MetadataPut(ctx context.Context, key, value []byte) error {
 
 	mdDB := l.pool[level.MetadataDB]
 	return mdDB.Put(key, value, nil)
-}
-
-// UpstreamStateId retrieves the upstream state ID that TBC currently holds, which
-// should correspond to TBC being in a deterministic state expected by upstream software
-// based on the upstream state ID which is set.
-func (l *ldb) UpstreamStateId(ctx context.Context) (*[32]byte, error) {
-	log.Tracef("UpstreamStateId")
-	defer log.Tracef("UpstreamStateId exit")
-
-	bhsDB := l.pool[level.BlockHeadersDB]
-
-	// Get last record
-	upstreamStateId, err := bhsDB.Get([]byte(upstreamStateIdKey), nil)
-	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, database.NotFoundError("upstream state id not found")
-		}
-		return nil, fmt.Errorf("upstream state id: %w", err)
-	}
-
-	var ret [32]byte
-	copy(ret[0:32], upstreamStateId[0:32])
-	return &ret, nil
-}
-
-// SetUpstreamStateId sets the upstream state ID which represents a unique upstream state
-// of the software that dictates the complete state of a TBC instance. Currently only used
-// for header-only mode TBC instances, where upstream software manages all of the headers
-// available to a TBC instance, and where the same upstream state ID should always correlate
-// to the same information being provided to TBC in the same order, which should render a
-// TBC instance with deterministic state. This externally exported method provides the
-// upstream software the ability to update the upstream state ID without making any other
-// state modifications to TBC, such that the upstream software can update TBC to reflect
-// a change in upstream state in the event that such a change does not result in any other
-// TBC state modifications.
-func (l *ldb) SetUpstreamStateId(ctx context.Context, upstreamStateId *[32]byte) error {
-	log.Tracef("SetUpstreamStateId")
-	defer log.Tracef("SetUpstreamStateId exit")
-
-	if upstreamStateId == nil {
-		return fmt.Errorf("cannot explicitly set upstream state id with a nil upstreamStateId")
-	}
-
-	// block headers
-	bhsTx, bhsCommit, bhsDiscard, err := l.startTransaction(level.BlockHeadersDB)
-	if err != nil {
-		return fmt.Errorf("block header open transaction: %w", err)
-	}
-
-	defer bhsDiscard()
-
-	bhBatch := new(leveldb.Batch)
-	bhBatch.Put([]byte(upstreamStateIdKey), upstreamStateId[:])
-
-	// Write block headers batch
-	if err = bhsTx.Write(bhBatch, nil); err != nil {
-		return fmt.Errorf("block header insert: %w", err)
-	}
-
-	// block headers commit
-	if err = bhsCommit(); err != nil {
-		return fmt.Errorf("block header commit: %w", err)
-	}
-
-	return nil
 }
 
 func (l *ldb) BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*tbcd.BlockHeader, error) {
@@ -469,7 +403,6 @@ func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeade
 	bhBatch.Put(bhash[:], ebh[:])
 
 	bhBatch.Put([]byte(bhsCanonicalTipKey), ebh[:])
-	bhBatch.Put([]byte(upstreamStateIdKey), tbcd.DefaultUpstreamStateId[:])
 
 	// Write height hash batch
 	if err = hhTx.Write(hhBatch, nil); err != nil {
@@ -606,13 +539,16 @@ func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeade
 //
 // If an upstreamCursor is provided, it is updated atomically in the database
 // along with the state transition of removing the block headers.
-func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, upstreamStateId *[32]byte) (tbcd.RemoveType, *tbcd.BlockHeader, error) {
+func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, postHook tbcd.PostHook) (tbcd.RemoveType, *tbcd.BlockHeader, error) {
 	log.Tracef("BlockHeadersRemove")
 	defer log.Tracef("BlockHeadersRemove exit")
 	if len(bhs.Headers) == 0 {
 		return tbcd.RTInvalid, nil,
 			errors.New("block headers remove: no block headers to remove")
 	}
+
+	// XXX this function looks broken; this looks ike everything should
+	// happen inside the database transaction.
 
 	// Get current canonical tip for later use
 	originalCanonicalTip, err := l.BlockHeaderBest(ctx)
@@ -788,17 +724,10 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 	tipEbh := encodeBlockHeader(tipAfterRemovalFromDb.Height, tipAfterRemovalEncoded, &tipAfterRemovalFromDb.Difficulty)
 	bhsBatch.Put([]byte(bhsCanonicalTipKey), tipEbh[:])
 
-	if upstreamStateId != nil {
-		bhsBatch.Put([]byte(upstreamStateIdKey), upstreamStateId[:])
-	} else {
-		// On updates if no upstream state ID is specified, we always set a default
-		// so errors where the upstream state ID can be troubleshooted more easily
-		// by making it clear that a call without a specified upstream state ID
-		// occurred.
-		bhsBatch.Put([]byte(upstreamStateIdKey), tbcd.DefaultUpstreamStateId[:])
-	}
+	// XXX move upstreamStateId from here to right before Commit
 
 	// Get parent block from database
+	// XXX verify l. here instead of using the bh transaction to get the hash
 	parentToRemovalSet, err := l.BlockHeaderByHash(ctx, &headersParsed[0].PrevBlock)
 	if err != nil {
 		return tbcd.RTInvalid, nil,
@@ -827,6 +756,24 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 		// Do this before the end of function so we don't apply database changes.
 		return tbcd.RTInvalid, nil,
 			fmt.Errorf("block headers remove: none of the chain geometry checks applies to this removal")
+	}
+
+	// Call post hook if set.
+	if postHook != nil {
+		dbTransactions := map[string]tbcd.Transaction{
+			level.BlockHeadersDB: {
+				Transaction: bhsTx,
+				Batch:       bhsBatch,
+			},
+			level.HeightHashDB: {
+				Transaction: hhTx,
+				Batch:       hhBatch,
+			},
+		}
+		err := postHook(ctx, dbTransactions)
+		if err != nil {
+			return tbcd.RTInvalid, nil, fmt.Errorf("post hook: %w", err)
+		}
 	}
 
 	// Write height hash batch
@@ -864,7 +811,7 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 // and always returns the canonical and last inserted blockheader, which may be
 // the same.
 // This call uses the database to prevent reentrancy.
-func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, upstreamStateId *[32]byte) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
+func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, postHook tbcd.PostHook) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
 	log.Tracef("BlockHeadersInsert")
 	defer log.Tracef("BlockHeadersInsert exit")
 
@@ -1039,14 +986,27 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, upst
 		it = tbcd.ITChainExtend
 	}
 
-	if upstreamStateId != nil {
-		bhsBatch.Put([]byte(upstreamStateIdKey), upstreamStateId[:])
-	} else {
-		// On updates if no upstream state ID is specified, we always set a default
-		// so errors where the upstream state ID can be troubleshooted more easily
-		// by making it clear that a call without a specified upstream state ID
-		// occurred.
-		bhsBatch.Put([]byte(upstreamStateIdKey), tbcd.DefaultUpstreamStateId[:])
+	// Call post hook if set.
+	if postHook != nil {
+		dbTransactions := map[string]tbcd.Transaction{
+			level.BlockHeadersDB: {
+				Transaction: bhsTx,
+				Batch:       bhsBatch,
+			},
+			level.BlocksMissingDB: {
+				Transaction: bmTx,
+				Batch:       bmBatch,
+			},
+			level.HeightHashDB: {
+				Transaction: hhTx,
+				Batch:       hhBatch,
+			},
+		}
+		err := postHook(ctx, dbTransactions)
+		if err != nil {
+			return tbcd.ITInvalid, nil, nil, 0,
+				fmt.Errorf("post hook: %w", err)
+		}
 	}
 
 	// Write height hash batch

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -46,6 +46,7 @@ const (
 	verbose  = false
 
 	bhsCanonicalTipKey = "canonicaltip"
+	upstreamStateIdKey = "upstreamstateid" // Key used for storing upstream state IDs representing a unique state of an upstream system driving TBC state
 )
 
 type IteratorError error
@@ -208,6 +209,71 @@ func (l *ldb) MetadataPut(ctx context.Context, key, value []byte) error {
 	return mdDB.Put(key, value, nil)
 }
 
+// UpstreamStateId retrieves the upstream state ID that TBC currently holds, which
+// should correspond to TBC being in a deterministic state expected by upstream software
+// based on the upstream state ID which is set.
+func (l *ldb) UpstreamStateId(ctx context.Context) (*[32]byte, error) {
+	log.Tracef("UpstreamStateId")
+	defer log.Tracef("UpstreamStateId exit")
+
+	bhsDB := l.pool[level.BlockHeadersDB]
+
+	// Get last record
+	upstreamStateId, err := bhsDB.Get([]byte(upstreamStateIdKey), nil)
+	if err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return nil, database.NotFoundError("upstream state id not found")
+		}
+		return nil, fmt.Errorf("upstream state id: %w", err)
+	}
+
+	var ret [32]byte
+	copy(ret[0:32], upstreamStateId[0:32])
+	return &ret, nil
+}
+
+// SetUpstreamStateId sets the upstream state ID which represents a unique upstream state
+// of the software that dictates the complete state of a TBC instance. Currently only used
+// for header-only mode TBC instances, where upstream software manages all of the headers
+// available to a TBC instance, and where the same upstream state ID should always correlate
+// to the same information being provided to TBC in the same order, which should render a
+// TBC instance with deterministic state. This externally exported method provides the
+// upstream software the ability to update the upstream state ID without making any other
+// state modifications to TBC, such that the upstream software can update TBC to reflect
+// a change in upstream state in the event that such a change does not result in any other
+// TBC state modifications.
+func (l *ldb) SetUpstreamStateId(ctx context.Context, upstreamStateId *[32]byte) error {
+	log.Tracef("SetUpstreamStateId")
+	defer log.Tracef("SetUpstreamStateId exit")
+
+	if upstreamStateId == nil {
+		return fmt.Errorf("cannot explicitly set upstream state id with a nil upstreamStateId")
+	}
+
+	// block headers
+	bhsTx, bhsCommit, bhsDiscard, err := l.startTransaction(level.BlockHeadersDB)
+	if err != nil {
+		return fmt.Errorf("block header open transaction: %w", err)
+	}
+
+	defer bhsDiscard()
+
+	bhBatch := new(leveldb.Batch)
+	bhBatch.Put([]byte(upstreamStateIdKey), upstreamStateId[:])
+
+	// Write block headers batch
+	if err = bhsTx.Write(bhBatch, nil); err != nil {
+		return fmt.Errorf("block header insert: %w", err)
+	}
+
+	// block headers commit
+	if err = bhsCommit(); err != nil {
+		return fmt.Errorf("block header commit: %w", err)
+	}
+
+	return nil
+}
+
 func (l *ldb) BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*tbcd.BlockHeader, error) {
 	log.Tracef("BlockHeaderByHash")
 	defer log.Tracef("BlockHeaderByHash exit")
@@ -337,7 +403,7 @@ func decodeBlockHeader(ebh []byte) *tbcd.BlockHeader {
 	return bh
 }
 
-func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader) error {
+func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader, height uint64, diff *big.Int) error {
 	log.Tracef("BlockHeaderGenesisInsert")
 	defer log.Tracef("BlockHeaderGenesisInsert exit")
 
@@ -377,14 +443,33 @@ func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeade
 	bmBatch := new(leveldb.Batch)
 	bhBatch := new(leveldb.Batch)
 
-	hhKey := heightHashToKey(0, bhash[:])
+	// Genesis insert can be called with an effective genesis block at a particular height
+	// and with a particular cumulative difficulty which is guaranteed canonical (protocol
+	// assumes this effective genesis block will never fork), allowing a header-only TBC
+	// instance to maintain Bitcoin consensus starting from a non-genesis block rather
+	// than requiring all historical state which is irrelevant to conesnsus assuming the
+	// effective genesis block is never forked.
+	hhKey := heightHashToKey(height, bhash[:])
 	hhBatch.Put(hhKey, []byte{})
-	cdiff := big.NewInt(0)
-	cdiff = new(big.Int).Add(cdiff, blockchain.CalcWork(wbh.Bits))
-	ebh := encodeBlockHeader(0, h2b(wbh), cdiff)
+
+	// Handle the default case where the passed-in block is actually the genesis
+	cdiff := blockchain.CalcWork(wbh.Bits)
+
+	// If an effective starting difficulty is supplied and is not set to zero, then use it
+	// instead (used for external header mode). In the event that an effective genesis block
+	// is supplied but the cumulative difficulty is not set, the difficulty of that
+	// effective genesis block (set above) will be retained, which has no effect on local
+	// consensus determination but will not permit direct comparison of cumulative difficulty
+	// against the full chain, only relative comparisons between cumulative difficulties of
+	// blocks on top of the same effective genesis block are guaranteed valid.
+	if diff != nil && diff.Cmp(big.NewInt(0)) > 0 {
+		cdiff = diff
+	}
+	ebh := encodeBlockHeader(height, h2b(wbh), cdiff)
 	bhBatch.Put(bhash[:], ebh[:])
 
 	bhBatch.Put([]byte(bhsCanonicalTipKey), ebh[:])
+	bhBatch.Put([]byte(upstreamStateIdKey), tbcd.DefaultUpstreamStateId[:])
 
 	// Write height hash batch
 	if err = hhTx.Write(hhBatch, nil); err != nil {
@@ -419,13 +504,367 @@ func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeade
 	return nil
 }
 
+// BlockHeadersRemove decodes and removes the passed blockheaders into the
+// database. Additionally it updates the canonical height/hash.
+// On return it informs the caller about the removal type which is self-evident
+// from the headers and post-removal canonical tip passed in as a convenience,
+// as well as the header the batch of headers was removed from which is now
+// the tip of that particular chain.
+//
+// The caller of this function must pass in the tipAfterRemoval which they
+// *know* to be the correct canonical tip after removal of the passed-in blocks.
+// This is critical to ensure that an operator of a TBC instance in External
+// Header mode can set a specific header as canonical in the event that removal
+// of header(s) results in a split tip where two or more headers are all at
+// the highest cumulative difficulty and TBC would otherwise have to choose one
+// without knowing what the upstream consumer considered canonical.
+//
+// This function is only intended to be used on a database which is used by
+// an instance of TBC running in External Header mode, where the header consensus
+// view needs to be walked back to account for information no longer being
+// known by an upstream consumer. For example, an L2 reorg could remove Bitcoin
+// consensus information from the L2 protocol's knowledge, so the External Header
+// mode TBC instance needs to represent Bitcoin consensus knowledge of the L2
+// protocol at the older tip height so that the full indexed TBC instance can
+// be moved to the correct indexed state to return queries that are consistent
+// with the L2's view of Bitcoin at that previous L2 block, otherwise L2 nodes
+// that processed the reorg versus L2 nodes that were always on the reorged-onto
+// chain could have a state divergence since queries against TBC would not be
+// deterministic between both types of nodes.
+//
+// All of the headers passed to the remove function must exist in the database.
+//
+// Headers must be ordered from lowest height to highest and must be contiguous,
+// meaning if header 0 is at height H, header N-1 must be at height H+N and for
+// each header N its previous block hash must be the hash of header N-1.
+//
+// The last header in the array must be the current tip of its chain (whether
+// canonical or fork); in other words the database must not have knowledge of
+// any headers who reference the last header as their previous block as this removal
+// would result in a dangling orphan chain segment in the database. A block can have
+// multiple children and calling this function with non-contiguous (non-linear)
+// blocks is not allowed, but this is correct behavior as removing chunks of
+// headers in the reverse order they were originally added will ensure that
+// a header being removed only has a maximum of one child (which must be included
+// in the headers passed to this function).
+//
+// For example given a chain:
+//
+//	_______/-[2a]-[3a]-[4a]
+//
+// [ G]-[ 1]-[2b]-[3b]-[4b]-[5b]
+//
+//	____________\-[3c]-[4c]-[5c]-[6c]
+//
+// Where the tip is [6c], the next removal could for example be:
+//
+//	[3a]-[4a]
+//	[3b]-[4b]-[5b]
+//	[5c]-[6c] (and pass in tipAfterRemoval=[5b])
+//
+// But the next removal could not for example be:
+//
+//	[2a]-[3a] // Leaves [4a] dangling
+//	[2b]-[3b]-[4b]-[5b] // Leaves "c" fork dangling
+//
+// The upstream user of a TBC instance in External Header mode is expected
+// to always remove chunks of headers in the opposite order they were
+// originally added. While this is not checked explicitly, failure to do so
+// can result in these types of dangling chain scenarios. In the above example,
+// block [2b] must have been added at or before the time of adding [3b] and [3c].
+//
+// It could have either been:
+// Update #1: ADD [2b]-[3b]-[4b]-[5b]
+// Update #2: ADD [3c]-[4c]-[5c]-[6c]
+// OR
+// Update #1: ADD [2b]-[3c]-[4c]-[5c]-[6c]
+// Update #2: ADD [3b]-[4b]-[5b]
+// (Or some similar order where some of the higher b/c blocks were added back
+// and forth between the chains or split into multiple smaller updates.)
+//
+// Assuming the upstream caller needs to remove the entire b and c chains:
+//
+// If it was the first order, then we would expect upstream caller to first
+// remove [3c]-...-[6c] (undo update #2), and then remove [2b]-...-[5b] (undo
+// update #1), which would never leave a chain dangling.
+//
+// Similarly, if it was the second order, then we would expect upstream caller
+// to first remove [3b]-...-[5b] (undo update #2), and then remove [2b]-...-[6c]
+// (undo update #1) which would also never leave a chain dangling.
+//
+// If the upstream caller removed [2b]-...-[5b] first, then they did not
+// remove headers in the same order that they added them, because it would
+// have been impossible to originally add [2b] after adding [3c].
+//
+// Calling this function with the incorrect tipAfterRemoval WILL FAIL as that
+// indicates incorrect upstream behavior.
+//
+// If any of the above requirements are not true, this function will return
+// an error. If this function returns an error, no changes have been made to
+// the underlying database state as all validity checks are done before db
+// modifications are applied.
+//
+// If an upstreamCursor is provided, it is updated atomically in the database
+// along with the state transition of removing the block headers.
+func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, upstreamStateId *[32]byte) (tbcd.RemoveType, *tbcd.BlockHeader, error) {
+	log.Tracef("BlockHeadersRemove")
+	defer log.Tracef("BlockHeadersRemove exit")
+	if len(bhs.Headers) == 0 {
+		return tbcd.RTInvalid, nil,
+			errors.New("block headers remove: no block headers to remove")
+	}
+
+	// Get current canonical tip for later use
+	originalCanonicalTip, err := l.BlockHeaderBest(ctx)
+	if err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: unable to get canonical tip from db, err: %w", err)
+	}
+
+	headersParsed := bhs.Headers
+
+	// Looking up each full header (with height and cumulative difficulty)
+	// in the next check; store so that later we have the data to create deletion
+	// keys.
+	fullHeadersFromDb := make([]*tbcd.BlockHeader, len(headersParsed))
+	// Check that each header exists in the database, and that no header
+	// to remove has a child unless that child is also going to be removed;
+	// no dangling chains will be left. Also check that none of the blocks
+	// to be removed match the tip the caller wants to be canonical after
+	// the removal.
+	tipAfterRemovalHash := tipAfterRemoval.BlockHash()
+	for i := 0; i < len(headersParsed); i++ {
+		headerToCheck := headersParsed[i]
+		hash := headerToCheck.BlockHash()
+
+		// Ensure that the header which should be canonical after removal is not one
+		// of the blocks to remove
+		if tipAfterRemovalHash.IsEqual(&hash) {
+			return tbcd.RTInvalid, nil,
+				fmt.Errorf("block headers remove: cannot remove header with hash %s when that is supposed to be"+
+					" the tip after removal", hash.String())
+		}
+
+		// Get full header that has height in it for the block to remove we are checking
+		fullHeader, err := l.BlockHeaderByHash(ctx, &hash)
+		if err != nil {
+			return 0, nil,
+				fmt.Errorf("block headers remove: cannot find header with hash %s in database, err: %w",
+					hash.String(), err)
+		}
+
+		// Save the full header from database (with height and cumulative difficulty)
+		fullHeadersFromDb[i] = fullHeader
+		nextHeight := fullHeader.Height + 1
+
+		// Get all headers from the database that could possibly be children
+		potentialChildren, err := l.BlockHeadersByHeight(ctx, nextHeight)
+		if err != nil {
+			if errors.Is(err, database.ErrNotFound) {
+				// No blocks at nextHeight in database. We could check that we are at
+				// the end of our headers array, but continuing here is fine because
+				// that will be detected on the next iteration.
+				continue
+			}
+			return tbcd.RTInvalid, nil,
+				fmt.Errorf("block headers remove: cannot get potential children at height %d "+
+					"from database, err: %w", nextHeight, err)
+		}
+
+		// Check all potential children. If one has our header to remove's hash as their
+		// previous block, then make sure it is in the removal list. Two or more cannot
+		// be in our removal list because they would have failed contiguous check prior.
+		for j := 0; j < len(potentialChildren); j++ {
+			toCheck := potentialChildren[j]
+			parent := toCheck.ParentHash()
+			if !bytes.Equal(parent[:], hash[:]) {
+				// Not a child of header to remove
+				continue
+			}
+
+			// This is a child of the header we are going to remove, make sure it is
+			// also going to be removed.
+			if i == (len(headersParsed) - 1) {
+				// We do not have another header in our removal list, meaning it would
+				// be left dangling.
+				return tbcd.RTInvalid, nil,
+					fmt.Errorf("block headers remove: want to remove header with hash %s but it is the "+
+						"last header in our removal list, and database has a child header with hash %s which "+
+						"would be left dangling", hash.String(), toCheck.BlockHash().String())
+			}
+
+			// This check will always fail if there are two children which claim the
+			// current header as a child, as one of them will not match the next
+			// header to remove, which is the only block which could be the removed
+			// child.
+			nextBlockToRemove := headersParsed[i+1].BlockHash()
+			if !nextBlockToRemove.IsEqual(toCheck.BlockHash()) {
+				// The header of the confirmed child does not match the next header to
+				// remove, meaning it would be left dangling.
+				return tbcd.RTInvalid, nil,
+					fmt.Errorf("block headers remove: want to remove header with hash %s, but database "+
+						"has a child header with hash %s which would be left dangling", hash.String(),
+						toCheck.BlockHash().String())
+			}
+		}
+	}
+
+	// Ensure that the tip which the caller claims should be canonical after the
+	// removal is a valid block in the database.
+	tipAfterRemovalFromDb, err := l.BlockHeaderByHash(ctx, &tipAfterRemovalHash)
+	if err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: cannot find tip after removal header with hash %s "+
+				"in database, err: %w", tipAfterRemovalHash.String(), err)
+	}
+
+	//
+	for i := 0; i < len(fullHeadersFromDb); i++ {
+		// This should be impossible since above loop should have errored when
+		// getting header, but extra sanity.
+		if fullHeadersFromDb[i] == nil {
+			return tbcd.RTInvalid, nil,
+				fmt.Errorf("block headers remove: unexpected internal error, header with hash %s at position "+
+					"%d in headers to remove was not retrieved from database", headersParsed[i].BlockHash().String(), i)
+		}
+
+		// Reconstitute the 80-byte header retrieved from the database for
+		// additional sanity checks
+		dbHeaderReconstituted, err := b2h(fullHeadersFromDb[i].Header[:])
+		if err != nil {
+			return tbcd.RTInvalid, nil,
+				fmt.Errorf("block headers remove: unexpected error parsing header %x, err: %w",
+					fullHeadersFromDb[i].Header[:], err)
+		}
+
+		// Check that the raw header we retrieved from the database matches the
+		// header we expected to move as an additional sanity check.
+		dbHeaderReconstitutedHash := dbHeaderReconstituted.BlockHash()
+		expectedHash := headersParsed[i].BlockHash()
+		if !expectedHash.IsEqual(&dbHeaderReconstitutedHash) {
+			// Recalculated hash of header from database doesn't match header of
+			// block, this should also be impossible but extra sanity.
+			return tbcd.RTInvalid, nil,
+				fmt.Errorf("block headers remove: unexpected internal error, header with hash %s at position %d"+
+					" in headers to remove does not match header %x with hash %s retrieved from db",
+					expectedHash.String(), i, fullHeadersFromDb[i].Header[:], expectedHash.String())
+		}
+	}
+
+	// Block headers
+	bhsTx, bhsCommit, bhsDiscard, err := l.startTransaction(level.BlockHeadersDB)
+	if err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: unable to start block headers leveldb transaction, err: %w", err)
+	}
+	defer bhsDiscard()
+
+	// height hash
+	hhTx, hhCommit, hhDiscard, err := l.startTransaction(level.HeightHashDB)
+	if err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: unable to start height hash leveldb transaction, err: %w", err)
+	}
+	defer hhDiscard()
+
+	bhsBatch := new(leveldb.Batch)
+	hhBatch := new(leveldb.Batch)
+
+	// Insert each block header deletion into the batch (for header itself and
+	// height-header association)
+	for i := 0; i < len(headersParsed); i++ {
+		// Delete header i
+		bhash := headersParsed[i].BlockHash()
+		fh := fullHeadersFromDb[i]
+		bhsBatch.Delete(bhash[:])
+
+		// Delete height mapping for header i
+		hhKey := heightHashToKey(fh.Height, bhash[:])
+		hhBatch.Delete(hhKey)
+	}
+
+	// Insert updated canonical tip after removal of the provided block headers
+	tipAfterRemovalEncoded := h2b(tipAfterRemoval)
+	tipEbh := encodeBlockHeader(tipAfterRemovalFromDb.Height, tipAfterRemovalEncoded, &tipAfterRemovalFromDb.Difficulty)
+	bhsBatch.Put([]byte(bhsCanonicalTipKey), tipEbh[:])
+
+	if upstreamStateId != nil {
+		bhsBatch.Put([]byte(upstreamStateIdKey), upstreamStateId[:])
+	} else {
+		// On updates if no upstream state ID is specified, we always set a default
+		// so errors where the upstream state ID can be troubleshooted more easily
+		// by making it clear that a call without a specified upstream state ID
+		// occurred.
+		bhsBatch.Put([]byte(upstreamStateIdKey), tbcd.DefaultUpstreamStateId[:])
+	}
+
+	// Get parent block from database
+	parentToRemovalSet, err := l.BlockHeaderByHash(ctx, &headersParsed[0].PrevBlock)
+	if err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: cannot find previous header (with hash %s) to lowest header"+
+				" removed (whth hash %s) in database, err: %w",
+				headersParsed[0].PrevBlock.String(), headersParsed[0].BlockHash().String(), err)
+	}
+
+	originalCanonicalTipHash := originalCanonicalTip.BlockHash()
+	heaviestRemovedBlockHash := headersParsed[len(headersParsed)-1].BlockHash()
+
+	removalType := tbcd.RTInvalid
+	if tipAfterRemovalHash.IsEqual(&parentToRemovalSet.Hash) {
+		// Canonical tip set by caller is the parent to the blocks removed
+		removalType = tbcd.RTChainDescend
+	} else if tipAfterRemovalHash.IsEqual(originalCanonicalTipHash) {
+		// Canonical tip did not change, meaning blocks we removed were on a non-canonical chain
+		removalType = tbcd.RTForkDescend
+	} else if originalCanonicalTipHash.IsEqual(&heaviestRemovedBlockHash) {
+		// The original canonical tip was a block we removed, but parent to removal set is
+		// not the new canonical per first condition, therefore we descended the canonical
+		// chain far enough that a previous fork is now canonical
+		removalType = tbcd.RTChainFork
+	} else {
+		// This should never happen, one of the above three conditions must be true.
+		// Do this before the end of function so we don't apply database changes.
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: none of the chain geometry checks applies to this removal")
+	}
+
+	// Write height hash batch
+	err = hhTx.Write(hhBatch, nil)
+	if err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: unable to write height hash batch: %w", err)
+	}
+
+	// Write block headers batch
+	err = bhsTx.Write(bhsBatch, nil)
+	if err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: unable to write block headers batch: %w", err)
+	}
+
+	// height hash commit
+	if err = hhCommit(); err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: unable to commit height hash modifications: %w", err)
+	}
+
+	// block headers commit
+	if err = bhsCommit(); err != nil {
+		return tbcd.RTInvalid, nil,
+			fmt.Errorf("block headers remove: unable to commit block header modifications: %w", err)
+	}
+
+	return removalType, parentToRemovalSet, nil
+}
+
 // BlockHeadersInsert decodes and inserts the passed blockheaders into the
 // database. Additionally it updates the hight/hash and missing blocks table as
 // well.  On return it informs the caller about potential forking situations
 // and always returns the canonical and last inserted blockheader, which may be
 // the same.
 // This call uses the database to prevent reentrancy.
-func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
+func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, upstreamStateId *[32]byte) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
 	log.Tracef("BlockHeadersInsert")
 	defer log.Tracef("BlockHeadersInsert exit")
 
@@ -598,6 +1037,16 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders) (tbc
 		// Extend current best tip
 		bhsBatch.Put([]byte(bhsCanonicalTipKey), lastRecord)
 		it = tbcd.ITChainExtend
+	}
+
+	if upstreamStateId != nil {
+		bhsBatch.Put([]byte(upstreamStateIdKey), upstreamStateId[:])
+	} else {
+		// On updates if no upstream state ID is specified, we always set a default
+		// so errors where the upstream state ID can be troubleshooted more easily
+		// by making it clear that a call without a specified upstream state ID
+		// occurred.
+		bhsBatch.Put([]byte(upstreamStateIdKey), tbcd.DefaultUpstreamStateId[:])
 	}
 
 	// Write height hash batch

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -105,7 +105,7 @@ func NewDefaultConfig() *Config {
 		BlockheaderCache:   1e6,
 		LogLevel:           logLevel,
 		MaxCachedTxs:       defaultMaxCachedTxs,
-		MempoolEnabled:     true,
+		MempoolEnabled:     false, // XXX default to false until it is fixed
 		PeersWanted:        defaultPeersWanted,
 		ExternalHeaderMode: false, // Default anyway, but for readability
 	}
@@ -167,6 +167,11 @@ type Server struct {
 func NewServer(cfg *Config) (*Server, error) {
 	if cfg == nil {
 		cfg = NewDefaultConfig()
+	}
+
+	if cfg.MempoolEnabled {
+		cfg.MempoolEnabled = false // XXX
+		log.Infof("mempool forced disabled")
 	}
 
 	// Only populate pings and blocks if not in External Header Mode

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -5,6 +5,7 @@
 package tbc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -87,17 +88,26 @@ type Config struct {
 	PrometheusListenAddress string
 	PprofListenAddress      string
 	Seeds                   []string
+
+	// Fields used for running TBC in External Header Mode, where P2P is disabled
+	// and TBC is used to determine consensus based on headers fed from external
+	// code that manages the TBC node.
+	ExternalHeaderMode      bool              // Whether Header-Only Mode is enabled
+	EffectiveGenesisBlock   *wire.BlockHeader // The header to use as the first block in TBC's consensus view
+	GenesisHeightOffset     uint64            // The height of the effective genesis block
+	GenesisDifficultyOffset big.Int           // The cumulative difficulty of the effective genesis block
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		ListenAddress:    tbcapi.DefaultListen,
-		BlockCache:       250,
-		BlockheaderCache: 1e6,
-		LogLevel:         logLevel,
-		MaxCachedTxs:     defaultMaxCachedTxs,
-		MempoolEnabled:   true,
-		PeersWanted:      defaultPeersWanted,
+		ListenAddress:      tbcapi.DefaultListen,
+		BlockCache:         250,
+		BlockheaderCache:   1e6,
+		LogLevel:           logLevel,
+		MaxCachedTxs:       defaultMaxCachedTxs,
+		MempoolEnabled:     true,
+		PeersWanted:        defaultPeersWanted,
+		ExternalHeaderMode: false, // Default anyway, but for readability
 	}
 }
 
@@ -158,14 +168,22 @@ func NewServer(cfg *Config) (*Server, error) {
 	if cfg == nil {
 		cfg = NewDefaultConfig()
 	}
-	pings, err := ttl.New(cfg.PeersWanted, true)
-	if err != nil {
-		return nil, err
+
+	// Only populate pings and blocks if not in External Header Mode
+	var pings *ttl.TTL
+	var blocks *ttl.TTL
+	var err error
+	if !cfg.ExternalHeaderMode {
+		pings, err = ttl.New(cfg.PeersWanted, true)
+		if err != nil {
+			return nil, err
+		}
+		blocks, err = ttl.New(defaultPendingBlocks, true)
+		if err != nil {
+			return nil, err
+		}
 	}
-	blocks, err := ttl.New(defaultPendingBlocks, true)
-	if err != nil {
-		return nil, err
-	}
+
 	defaultRequestTimeout := 10 * time.Second // XXX: make config option?
 	s := &Server{
 		cfg:        cfg,
@@ -185,7 +203,17 @@ func NewServer(cfg *Config) (*Server, error) {
 		promPollVerbose: false,
 	}
 
+	// Only set pings and blocks if not in External Header Mode
+	if !s.cfg.ExternalHeaderMode {
+		s.blocks = blocks
+		s.pings = pings
+	}
+
 	if s.cfg.MempoolEnabled {
+		if s.cfg.ExternalHeaderMode {
+			// Cannot combine mempool behavior with External Header Mode
+			panic("cannot enable mempool on an external-header-only mode TBC instance")
+		}
 		s.mempool, err = mempoolNew()
 		if err != nil {
 			return nil, err
@@ -214,11 +242,14 @@ func NewServer(cfg *Config) (*Server, error) {
 		return nil, fmt.Errorf("invalid network: %v", cfg.Network)
 	}
 
-	pm, err := NewPeerManager(s.wireNet, s.cfg.Seeds, wanted)
-	if err != nil {
-		return nil, err
+	// Only create a PeerManager if not in External Header Mode
+	if !s.cfg.ExternalHeaderMode {
+		pm, err := NewPeerManager(s.wireNet, s.cfg.Seeds, wanted)
+		if err != nil {
+			return nil, err
+		}
+		s.pm = pm
 	}
-	s.pm = pm
 
 	return s, nil
 }
@@ -968,6 +999,91 @@ func (s *Server) syncBlocks(ctx context.Context) {
 	}
 }
 
+// RemoveExternalHeaders removes the provided headers from TBC's state knowledge,
+// setting the canonical tip to the provided tip. This method can only be
+// used when TBC is running in External Header Mode.
+//
+// The upstream state id is an optional identifier that the caller can use to track
+// some upstream state which represents TBC's own state once this removal is
+// performed. For example, op-geth uses this to track the hash of the EVM block
+// which cumulatively represents TBC's entire header knowledge after the removal
+// is processed, such that re-applying all Bitcoin Attributes Deposited transactions
+// in the EVM from genesis to that hash would result in TBC having this state.
+//
+// This upstream state id is tracked in TBC rather than upstream in the caller so
+// that updates to the upstreamCursor are always made atomically with the
+// corresponding TBC database state transition. Otherwise, an unexpected termination
+// between updating TBC state and recording the updated upstreamCursor could cause
+// state corruption.
+func (s *Server) RemoveExternalHeaders(ctx context.Context, headers *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, upstreamStateId *[32]byte) (tbcd.RemoveType, *tbcd.BlockHeader, error) {
+	if !s.cfg.ExternalHeaderMode {
+		return tbcd.RTInvalid, nil,
+			errors.New("RemoveExternalHeaders called on TBC instance that is not in external header mode")
+	}
+
+	if len(headers.Headers) == 0 {
+		return tbcd.RTInvalid, nil,
+			errors.New("RemoveExternalHeaders called with no headers")
+	}
+
+	if tipAfterRemoval == nil {
+		return tbcd.RTInvalid, nil,
+			errors.New("RemoveExternalHeaders called with no tipAfterRemoval")
+	}
+
+	// Check that chain is contiguous
+	for i := 1; i < len(headers.Headers); i++ {
+		bh := headers.Headers[i].PrevBlock
+		ph := headers.Headers[i-1].BlockHash()
+		if !bh.IsEqual(&ph) {
+			// Chain is not contiguous / linear as this block does not connect to parent
+			return tbcd.RTInvalid, nil,
+				fmt.Errorf("remove external headers: header with hash %s at index %d does not connect to "+
+					"previous header with hash %s at index %d",
+					bh.String(), i, ph.String(), i-1)
+		}
+	}
+
+	// We aren't checking error because we want to pass everything from db upstream
+	it, por, err := s.db.BlockHeadersRemove(ctx, headers, tipAfterRemoval, upstreamStateId)
+
+	// Caller of RemoveExternalHeaders wants fork geometry info, parent of removal set, and must handle error upstream
+	// as an error here generally represents an issue with the header additions/removals provided by upstream code.
+	return it, por, err
+}
+
+func (s *Server) AddExternalHeaders(ctx context.Context, headers *wire.MsgHeaders, upstreamStateId *[32]byte) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
+	if !s.cfg.ExternalHeaderMode {
+		return tbcd.ITInvalid, nil, nil, 0,
+			errors.New("AddExternalHeaders called on TBC instance that is not in external header mode")
+	}
+
+	if len(headers.Headers) == 0 {
+		return tbcd.ITInvalid, nil, nil, 0,
+			errors.New("AddExternalHeaders called with no headers")
+	}
+
+	// Check that chain is contiguous
+	for i := 1; i < len(headers.Headers); i++ {
+		bh := headers.Headers[i].PrevBlock
+		ph := headers.Headers[i-1].BlockHash()
+		if !bh.IsEqual(&ph) {
+			// Chain is not contiguous / linear as this block does not connect to parent
+			return tbcd.ITInvalid, nil, nil, 0,
+				fmt.Errorf("add external headers: header with hash %s at index %d does not connect to "+
+					"previous header with hash %s at index %d",
+					bh.String(), i, ph.String(), i-1)
+		}
+	}
+
+	// We aren't checking error because we want to pass everything from db upstream
+	it, cbh, lbh, n, err := s.db.BlockHeadersInsert(ctx, headers, upstreamStateId)
+
+	// Caller of AddExternalHeaders wants fork geometry change, canonical and last inserted header, and must handle error upstream
+	// as an error here generally represents an issue with the header additions/removals provided by upstream code.
+	return it, cbh, lbh, n, err
+}
+
 func (s *Server) handleHeaders(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgHeaders) error {
 	log.Tracef("handleHeaders (%v): %v %v", p, len(msg.Headers))
 	defer log.Tracef("handleHeaders exit (%v): %v", p, len(msg.Headers))
@@ -1037,7 +1153,9 @@ func (s *Server) handleHeaders(ctx context.Context, p *rawpeer.RawPeer, msg *wir
 		}
 		pbhHash = &msg.Headers[k].PrevBlock
 	}
-	it, cbh, lbh, n, err := s.db.BlockHeadersInsert(ctx, msg)
+
+	// When running in normal (not External Header) mode, do not set upstream state IDs
+	it, cbh, lbh, n, err := s.db.BlockHeadersInsert(ctx, msg, nil)
 	if err != nil {
 		// This ends the race between peers during IBD. It should
 		// starve the slower peers and eventually we end up with one
@@ -1317,14 +1435,14 @@ func (s *Server) handleGetData(ctx context.Context, p *rawpeer.RawPeer, msg *wir
 	return nil
 }
 
-func (s *Server) insertGenesis(ctx context.Context) error {
+func (s *Server) insertGenesis(ctx context.Context, height uint64, diff *big.Int) error {
 	log.Tracef("insertGenesis")
 	defer log.Tracef("insertGenesis exit")
 
 	// We really should be inserting the block first but block insert
 	// verifies that a block header exists.
 	log.Infof("Inserting genesis block and header: %v", s.chainParams.GenesisHash)
-	err := s.db.BlockHeaderGenesisInsert(ctx, &s.chainParams.GenesisBlock.Header)
+	err := s.db.BlockHeaderGenesisInsert(ctx, &s.chainParams.GenesisBlock.Header, height, diff)
 	if err != nil {
 		return fmt.Errorf("genesis block header insert: %w", err)
 	}
@@ -1342,6 +1460,11 @@ func (s *Server) insertGenesis(ctx context.Context) error {
 func (s *Server) BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error) {
 	log.Tracef("BlockByHash")
 	defer log.Tracef("BlockByHash exit")
+
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call BlockByHash on TBC running in External Header mode")
+	}
+
 	return s.db.BlockByHash(ctx, hash)
 }
 
@@ -1365,6 +1488,11 @@ func (s *Server) BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*
 func (s *Server) BlocksMissing(ctx context.Context, count int) ([]tbcd.BlockIdentifier, error) {
 	log.Tracef("BlocksMissing")
 	defer log.Tracef("BlocksMissing exit")
+
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call BlocksMissing on TBC running in External Header mode")
+	}
+
 	return s.db.BlocksMissing(ctx, count)
 }
 
@@ -1446,6 +1574,10 @@ func (s *Server) BalanceByAddress(ctx context.Context, encodedAddress string) (u
 	log.Tracef("BalanceByAddress")
 	defer log.Tracef("BalanceByAddress exit")
 
+	if s.cfg.ExternalHeaderMode {
+		return 0, errors.New("cannot call BalanceByAddress on TBC running in External Header mode")
+	}
+
 	addr, err := btcutil.DecodeAddress(encodedAddress, s.chainParams)
 	if err != nil {
 		return 0, err
@@ -1469,6 +1601,10 @@ func (s *Server) BalanceByScriptHash(ctx context.Context, hash tbcd.ScriptHash) 
 	log.Tracef("BalanceByScriptHash")
 	defer log.Tracef("BalanceByScriptHash exit")
 
+	if s.cfg.ExternalHeaderMode {
+		return 0, errors.New("cannot call BalanceByScriptHash on TBC running in External Header mode")
+	}
+
 	balance, err := s.db.BalanceByScriptHash(ctx, hash)
 	if err != nil {
 		return 0, err
@@ -1480,6 +1616,10 @@ func (s *Server) BalanceByScriptHash(ctx context.Context, hash tbcd.ScriptHash) 
 func (s *Server) UtxosByAddress(ctx context.Context, encodedAddress string, start uint64, count uint64) ([]tbcd.Utxo, error) {
 	log.Tracef("UtxosByAddress")
 	defer log.Tracef("UtxosByAddress exit")
+
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call UtxosByAddress on TBC running in External Header mode")
+	}
 
 	addr, err := btcutil.DecodeAddress(encodedAddress, s.chainParams)
 	if err != nil {
@@ -1502,12 +1642,49 @@ func (s *Server) UtxosByScriptHash(ctx context.Context, hash tbcd.ScriptHash, st
 	log.Tracef("UtxosByScriptHash")
 	defer log.Tracef("UtxosByScriptHash exit")
 
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call UtxosByScriptHash on TBC running in External Header mode")
+	}
+
 	return s.db.UtxosByScriptHash(ctx, hash, start, count)
+}
+
+// ScriptHashAvailableToSpend returns a boolean which indicates whether
+// a specific output (uniquely identified by TxId output index) is
+// available for spending in the UTXO table.
+// This function can return false for two reasons:
+//  1. The outpoint was already spent
+//  2. The outpoint never existed
+func (s *Server) ScriptHashAvailableToSpend(ctx context.Context, txId *chainhash.Hash, index uint32) (bool, error) {
+	log.Tracef("ScriptHashAvailableToSpend")
+	defer log.Tracef("ScriptHashAvailableToSpend exit")
+	if s.cfg.ExternalHeaderMode {
+		return false, errors.New("cannot call script hash available to spend on TBC running in External Header mode")
+	}
+
+	txIdBytes := [32]byte(txId.CloneBytes())
+	op := tbcd.NewOutpoint(txIdBytes, index)
+	sh, err := s.db.ScriptHashByOutpoint(ctx, op)
+	if err != nil {
+		return false, err
+	}
+
+	if sh != nil {
+		// Found it, therefore is unspent
+		return true, nil
+	}
+
+	// Did not find it, therefore either spent or never existed
+	return false, nil
 }
 
 func (s *Server) SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]tbcd.SpentInfo, error) {
 	log.Tracef("SpentOutputsByTxId")
 	defer log.Tracef("SpentOutputsByTxId exit")
+
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call SpentOutputsByTxId on TBC running in External Header mode")
+	}
 
 	// As it is written now it returns all spent outputs per the tx index view.
 	si, err := s.db.SpentOutputsByTxId(ctx, txId)
@@ -1522,6 +1699,10 @@ func (s *Server) BlockInTxIndex(ctx context.Context, blkid *chainhash.Hash) (boo
 	log.Tracef("BlockInTxIndex")
 	defer log.Tracef("BlockInTxIndex exit")
 
+	if s.cfg.ExternalHeaderMode {
+		return false, errors.New("cannot call BlockInTxIndex on TBC running in External Header mode")
+	}
+
 	// As it is written now it returns true/false per the tx index view.
 	return s.db.BlockInTxIndex(ctx, blkid)
 }
@@ -1530,12 +1711,20 @@ func (s *Server) BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*ch
 	log.Tracef("BlockHashByTxId")
 	defer log.Tracef("BlockHashByTxId exit")
 
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call BlockHashByTxId on TBC running in External Header mode")
+	}
+
 	return s.db.BlockHashByTxId(ctx, txId)
 }
 
 func (s *Server) TxById(ctx context.Context, txId *chainhash.Hash) (*wire.MsgTx, error) {
 	log.Tracef("TxById")
 	defer log.Tracef("TxById exit")
+
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call TxById on TBC running in External Header mode")
+	}
 
 	blockHash, err := s.db.BlockHashByTxId(ctx, txId)
 	if err != nil {
@@ -1557,6 +1746,10 @@ func (s *Server) TxById(ctx context.Context, txId *chainhash.Hash) (*wire.MsgTx,
 func (s *Server) TxBroadcastAllToPeer(ctx context.Context, p *rawpeer.RawPeer) error {
 	log.Tracef("TxBroadcastAllToPeer %v", p)
 	defer log.Tracef("TxBroadcastAllToPeer %v exit", p)
+
+	if s.cfg.ExternalHeaderMode {
+		return errors.New("cannot call TxBroadcastAllToPeer on TBC running in External Header mode")
+	}
 
 	s.mtx.RLock()
 	if len(s.broadcast) == 0 {
@@ -1587,6 +1780,10 @@ func (s *Server) TxBroadcastAllToPeer(ctx context.Context, p *rawpeer.RawPeer) e
 func (s *Server) TxBroadcast(ctx context.Context, tx *wire.MsgTx, force bool) (*chainhash.Hash, error) {
 	log.Tracef("TxBroadcast")
 	defer log.Tracef("TxBroadcast exit")
+
+	if s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call TxBroadcast on TBC running in External Header mode")
+	}
 
 	s.mtx.Lock()
 	if _, ok := s.broadcast[tx.TxHash()]; ok && !force {
@@ -1648,6 +1845,10 @@ func (s *Server) FeesAtHeight(ctx context.Context, height, count int64) (uint64,
 	log.Tracef("FeesAtHeight")
 	defer log.Tracef("FeesAtHeight exit")
 
+	if s.cfg.ExternalHeaderMode {
+		return 0, errors.New("cannot call FeesAtHeight on TBC running in External Header mode")
+	}
+
 	if height-count < 0 {
 		return 0, errors.New("height - count is less than 0")
 	}
@@ -1675,6 +1876,58 @@ func (s *Server) FeesAtHeight(ctx context.Context, height, count int64) (uint64,
 	}
 
 	return fees, errors.New("not yet")
+}
+
+// FullBlockAvailable returns whether TBC has the full block
+// corresponding to the specified hash available in its database.
+func (s *Server) FullBlockAvailable(ctx context.Context, hash *chainhash.Hash) (bool, error) {
+	if s.cfg.ExternalHeaderMode {
+		return false, errors.New("cannot call full block available on TBC running in External Header mode")
+	}
+
+	block, err := s.db.BlockByHash(ctx, hash)
+	if err != nil {
+		if errors.Is(err, database.ErrBlockNotFound) {
+			return false, nil // Not found, but not an error to pass upstream
+		} else {
+			return false, err // Another error was encountered which upstream should know about
+		}
+	}
+
+	if block != nil {
+		// Were able to get full block from database
+		return true, nil
+	} else {
+		return false, errors.New("fetching block did not return error but block is nil")
+	}
+}
+
+// UpstreamStateId fetches the last-stored upstream state ID.
+// If the last header insertion/removal did not specify an upstream
+// state ID, this will return the default upstream state ID.
+func (s *Server) UpstreamStateId(ctx context.Context) (*[32]byte, error) {
+	log.Tracef("UpstreamStateId")
+	defer log.Tracef("UpstreamStateId exit")
+
+	if !s.cfg.ExternalHeaderMode {
+		return nil, errors.New("cannot call UpstreamStateId on TBC not running in External Header mode")
+	}
+
+	return s.db.UpstreamStateId(ctx)
+}
+
+// SetUpstreamStateId sets a new upstream state ID without
+// making any other state changes to TBC, used when the upstream
+// state is updated without requiring any TBC updates.
+func (s *Server) SetUpstreamStateId(ctx context.Context, upstreamStateId *[32]byte) error {
+	log.Tracef("SetUpstreamStateId")
+	defer log.Tracef("SetUpstreamStateId exit")
+
+	if !s.cfg.ExternalHeaderMode {
+		return errors.New("cannot call SetUpstreamStateId on TBC not running in External Header mode")
+	}
+
+	return s.db.SetUpstreamStateId(ctx, upstreamStateId)
 }
 
 type SyncInfo struct {
@@ -1740,6 +1993,10 @@ func (s *Server) Synced(ctx context.Context) SyncInfo {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
+	if s.cfg.ExternalHeaderMode {
+		panic("cannot call Synced on TBC running in External Header mode")
+	}
+
 	return s.synced(ctx)
 }
 
@@ -1785,6 +2042,10 @@ func (s *Server) Run(pctx context.Context) error {
 	log.Tracef("Run")
 	defer log.Tracef("Run exit")
 
+	if s.cfg.ExternalHeaderMode {
+		return errors.New("run called but External Header mode is enabled")
+	}
+
 	if !s.testAndSetRunning(true) {
 		return errors.New("tbc already running")
 	}
@@ -1825,7 +2086,10 @@ func (s *Server) Run(pctx context.Context) error {
 			return fmt.Errorf("block header best: %w", err)
 		}
 
-		if err = s.insertGenesis(ctx); err != nil {
+		// This Run function is only called in regular (not external header) mode, so this is true genesis block @ 0
+		// and we pass in a nil difficulty so it calculates the starting difficulty as the genesis block's own local
+		// difficulty.
+		if err = s.insertGenesis(ctx, 0, nil); err != nil {
 			return fmt.Errorf("insert genesis: %w", err)
 		}
 		bhb, err = s.db.BlockHeaderBest(ctx)
@@ -2030,4 +2294,80 @@ func (s *Server) Run(pctx context.Context) error {
 	log.Infof("tbc service clean shutdown")
 
 	return err
+}
+
+func (s *Server) ExternalHeaderSetup(ctx context.Context) error {
+	log.Tracef("ExternalHeaderSetup")
+	defer log.Tracef("ExternalHeaderSetup exit")
+
+	if !s.cfg.ExternalHeaderMode {
+		return errors.New("ExternalHeaderSetup called but external header mode is not enabled in config")
+	}
+
+	err := s.DBOpen(ctx)
+	if err != nil {
+		return fmt.Errorf("open level database: %w", err)
+	}
+
+	genesis := s.cfg.EffectiveGenesisBlock
+	genesisHeight := s.cfg.GenesisHeightOffset
+	genesisDiff := &s.cfg.GenesisDifficultyOffset
+
+	if genesis == nil {
+		genesis = &s.chainParams.GenesisBlock.Header
+		genesisHeight = 0
+		genesisDiff = nil
+	}
+
+	// Check if there is already a best header in database
+	bhb, err := s.db.BlockHeaderBest(ctx)
+	if err != nil {
+		if !errors.Is(err, database.ErrNotFound) {
+			return fmt.Errorf("block headers best: %w", err)
+		}
+
+		// Getting best header returned ErrNotFound so assume initial startup
+		err := s.db.BlockHeaderGenesisInsert(ctx, genesis, genesisHeight, genesisDiff)
+		if err != nil {
+			return fmt.Errorf("genesis block header insert: %w", err)
+		}
+
+		// Ensure after inserting the effective genesis block, ensure we can get the best header
+		bhb, err = s.db.BlockHeaderBest(ctx)
+		if err != nil {
+			return err
+		}
+	} else { // No error getting best header, no genesis insert, so check db genesis matches
+		gb, err := s.db.BlockHeadersByHeight(ctx, s.cfg.GenesisHeightOffset)
+		if err != nil {
+			return fmt.Errorf("error getting effective genesis block from db, %w", err)
+		}
+		if len(gb) > 1 {
+			// Impossible to have more than one block at the genesis height
+			return fmt.Errorf("invalid state, have %d effective genesis blocks", len(gb))
+		}
+		gh := genesis.BlockHash()
+		if !bytes.Equal(gb[0].Hash[:], gh[:]) {
+			return fmt.Errorf("effective genesis block hash mismatch, db has %x but genesis should be %x", gb[0].Hash, gh)
+		}
+	}
+	log.Infof("TBC set up in External Header Mode, effectiveGenesis=%x, tip=%x", genesis.BlockHash(), bhb.Hash)
+
+	return nil
+}
+
+func (s *Server) ExternalHeaderTearDown() error {
+	log.Tracef("ExternalHeaderTearDown")
+	defer log.Tracef("ExternalHeaderTearDown exit")
+
+	if !s.cfg.ExternalHeaderMode {
+		return errors.New("ExternalHeaderTearDown called but external header mode is not enabled in config")
+	}
+
+	err := s.DBClose()
+	if err != nil {
+		log.Errorf("db close: %v", err)
+		return err
+	}
+	return nil
 }

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1831,10 +1831,10 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 		t.Errorf("unable to get upstream state id, err: %v", err)
 	}
 
-	if !bytes.Equal(stateIdRet[:], tbcd.DefaultUpstreamStateId[:]) {
+	if !bytes.Equal(stateIdRet[:], DefaultUpstreamStateId[:]) {
 		t.Errorf("after successfully removing external headers with no state id specified, state id should "+
 			"have been the default upstream state id %x but got %x instead",
-			tbcd.DefaultUpstreamStateId[:], stateIdRet[:])
+			DefaultUpstreamStateId[:], stateIdRet[:])
 	} else {
 		t.Logf("after successfully removing external headers with no state id specified, state id of "+
 			"%x is correct (set to default)", stateIdRet[:])


### PR DESCRIPTION
**Summary**
This PR adds an "External Header Mode" for TBC to run in, which causes P2P to be disabled and for TBC to maintain lightweight BTC consensus knowledge based purely on headers that are added/removed by upstream code that manages the External Header Mode TBC instance. Also added a few methods for normal-mode TBC for fetching specific data desired for hVM.

**Changes**
External Header Mode:
- Added the ability to spin up a TBC instance in ExternalHeaderMode which does not connect to P2P and receives header insertions/deletions from upstream code
- Ability to associate ExternalHeaderMode TBC instance state with an upstream state ID for upstream reconciliation
- Added the ability to remove headers from the chain's view of consensus and set a specific header as canonical afterwards, so that ExternalHeaderMode TBC can be rolled back to a previous consensus state
- Added the ability for TBC in ExternalHeaderMode to be initialized with a specific "effective" genesis block, which is assumed permanently canonical so that lightweight conesnsus can be tracked from a specific non-genesis height
- Updated methods that will not work with ExternalHeaderMode to return errors when called on ExternalHeaderMode TBC

Other Updates:
- Added ScriptHashAvailableToSpend method to check for the existence of a single outpoint in the UTXO table of a normal-mode TBC node
- Added FullBlockAvailable method to check whether a normal-mode TBC node has knowledge of a particular full block
