### PR TITLE
Add additional prometheus capability to integrate in grafana

### DIFF
--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -106,6 +106,12 @@ var (
 			Help:         "address and port tbcd prometheus listens on",
 			Print:        config.PrintAll,
 		},
+		"TBC_PROMETHEUS_SUBSYTEM": config.Config{
+			Value:        &cfg.PrometheusSubsystem,
+			DefaultValue: "tbc",
+			Help:         "prefix of prometheus subsystem",
+			Print:        config.PrintAll,
+		},
 		"TBC_PPROF_ADDRESS": config.Config{
 			Value:        &cfg.PprofListenAddress,
 			DefaultValue: "",

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -106,12 +106,6 @@ var (
 			Help:         "address and port tbcd prometheus listens on",
 			Print:        config.PrintAll,
 		},
-		"TBC_PROMETHEUS_NAMESPACE": config.Config{
-			Value:        &cfg.PrometheusNamespace,
-			DefaultValue: "tbc",
-			Help:         "prefix of prometheus namespace",
-			Print:        config.PrintAll,
-		},
 		"TBC_PPROF_ADDRESS": config.Config{
 			Value:        &cfg.PprofListenAddress,
 			DefaultValue: "",

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -106,10 +106,10 @@ var (
 			Help:         "address and port tbcd prometheus listens on",
 			Print:        config.PrintAll,
 		},
-		"TBC_PROMETHEUS_SUBSYTEM": config.Config{
-			Value:        &cfg.PrometheusSubsystem,
+		"TBC_PROMETHEUS_NAMESPACE": config.Config{
+			Value:        &cfg.PrometheusNamespace,
 			DefaultValue: "tbc",
-			Help:         "prefix of prometheus subsystem",
+			Help:         "prefix of prometheus namespace",
 			Print:        config.PrintAll,
 		},
 		"TBC_PPROF_ADDRESS": config.Config{

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -104,8 +104,9 @@ func lastCheckpointHeight(height uint64, hhm map[chainhash.Hash]uint64) uint64 {
 }
 
 type HashHeight struct {
-	Hash   chainhash.Hash
-	Height uint64
+	Hash      chainhash.Hash
+	Height    uint64
+	Timestamp int64 // optional
 }
 
 func (h HashHeight) String() string {
@@ -127,7 +128,11 @@ func (s *Server) mdHashHeight(ctx context.Context, key []byte) (*HashHeight, err
 	if err != nil {
 		return nil, fmt.Errorf("metadata block header: %w", err)
 	}
-	return &HashHeight{Hash: *ch, Height: bh.Height}, nil
+	return &HashHeight{
+		Hash:      *ch,
+		Height:    bh.Height,
+		Timestamp: bh.Timestamp().Unix(),
+	}, nil
 }
 
 // UtxoIndexHash returns the last hash that has been been UTxO indexed.

--- a/service/tbc/prometheushorror.go
+++ b/service/tbc/prometheushorror.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
 package tbc
 
 // Prometheus makes kitty cry. Hide it in here.

--- a/service/tbc/prometheushorror.go
+++ b/service/tbc/prometheushorror.go
@@ -1,0 +1,23 @@
+package tbc
+
+// Prometheus makes kitty cry. Hide it in here.
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type valueVecFunc[T prometheus.Collector] struct {
+	metric T
+	fn     func(t T)
+}
+
+func newValueVecFunc[T prometheus.Collector](metric T, fn func(t T)) prometheus.Collector {
+	return &valueVecFunc[T]{metric: metric, fn: fn}
+}
+
+func (v *valueVecFunc[T]) Describe(descs chan<- *prometheus.Desc) {
+	v.metric.Describe(descs)
+}
+
+func (v *valueVecFunc[T]) Collect(metrics chan<- prometheus.Metric) {
+	v.fn(v.metric)
+	v.metric.Collect(metrics)
+}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2248,11 +2248,11 @@ func (s *Server) Run(pctx context.Context) error {
 				Name:      "synced",
 				Help:      "Is tbc synced.",
 			}, s.promSynced),
-			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			newValueVecFunc(prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Subsystem: promSubsystem,
 				Name:      "blockheader_height",
 				Help:      "Blockheader height.",
-			}, s.promBlockHeader),
+			}, []string{"hash"}), s.promBlockHeader),
 			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 				Subsystem: promSubsystem,
 				Name:      "utxo_sync_height",

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -203,7 +203,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		blocks:     blocks,
 		pings:      pings,
 		timeSource: blockchain.NewMedianTime(),
