### PR TITLE
add index to pop_basis for pop tx queries

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	bfgdVersion = 10
+	bfgdVersion = 11
 
 	logLevel = "INFO"
 	verbose  = false

--- a/database/bfgd/scripts/0011.sql
+++ b/database/bfgd/scripts/0011.sql
@@ -7,6 +7,6 @@ BEGIN;
 
 UPDATE version SET version = 11;
 
-CREATE INDEX pop_pasis_published_pop_txs_desc_idx ON pop_basis (l2_keystone_abrev_hash, id DESC) WHERE btc_block_hash IS NOT NULL;
+CREATE INDEX pop_pasis_published_pop_txs_desc_idx ON pop_basis (l2_keystone_abrev_hash, id ASC) WHERE btc_block_hash IS NOT NULL;
 
 COMMIT;

--- a/database/bfgd/scripts/0011.sql
+++ b/database/bfgd/scripts/0011.sql
@@ -1,0 +1,12 @@
+
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 11;
+
+CREATE INDEX pop_pasis_published_pop_txs_desc_idx ON pop_basis (l2_keystone_abrev_hash, id DESC) WHERE btc_block_hash IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
add index to pop_basis so we can avoid "rescans" in the query

**Summary**
rescans were taking a long time in the pop tx query, add an index to avoid them. 

**Changes**

_Note:_ I call my index `clayton_tmp_0` for testing purposes, I have removed this indexed and renamed it in the PR.

before (for about 6-7k rows matching the `pop_basis` query)
```
 Limit  (cost=26902.86..26903.11 rows=100 width=1321) (actual time=1979.313..1979.328 rows=100 loops=1)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=8.69..8.86 rows=1 width=41) (actual time=0.084..0.085 rows=1 loops=1)
           ->  Index Scan Backward using l2_keystone_l2_block_number_idx on l2_keystones  (cost=0.28..1175.82 rows=6989 width=41) (actual time=0.044..0.083 rows=51 loops=1)
   ->  Sort  (cost=26894.00..26911.03 rows=6811 width=1321) (actual time=1979.312..1979.319 rows=100 loops=1)
         Sort Key: pop_basis.id
         Sort Method: top-N heapsort  Memory: 282kB
         ->  Bitmap Heap Scan on pop_basis  (cost=89.35..26633.69 rows=6811 width=1321) (actual time=4.331..1974.378 rows=13371 loops=1)
               Recheck Cond: (l2_keystone_abrev_hash = $0)
               Filter: (btc_block_hash IS NOT NULL)
               Heap Blocks: exact=6438
               ->  Bitmap Index Scan on l2_keystone_abrev_hash_idx  (cost=0.00..87.64 rows=6811 width=0) (actual time=3.113..3.113 rows=13371 loops=1)
                     Index Cond: (l2_keystone_abrev_hash = $0)
 Planning Time: 0.604 ms
 Execution Time: 1979.356 ms
```

after (for a similar number of `pop_basis` rows)
```
 Limit  (cost=11.95..416.75 rows=100 width=1321) (actual time=0.928..5.350 rows=100 loops=1)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=11.22..11.38 rows=1 width=41) (actual time=0.264..0.264 rows=1 loops=1)
           ->  Index Scan Backward using l2_keystone_l2_block_number_idx on l2_keystones  (cost=0.28..1175.82 rows=6989 width=41) (actual time=0.013..0.261 rows=66 loops=1)
   ->  Index Scan using clayton_tmp_0 on pop_basis  (cost=0.56..27656.70 rows=6832 width=1321) (actual time=0.928..5.319 rows=100 loops=1)
         Index Cond: (l2_keystone_abrev_hash = $0)
 Planning Time: 0.206 ms
 Execution Time: 5.375 ms
(8 rows)
```