### PR TITLE
version: bump to 0.6.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -22,8 +22,8 @@ const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst
 // GoReleaser for releases.
 var (
 	Major = "0"
-	Minor = "5"
-	Patch = "1"
+	Minor = "6"
+	Patch = "0"
 )
 
 // PreRelease contains the prerelease name of the application. It is a variable,


### PR DESCRIPTION
**Summary**
Prepare to release v0.6.0.

**Changes**
- Bump version constants to represent v0.6.0.
