### PR TITLE
make: improve all target order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ cmds = \
 .PHONY: all clean deps go-deps $(cmds) build install lint lint-deps tidy race test vulncheck \
 	vulncheck-deps
 
-all: lint tidy test build install
+all: tidy build lint test install
 
 clean: clean-test
 	rm -rf $(GOBIN) $(GOCACHE) $(GOPKG)


### PR DESCRIPTION
**Summary**
Improve the order of the targets run by 'all', to improve error readability (prefer build errors from go build instead of golangci-lint), and performance by running build to refresh the cache before running test/install.

**Changes**
- Change Makefile `all` target to run: `tidy build lint test install`. Previously: `lint tidy test build install`.