### PR TITLE
tbc: fix err logging in sync indexers

### DIFF
--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1354,7 +1354,7 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 	log.Debugf("Done syncing to: %v", hash)
 
 	bh, err := s.db.BlockHeaderByHash(ctx, hash)
-	if err == nil {
+	if err != nil {
 		return err
 	}
 	log.Infof("Syncing complete at: %v", bh.HH())
@@ -1442,7 +1442,7 @@ func (s *Server) syncIndexersToBest(ctx context.Context) error {
 	}
 
 	bh, err := s.db.BlockHeaderByHash(ctx, &bhb.Hash)
-	if err == nil {
+	if err != nil {
 		return err
 	}
 	log.Infof("Syncing complete at: %v", bh.HH())

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1355,9 +1355,10 @@ func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) e
 
 	bh, err := s.db.BlockHeaderByHash(ctx, hash)
 	if err != nil {
-		return err
+		log.Errorf("block header by hash: %v", err)
+	} else {
+		log.Infof("Syncing complete at: %v", bh.HH())
 	}
-	log.Infof("Syncing complete at: %v", bh.HH())
 
 	return nil
 }
@@ -1443,9 +1444,10 @@ func (s *Server) syncIndexersToBest(ctx context.Context) error {
 
 	bh, err := s.db.BlockHeaderByHash(ctx, &bhb.Hash)
 	if err != nil {
-		return err
+		log.Errorf("block header by hash: %v", err)
+	} else {
+		log.Infof("Syncing complete at: %v", bh.HH())
 	}
-	log.Infof("Syncing complete at: %v", bh.HH())
 
 	return nil
 }


### PR DESCRIPTION
**Summary**

Fix incorrect error handling in crawler synchronization methods.

**Changes**

- Changed `if err == nil` to `if err != nil` in `SyncIndexersToHash` to correctly return errors.
- Made the same change in `syncIndexersToBest`.