-		cmdsProcessed: prometheus.NewCounter(prometheus.CounterOpts{ // XXX: move into Collectors func
+		cmdsProcessed: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: cfg.PrometheusNamespace,
 			Name:      "rpc_calls_total",
 			Help:      "The total number of successful RPC commands",
@@ -2159,7 +2159,7 @@ func (s *Server) Collectors() []prometheus.Collector {
 			s.cmdsProcessed,
 			newValueVecFunc(prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Namespace: s.cfg.PrometheusNamespace,
-				Name:      "blockheader_height", // XXX: rename to block_height?
+				Name:      "block_height",
 				Help:      "Best block canonical height and hash",
 			}, []string{"hash", "timestamp"}), s.promBlockHeader),
 			prometheus.NewGaugeFunc(prometheus.GaugeOpts{

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -202,7 +202,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		blocks:     blocks,
 		pings:      pings,
 		timeSource: blockchain.NewMedianTime(),
-		cmdsProcessed: prometheus.NewCounter(prometheus.CounterOpts{
+		cmdsProcessed: prometheus.NewCounter(prometheus.CounterOpts{ // XXX: move into Collectors func
 			Subsystem: cfg.PrometheusSubsystem,
 			Name:      "rpc_calls_total",
 			Help:      "The total number of successful RPC commands",

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2166,9 +2166,10 @@ func (s *Server) Run(pctx context.Context) error {
 			return fmt.Errorf("block header best: %w", err)
 		}
 
-		// This Run function is only called in regular (not external header) mode, so this is true genesis block @ 0
-		// and we pass in a nil difficulty so it calculates the starting difficulty as the genesis block's own local
-		// difficulty.
+		// This Run function is only called in regular (not external
+		// header) mode, so this is true genesis block @ 0 and we pass
+		// in a nil difficulty so it calculates the starting difficulty
+		// as the genesis block's own local difficulty.
 		if err = s.insertGenesis(ctx, 0, nil); err != nil {
 			return fmt.Errorf("insert genesis: %w", err)
 		}
@@ -2456,22 +2457,4 @@ func (s *Server) ExternalHeaderTearDown() error {
 		return err
 	}
 	return nil
-}
-
-type valueVecFunc[T prometheus.Collector] struct {
-	metric T
-	fn     func(t T)
-}
-
-func newValueVecFunc[T prometheus.Collector](metric T, fn func(t T)) prometheus.Collector {
-	return &valueVecFunc[T]{metric: metric, fn: fn}
-}
-
-func (v *valueVecFunc[T]) Describe(descs chan<- *prometheus.Desc) {
-	v.metric.Describe(descs)
-}
-
-func (v *valueVecFunc[T]) Collect(metrics chan<- prometheus.Metric) {
-	v.fn(v.metric)
-	v.metric.Collect(metrics)
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -152,6 +152,7 @@ type Server struct {
 	db tbcd.Database
 
 	// Prometheus
+	promCollectors  []prometheus.Collector
 	promPollVerbose bool // set to true to print stats during poll
 	prom            struct {
 		syncInfo                  SyncInfo
@@ -2152,66 +2153,7 @@ func (s *Server) DBClose() error {
 
 // Collectors returns the Prometheus collectors available for the server.
 func (s *Server) Collectors() []prometheus.Collector {
-	// Naming: https://prometheus.io/docs/practices/naming/
-	namespace := s.cfg.PrometheusNamespace
-	return []prometheus.Collector{
-		s.cmdsProcessed,
-		newValueVecFunc(prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "blockheader_height", // XXX: rename to block_height?
-			Help:      "Best block canonical height and hash",
-		}, []string{"hash", "timestamp"}), s.promBlockHeader),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "blocks_missing",
-			Help:      "Number of missing blocks. -1 means more than 64 missing",
-		}, s.promBlocksMissing),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "running",
-			Help:      "Whether the TBC service is running",
-		}, s.promRunning),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "synced",
-			Help:      "Whether the TBC service is synced",
-		}, s.promSynced),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "utxo_sync_height",
-			Help:      "Height of the UTXO indexer",
-		}, s.promUtxo),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "tx_sync_height",
-			Help:      "Height of transaction indexer",
-		}, s.promTx),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "peers_connected",
-			Help:      "Number of peers connected",
-		}, s.promConnectedPeers),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "peers_good",
-			Help:      "Number of good peers",
-		}, s.promGoodPeers),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "peers_bad",
-			Help:      "Number of bad peers",
-		}, s.promBadPeers),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "mempool_count",
-			Help:      "Number of transactions in mempool",
-		}, s.promMempoolCount),
-		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "mempool_size_bytes",
-			Help:      "Size of mempool in bytes",
-		}, s.promMempoolSize),
-	}
+	return s.promCollectors
 }
 
 func (s *Server) Run(pctx context.Context) error {
@@ -2336,11 +2278,70 @@ func (s *Server) Run(pctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("create server: %w", err)
 		}
-		cs := s.Collectors()
+
+		// Naming: https://prometheus.io/docs/practices/naming/
+		s.promCollectors = []prometheus.Collector{
+			s.cmdsProcessed,
+			newValueVecFunc(prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "blockheader_height", // XXX: rename to block_height?
+				Help:      "Best block canonical height and hash",
+			}, []string{"hash", "timestamp"}), s.promBlockHeader),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "blocks_missing",
+				Help:      "Number of missing blocks. -1 means more than 64 missing",
+			}, s.promBlocksMissing),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "running",
+				Help:      "Whether the TBC service is running",
+			}, s.promRunning),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "synced",
+				Help:      "Whether the TBC service is synced",
+			}, s.promSynced),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "utxo_sync_height",
+				Help:      "Height of the UTXO indexer",
+			}, s.promUtxo),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "tx_sync_height",
+				Help:      "Height of transaction indexer",
+			}, s.promTx),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "peers_connected",
+				Help:      "Number of peers connected",
+			}, s.promConnectedPeers),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "peers_good",
+				Help:      "Number of good peers",
+			}, s.promGoodPeers),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "peers_bad",
+				Help:      "Number of bad peers",
+			}, s.promBadPeers),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "mempool_count",
+				Help:      "Number of transactions in mempool",
+			}, s.promMempoolCount),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "mempool_size_bytes",
+				Help:      "Size of mempool in bytes",
+			}, s.promMempoolSize),
+		}
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := d.Run(ctx, cs); !errors.Is(err, context.Canceled) {
+			if err := d.Run(ctx, s.promCollectors); !errors.Is(err, context.Canceled) {
 				log.Errorf("prometheus terminated with error: %v", err)
 				return
 			}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2153,6 +2153,9 @@ func (s *Server) DBClose() error {
 
 // Collectors returns the Prometheus collectors available for the server.
 func (s *Server) Collectors() []prometheus.Collector {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
 	if s.promCollectors == nil {
 		// Naming: https://prometheus.io/docs/practices/naming/
 		s.promCollectors = []prometheus.Collector{


### PR DESCRIPTION
**Summary**
Add a new prometheus gauge type that can carry labels so that we can expose strings when needed. Also make sure we can set the prometheus subsystem name so that an app can embed multiple tbc structs (hello op-geth!).

**Changes**
<!-- A list of changes made by this pull request. -->
