### PR TITLE
Fix or workaround dumb linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -97,4 +97,6 @@ linters-settings:
   # Lints nolint directives.
   nolintlint:
     # Require an explanation after each nolint directive.
+    # Explanation format example: '//nolint:ineffassign // Explanation goes here.'
+    # If this becomes too annoying, disable it.
     require-explanation: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,10 @@ run:
   tests: false
 
 issues:
+  # Show all errors
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
   # Exclude sources following the Go generated file convention.
   exclude-generated: "strict"
 
@@ -14,13 +18,18 @@ issues:
 linters:
   enable:
     - "errcheck" # Checks for unchecked errors.
+    - "errorlint" # Verifies errors are properly wrapped.
     - "gci" # Enforces package import order, making it deterministic.
     - "gofumpt" # Runs gofumpt.
     - "goheader" # Enforces copyright header.
+    # TODO enable gosec, when bored run 'golangci-lint run -Egosec' to fix these
+    # - "gosec" # Checks for potential security issues
     - "gosimple" # Checks for ways to simplify code.
     - "gomoddirectives" # Manages 'replace', 'retract' and 'excludes' directives in go.mod.
     - "govet" # Runs go vet.
     - "ineffassign" # Detects when assignments to variables are not used.
+    # TODO enable revive, when bored run 'golangci-lint run -Erevive' to fix these
+    # - "revive" # Checks for potential security issues
     - "staticcheck" # Runs staticcheck.
     - "unconvert" # Checks for unnecessary type conversions.
     - "unused" # Checks for unused constants, variables, functions and types.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ issues:
 linters:
   enable:
     - "asasalint" # Check for pass []any as any in variadic func(...any).
+    - "bodyclose" # Checks whether HTTP response body is closed successfully.
     - "dupword" # Checks for duplicate words in the source code.
     - "errcheck" # Checks for unchecked errors.
     - "errorlint" # Verifies errors are properly wrapped.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,6 +38,7 @@ linters:
     # TODO enable revive, when bored run 'golangci-lint run -Erevive' to fix these
     # - "revive" # Checks for potential security issues
     - "nilerr" # Finds the code that returns nil even if it checks that the error is not nil.
+    - "nolintlint" # Reports ill-formed or insufficient nolint directives.
     - "prealloc" # Finds slice declarations that could potentially be pre-allocated.
     - "predeclared" # Find code that shadows one of Go's predeclared identifiers.
     - "promlinter" # Check Prometheus metrics naming via promlint.
@@ -92,3 +93,8 @@ linters-settings:
       Copyright (c) {{ YEAR }} {{ COMPANY }}
       Use of this source code is governed by the MIT License,
       which can be found in the LICENSE file.
+
+  # Lints nolint directives.
+  nolintlint:
+    # Require an explanation after each nolint directive.
+    require-explanation: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,6 +50,13 @@ linters-settings:
       - "localmodule"
     custom-order: true
 
+  gocritic:
+    disabled-checks:
+      - "elseif"
+      - "exitAfterDefer"
+      - "ifElseChain"
+      - "singleCaseSwitch"
+
   # Detects XXX/TODO/FIXME comments. Useful for finding old todo items.
   #  Use: golangci-lint run --enable-only godox
   godox:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,20 +17,32 @@ issues:
 
 linters:
   enable:
+    - "asasalint" # Check for pass []any as any in variadic func(...any).
+    - "dupword" # Checks for duplicate words in the source code.
     - "errcheck" # Checks for unchecked errors.
     - "errorlint" # Verifies errors are properly wrapped.
+    - "errname" # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
     - "gci" # Enforces package import order, making it deterministic.
+    - "gocheckcompilerdirectives" # Checks that go compiler directive comments (//go:) are valid.
+    - "gochecksumtype" # Run exhaustiveness checks on Go "sum types".
     - "gofumpt" # Runs gofumpt.
     - "goheader" # Enforces copyright header.
     # TODO enable gosec, when bored run 'golangci-lint run -Egosec' to fix these
     # - "gosec" # Checks for potential security issues
     - "gosimple" # Checks for ways to simplify code.
     - "gomoddirectives" # Manages 'replace', 'retract' and 'excludes' directives in go.mod.
+    - "gosmopolitan" # Report certain i18n/l10n anti-patterns in your Go codebase.
     - "govet" # Runs go vet.
     - "ineffassign" # Detects when assignments to variables are not used.
     # TODO enable revive, when bored run 'golangci-lint run -Erevive' to fix these
     # - "revive" # Checks for potential security issues
+    - "nilerr" # Finds the code that returns nil even if it checks that the error is not nil.
+    - "prealloc" # Finds slice declarations that could potentially be pre-allocated.
+    - "predeclared" # Find code that shadows one of Go's predeclared identifiers.
+    - "promlinter" # Check Prometheus metrics naming via promlint.
     - "staticcheck" # Runs staticcheck.
+    - "sqlclosecheck" # Checks that sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed.
+    - "rowserrcheck" # Checks whether Rows.Err of rows is checked successfully.
     - "unconvert" # Checks for unnecessary type conversions.
     - "unused" # Checks for unused constants, variables, functions and types.
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,11 +2,6 @@ run:
   tests: false
 
 issues:
-  # TODO: Currently, we exclude all issues introduced before commit 8e55591c.
-  # If you're bored, run this command to show all issues :)
-  #  golangci-lint run --show-stats --new-from-rev=""
-  new-from-rev: "8e55591ce900688a9bb1107584bcb014e76f22c9"
-
   # Exclude sources following the Go generated file convention.
   exclude-generated: "strict"
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint:
 	$(shell go env GOPATH)/bin/golangci-lint run --fix ./...
 
 lint-deps:
-	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62
 
 tidy:
 	go mod tidy

--- a/api/auth/secp256k1.go
+++ b/api/auth/secp256k1.go
@@ -86,7 +86,7 @@ func handleSecp256k1HelloChallenge(privKey *dcrsecpk256k1.PrivateKey, hc *Secp25
 	}
 
 	signatureHash := am.Hash()
-	signature := dcrecdsa.SignCompact(privKey, signatureHash[:], true)
+	signature := dcrecdsa.SignCompact(privKey, signatureHash, true)
 	return &Secp256k1HelloChallengeAccepted{
 		Signature: hex.EncodeToString(signature),
 	}, nil
@@ -101,7 +101,7 @@ func handleSecp256k1HelloChallengeAccepted(am *AuthenticateMessage, hca *Secp256
 		return nil, fmt.Errorf("hex decode: %w", err)
 	}
 	signatureHash := am.Hash()
-	derived, _, err := dcrecdsa.RecoverCompact(signature, signatureHash[:])
+	derived, _, err := dcrecdsa.RecoverCompact(signature, signatureHash)
 	if err != nil {
 		return nil, fmt.Errorf("hex decode: %w", err)
 	}

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -376,6 +376,7 @@ func (ac *Conn) Connect(ctx context.Context) error {
 	// package.
 	// Note that we cannot have DialOptions on a WASM websocket
 	log.Tracef("Connect: dialing %v", ac.serverURL)
+	// nolint:bodyclose
 	conn, _, err := websocket.Dial(connectCtx, ac.serverURL, newDialOptions(ac.opts))
 	if err != nil {
 		return fmt.Errorf("dial server: %w", err)

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -52,8 +52,7 @@ var PublicKeyAuthError = websocket.CloseError{
 }
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -376,7 +376,7 @@ func (ac *Conn) Connect(ctx context.Context) error {
 	// package.
 	// Note that we cannot have DialOptions on a WASM websocket
 	log.Tracef("Connect: dialing %v", ac.serverURL)
-	// nolint:bodyclose
+	//nolint:bodyclose // Response body closure is handled by websocket library.
 	conn, _, err := websocket.Dial(connectCtx, ac.serverURL, newDialOptions(ac.opts))
 	if err != nil {
 		return fmt.Errorf("dial server: %w", err)

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -46,7 +46,7 @@ func (he HandshakeError) Is(target error) bool {
 	return ok
 }
 
-var PublicKeyAuthError = websocket.CloseError{
+var ErrPublicKeyAuth = websocket.CloseError{
 	Code:   StatusHandshakeErr,
 	Reason: HandshakeError("invalid public key").Error(),
 }

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -52,7 +52,10 @@ var PublicKeyAuthError = websocket.CloseError{
 }
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // random returns a variable number of random bytes.

--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -164,7 +164,9 @@ func _main() error {
 		return err
 	}
 
-	loggo.ConfigureLoggers(cfg.LogLevel)
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		return err
+	}
 	log.Infof(welcome)
 
 	pc := config.PrintableConfig(cm)

--- a/cmd/bssd/bssd.go
+++ b/cmd/bssd/bssd.go
@@ -91,7 +91,9 @@ func _main() error {
 		return err
 	}
 
-	loggo.ConfigureLoggers(cfg.LogLevel)
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		return err
+	}
 	log.Infof("%v", welcome)
 
 	pc := config.PrintableConfig(cm)

--- a/cmd/btctool/blockstream/blockstream.go
+++ b/cmd/btctool/blockstream/blockstream.go
@@ -15,8 +15,8 @@ import (
 
 var (
 	bsTestnetURL = "https://blockstream.info/testnet/api" // XXX wrap in structure
-	bsMainnetURL = "https://blockstream.info/api"         // XXX wrap in structure
-	bsURL        = bsTestnetURL                           // XXX wrap in structure
+	// bsMainnetURL = "https://blockstream.info/api"         // XXX wrap in structure
+	bsURL = bsTestnetURL // XXX wrap in structure
 )
 
 type TBlock struct {

--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -513,8 +513,8 @@ func _main() error {
 	// flag.StringVar(&downloadDir, "downloaddir", "", "Directory to download block header and data to. Leave empty to dump to stdout.")
 	flag.Parse()
 
-	err := loggo.ConfigureLoggers("info") // XXX make flag
-	if err != nil {
+	// XXX make flag
+	if err := loggo.ConfigureLoggers("info"); err != nil {
 		return fmt.Errorf("configure loggers: %w", err)
 	}
 

--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -245,7 +245,7 @@ func handleBlock(p *peer, msg *wire.MsgBlock) {
 		len(msg.Transactions))
 }
 
-// nolint:dupword
+//nolint:dupword // False positive in commented-out code.
 func btcConnect(ctx context.Context, btcNet string) error {
 	// ips, err := net.LookupIP("seed.bitcoin.sipa.be")
 	// if err != nil {

--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -35,8 +35,6 @@ import (
 	"github.com/hemilabs/heminetwork/version"
 )
 
-var log = loggo.GetLogger("bdf")
-
 func parseBlockFromHex(blk string) (*btcutil.Block, error) {
 	eb, err := hex.DecodeString(strings.Trim(blk, "\n"))
 	if err != nil {
@@ -113,7 +111,7 @@ func (p *peer) connect(ctx context.Context) error {
 	return nil
 }
 
-func (p *peer) close() error {
+func (p *peer) Close() error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	if p.conn != nil {

--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -245,6 +245,7 @@ func handleBlock(p *peer, msg *wire.MsgBlock) {
 		len(msg.Transactions))
 }
 
+// nolint:dupword
 func btcConnect(ctx context.Context, btcNet string) error {
 	// ips, err := net.LookupIP("seed.bitcoin.sipa.be")
 	// if err != nil {

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -1051,6 +1051,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\tbss-client long connection to bss\n")
 	fmt.Fprintf(os.Stderr, "\thelp (this help)\n")
 	fmt.Fprintf(os.Stderr, "\thelp-verbose JSON print RPC default request/response\n")
+	// nolint:dupword
 	fmt.Fprintf(os.Stderr, "\tp2p p2p commands\n")
 	fmt.Fprintf(os.Stderr, "\ttbcdb datase open (tbcd must not be running)\n")
 	fmt.Fprintf(os.Stderr, "Environment:\n")

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -1100,7 +1100,9 @@ func _main() error {
 		return err
 	}
 
-	loggo.ConfigureLoggers(logLevel)
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
+		return err
+	}
 	log.Debugf("%v", welcome)
 
 	pc := config.PrintableConfig(cm)

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -1051,7 +1051,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\tbss-client long connection to bss\n")
 	fmt.Fprintf(os.Stderr, "\thelp (this help)\n")
 	fmt.Fprintf(os.Stderr, "\thelp-verbose JSON print RPC default request/response\n")
-	// nolint:dupword
+	//nolint:dupword // command help, not sentence.
 	fmt.Fprintf(os.Stderr, "\tp2p p2p commands\n")
 	fmt.Fprintf(os.Stderr, "\ttbcdb datase open (tbcd must not be running)\n")
 	fmt.Fprintf(os.Stderr, "Environment:\n")

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -952,8 +952,7 @@ func (bsc *bssClient) connectBSS(ctx context.Context) {
 	log.Tracef("bssClient")
 	defer log.Tracef("bssClient exit")
 
-	bssURI := filepath.Join(bsc.bssURL)
-	log.Infof("Connecting to: %v", bssURI)
+	log.Infof("Connecting to: %v", bsc.bssURL)
 	for {
 		if err := bsc.connect(ctx); err != nil {
 			// Do nothing
@@ -968,7 +967,7 @@ func (bsc *bssClient) connectBSS(ctx context.Context) {
 
 		// hold off reconnect for a couple of seconds
 		time.Sleep(5 * time.Second)
-		log.Debugf("Reconnecting to: %v", bssURI)
+		log.Debugf("Reconnecting to: %v", bsc.bssURL)
 	}
 }
 

--- a/cmd/keygen/keygen.go
+++ b/cmd/keygen/keygen.go
@@ -59,8 +59,7 @@ func _main() error {
 		btcAddress, err := btcutil.NewAddressPubKey(privKey.PubKey().SerializeCompressed(),
 			btcChainParams)
 		if err != nil {
-			return fmt.Errorf("create BTC address from public key: %v",
-				err)
+			return fmt.Errorf("create BTC address from public key: %w", err)
 		}
 		hash := btcAddress.AddressPubKeyHash().String()
 		ethAddress := ethereum.AddressFromPrivateKey(privKey)

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -117,7 +117,9 @@ func _main() error {
 		return err
 	}
 
-	loggo.ConfigureLoggers(cfg.LogLevel)
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		return err
+	}
 	log.Infof("%v", welcome)
 
 	pc := config.PrintableConfig(cm)

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -147,7 +147,9 @@ func _main() error {
 		return err
 	}
 
-	loggo.ConfigureLoggers(cfg.LogLevel)
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		return err
+	}
 	log.Infof("%v", welcome)
 
 	pc := config.PrintableConfig(cm)

--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func Parse(c CfgMap) error {
 			if v.Parse != nil {
 				val, err := v.Parse(envValue)
 				if err != nil {
-					return fmt.Errorf("invalid value for %v: %v", k, err)
+					return fmt.Errorf("invalid value for %v: %w", k, err)
 				}
 				reflect.ValueOf(v.Value).Elem().Set(reflect.ValueOf(val))
 				return nil
@@ -74,7 +74,7 @@ func Parse(c CfgMap) error {
 
 				evTyped, err := strconv.ParseInt(envValue, 10, 64)
 				if err != nil {
-					return fmt.Errorf("invalid integer for %v: %v",
+					return fmt.Errorf("invalid integer for %v: %w",
 						k, err)
 				}
 				reflect.ValueOf(v.Value).Elem().SetInt(evTyped)
@@ -84,7 +84,7 @@ func Parse(c CfgMap) error {
 
 				evTyped, err := strconv.ParseUint(envValue, 10, 64)
 				if err != nil {
-					return fmt.Errorf("invalid unsigned for %v: %v",
+					return fmt.Errorf("invalid unsigned for %v: %w",
 						k, err)
 				}
 				reflect.ValueOf(v.Value).Elem().SetUint(evTyped)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -761,6 +761,7 @@ func (p *pgdb) L2BTCFinalityMostRecent(ctx context.Context, limit uint32) ([]bfg
 			}
 		}
 
+		// nolint:ifElseChain
 		if publishedFinality == nil {
 			finality = unpublishedFinality
 		} else if unpublishedFinality == nil {

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -762,7 +762,6 @@ func (p *pgdb) L2BTCFinalityMostRecent(ctx context.Context, limit uint32) ([]bfg
 			}
 		}
 
-		// nolint:ifElseChain
 		if publishedFinality == nil {
 			finality = unpublishedFinality
 		} else if unpublishedFinality == nil {

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1122,10 +1122,14 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 	var serializedTx []byte
 	err := p.db.QueryRowContext(ctx, querySql).Scan(&serializedTx)
 	if err != nil {
-		return nil, fmt.Errorf("could not get next btc_transaction_broadcast_request: %w", err)
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("could not get next btc_transaction_broadcast_request: %w", err)
+		}
+		// Query may return 1 or 0 rows.
+		return nil, nil
 	}
 
-	return nil, nil
+	return serializedTx, nil
 }
 
 // BtcTransactionBroadcastRequestConfirmBroadcast sets a broadcast request to

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -46,8 +46,7 @@ const effectiveHeightSql = `
 var log = loggo.GetLogger("bfgpostgres")
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -550,7 +550,7 @@ func (p *pgdb) PopBasisByL2KeystoneAbrevHash(ctx context.Context, aHash [32]byte
 }
 
 // nextL2BTCFinalitiesPublished , given a block number (lessThanL2BlockNumber)
-// will find the the next smallest published finality on the canoncial chain
+// will find the next smallest published finality on the canoncial chain
 func (p *pgdb) nextL2BTCFinalitiesPublished(ctx context.Context, lessThanL2BlockNumber uint32, limit int) ([]bfgd.L2BTCFinality, error) {
 	sql := fmt.Sprintf(`
 		SELECT
@@ -615,9 +615,10 @@ func (p *pgdb) nextL2BTCFinalitiesPublished(ctx context.Context, lessThanL2Block
 	return finalities, nil
 }
 
-// nextL2BTCFinalitiesAssumedUnpublished , given a block number (lessThanL2BlockNumber)
-// will find the the next smallest published finality that is not within explicitExcludeL2BlockNumbers
-// and assume it is unpublished (returning nothing for BTC fields)
+// nextL2BTCFinalitiesAssumedUnpublished , given a block number
+// (lessThanL2BlockNumber) will find the next smallest published finality that
+// is not within explicitExcludeL2BlockNumbers and assume it is unpublished
+// (returning nothing for BTC fields)
 func (p *pgdb) nextL2BTCFinalitiesAssumedUnpublished(ctx context.Context, lessThanL2BlockNumber uint32, limit int, explicitExcludeL2BlockNumbers []uint32) ([]bfgd.L2BTCFinality, error) {
 	sql := fmt.Sprintf(`
 		SELECT
@@ -1118,15 +1119,8 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 		RETURNING serialized_tx
 	`, onlyNewClause, orderClause)
 
-	rows, err := p.db.QueryContext(ctx, querySql)
-	if err != nil {
-		return nil, fmt.Errorf("could not get next btc_transaction_broadcast_request: %w", err)
-	}
-
-	defer rows.Close()
-
 	var serializedTx []byte
-	err = p.db.QueryRowContext(ctx, querySql).Scan(&serializedTx)
+	err := p.db.QueryRowContext(ctx, querySql).Scan(&serializedTx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get next btc_transaction_broadcast_request: %w", err)
 	}

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1124,14 +1124,10 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 
 	defer rows.Close()
 
-	for rows.Next() {
-		var serializedTx []byte
-		if err := rows.Scan(&serializedTx); err != nil {
-			return nil, err
-		}
-		// LIMIT 1 above so linter needs to shut up
-		// nolint:staticcheck
-		return serializedTx, nil
+	var serializedTx []byte
+	err = p.db.QueryRowContext(ctx, querySql).Scan(&serializedTx)
+	if err != nil {
+		return nil, fmt.Errorf("could not get next btc_transaction_broadcast_request: %w", err)
 	}
 
 	return nil, nil

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -46,7 +46,10 @@ const effectiveHeightSql = `
 var log = loggo.GetLogger("bfgpostgres")
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 type pgdb struct {
@@ -1127,7 +1130,8 @@ func (p *pgdb) BtcTransactionBroadcastRequestGetNext(ctx context.Context, onlyNe
 		if err := rows.Scan(&serializedTx); err != nil {
 			return nil, err
 		}
-
+		// LIMIT 1 above so linter needs to shut up
+		// nolint:staticcheck
 		return serializedTx, nil
 	}
 

--- a/database/level/level.go
+++ b/database/level/level.go
@@ -43,7 +43,10 @@ const (
 var log = loggo.GetLogger("level")
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 type Pool map[string]*leveldb.DB

--- a/database/level/level.go
+++ b/database/level/level.go
@@ -43,8 +43,7 @@ const (
 var log = loggo.GetLogger("level")
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -29,8 +29,7 @@ const (
 var log = loggo.GetLogger("postgres")
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		fmt.Println(err)
 	}
 }

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -30,7 +30,7 @@ var log = loggo.GetLogger("postgres")
 
 func init() {
 	if err := loggo.ConfigureLoggers(logLevel); err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 }
 

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -29,7 +29,10 @@ const (
 var log = loggo.GetLogger("postgres")
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 type psqlNotification struct {
@@ -179,7 +182,12 @@ func (p *Database) ntfnListenHandler(ctx context.Context) {
 		case <-time.After(60 * time.Second):
 			go func() {
 				// log.Tracef("ntfnHandler: ping")
-				p.listener.Ping()
+				err := p.listener.Ping()
+				if err != nil {
+					// This is probably too loud but shut
+					// the linter up.
+					log.Errorf("pg ping: %v", err)
+				}
 			}()
 		}
 	}

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -349,7 +349,7 @@ func NewScriptHashFromBytes(hash []byte) (scriptHash ScriptHash, err error) {
 		err = errors.New("invalid script hash length")
 		return
 	}
-	copy(scriptHash[:], hash[:])
+	copy(scriptHash[:], hash)
 	return
 }
 

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -855,7 +855,8 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 	originalCanonicalTipHash := originalCanonicalTip.BlockHash()
 	heaviestRemovedBlockHash := headersParsed[len(headersParsed)-1].BlockHash()
 
-	removalType := tbcd.RTInvalid //nolint:ineffassign
+	// nolint:ineffassign
+	removalType := tbcd.RTInvalid
 	if tipAfterRemovalHash.IsEqual(&parentToRemovalSet.Hash) {
 		// Canonical tip set by caller is the parent to the blocks removed
 		removalType = tbcd.RTChainDescend
@@ -1507,7 +1508,7 @@ func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd
 		// irrelevant.
 		if utxo.IsDelete() {
 			// Delete balance and utxos
-			outsBatch.Delete(op[:][:])
+			outsBatch.Delete(op[:])
 			outsBatch.Delete(hop[:])
 		} else {
 			// Add utxo to balance and utxos

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -11,8 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"sync"
-	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcutil"
@@ -59,12 +57,13 @@ var log = loggo.GetLogger("level")
 var ErrIterator = IteratorError(errors.New("iteration error"))
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 type ldb struct {
-	mtx sync.Mutex
-
 	*level.Database
 	pool    level.Pool
 	rawPool level.RawPool
@@ -1187,11 +1186,6 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, batc
 	}
 
 	return it, cbh, lbh, len(bhs.Headers), nil
-}
-
-type cacheEntry struct {
-	height    uint64
-	timestamp time.Time
 }
 
 // XXX return hash and height only

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -855,7 +855,7 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 	originalCanonicalTipHash := originalCanonicalTip.BlockHash()
 	heaviestRemovedBlockHash := headersParsed[len(headersParsed)-1].BlockHash()
 
-	// nolint:ineffassign
+	//nolint:ineffassign // tbcd.RTInvalid is being used as the default.
 	removalType := tbcd.RTInvalid
 	if tipAfterRemovalHash.IsEqual(&parentToRemovalSet.Hash) {
 		// Canonical tip set by caller is the parent to the blocks removed

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -57,8 +57,7 @@ var log = loggo.GetLogger("level")
 var ErrIterator = IteratorError(errors.New("iteration error"))
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/hemi/electrs/conn_pool.go
+++ b/hemi/electrs/conn_pool.go
@@ -147,6 +147,8 @@ func (p *connPool) freeConn(conn *clientConn) {
 }
 
 // size returns the number of connections in the pool.
+// Linter narrator, it is indeed used.
+// nolint:unused
 func (p *connPool) size() int {
 	p.poolMx.Lock()
 	defer p.poolMx.Unlock()

--- a/hemi/electrs/conn_pool.go
+++ b/hemi/electrs/conn_pool.go
@@ -147,8 +147,8 @@ func (p *connPool) freeConn(conn *clientConn) {
 }
 
 // size returns the number of connections in the pool.
-// Linter narrator, it is indeed used.
-// nolint:unused
+//
+//nolint:unused // False positive, used in tests.
 func (p *connPool) size() int {
 	p.poolMx.Lock()
 	defer p.poolMx.Unlock()

--- a/hemi/electrs/electrs.go
+++ b/hemi/electrs/electrs.go
@@ -433,7 +433,7 @@ func (c *Client) UTXOs(ctx context.Context, scriptHash []byte) ([]*UTXO, error) 
 	if err := c.call(ctx, "blockchain.scripthash.listunspent", &params, &eutxos); err != nil {
 		return nil, err
 	}
-	var utxos []*UTXO
+	utxos := make([]*UTXO, 0, len(eutxos))
 	for _, eutxo := range eutxos {
 		hash, err := btcchainhash.NewHashFromStr(eutxo.Hash)
 		if err != nil {

--- a/rawdb/rawdb.go
+++ b/rawdb/rawdb.go
@@ -31,8 +31,7 @@ var (
 )
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		fmt.Println(err)
 	}
 }

--- a/rawdb/rawdb.go
+++ b/rawdb/rawdb.go
@@ -32,7 +32,7 @@ var (
 
 func init() {
 	if err := loggo.ConfigureLoggers(logLevel); err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 }
 

--- a/rawdb/rawdb.go
+++ b/rawdb/rawdb.go
@@ -31,7 +31,10 @@ var (
 )
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 type RawDB struct {

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -62,7 +62,10 @@ var log = loggo.GetLogger("bfg")
 var ErrBTCPrivateKeyMissing error = errors.New("you must specify a BTC private key")
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func NewDefaultConfig() *Config {

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1178,7 +1178,7 @@ func (s *Server) handleWebsocketPublic(w http.ResponseWriter, r *http.Request) {
 		}
 		if !exists {
 			log.Errorf("unauthorized public key: %s", publicKeyEncoded)
-			conn.Close(protocol.PublicKeyAuthError.Code, protocol.PublicKeyAuthError.Reason)
+			conn.Close(protocol.ErrPublicKeyAuth.Code, protocol.ErrPublicKeyAuth.Reason)
 			return
 		}
 	}

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -22,7 +22,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 	"github.com/davecgh/go-spew/spew"
-	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/juju/loggo"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -62,8 +62,7 @@ var log = loggo.GetLogger("bfg")
 var ErrBTCPrivateKeyMissing error = errors.New("you must specify a BTC private key")
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -645,8 +645,7 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 
 	rbh, err := s.btcClient.RawBlockHeader(ctx, height)
 	if err != nil {
-		return fmt.Errorf("get block header at height %v: %v",
-			height, err)
+		return fmt.Errorf("get block header at height %v: %w", height, err)
 	}
 
 	// grab the merkle root from the header, I am not sure if there is a
@@ -735,7 +734,7 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 
 		publicKeyUncompressed, err := pop.ParsePublicKeyFromSignatureScript(mtx.TxIn[0].SignatureScript)
 		if err != nil {
-			return fmt.Errorf("could not parse signature script: %s", err)
+			return fmt.Errorf("could not parse signature script: %w", err)
 		}
 
 		popTxIdFull := []byte{}
@@ -1231,8 +1230,7 @@ func (s *Server) handlePingRequest(ctx context.Context, bws *bfgWs, payload any,
 	log.Tracef("responding with %v", spew.Sdump(response))
 
 	if err := bfgapi.Write(ctx, bws.conn, id, response); err != nil {
-		return fmt.Errorf("handlePingRequest write: %v %v",
-			bws.addr, err)
+		return fmt.Errorf("handlePingRequest write: %v %w", bws.addr, err)
 	}
 	return nil
 }

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -219,8 +219,7 @@ func (s *Server) handlePingRequest(ctx context.Context, bws *bssWs, payload any,
 	log.Tracef("responding with %v", spew.Sdump(response))
 
 	if err := bssapi.Write(ctx, bws.conn, id, response); err != nil {
-		return fmt.Errorf("handlePingRequest write: %v %v",
-			bws.addr, err)
+		return fmt.Errorf("handlePingRequest write: %v %w", bws.addr, err)
 	}
 	return nil
 }

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -41,8 +41,7 @@ const (
 var log = loggo.GetLogger("bss")
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -41,7 +41,10 @@ const (
 var log = loggo.GetLogger("bss")
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Wrap for calling bfg commands

--- a/service/deucalion/deucalion.go
+++ b/service/deucalion/deucalion.go
@@ -75,7 +75,10 @@ func init() {
 		return
 	}
 
-	loggo.ConfigureLoggers(cfg.logLevel)
+	err := loggo.ConfigureLoggers(cfg.logLevel)
+	if err != nil {
+		panic(err)
+	}
 
 	// launch prometheus automatically
 	ctx := context.Background()
@@ -118,7 +121,7 @@ func handle(service string, mux *http.ServeMux, pattern string, handler func(htt
 	log.Infof("handle (%v): %v", service, pattern)
 }
 
-func (d *Deucalion) running() bool {
+func (d *Deucalion) Running() bool {
 	d.mtx.RLock()
 	defer d.mtx.RUnlock()
 	return d.isRunning

--- a/service/deucalion/deucalion.go
+++ b/service/deucalion/deucalion.go
@@ -75,8 +75,7 @@ func init() {
 		return
 	}
 
-	err := loggo.ConfigureLoggers(cfg.logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(cfg.logLevel); err != nil {
 		panic(err)
 	}
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -755,7 +755,7 @@ func (m *Miner) handleBFGWebsocketRead(ctx context.Context, conn *protocol.Conn)
 		cmd, rid, payload, err := bfgapi.ReadConn(ctx, conn)
 		if err != nil {
 			// XXX kinda don't want to do thi here
-			if errors.Is(err, protocol.PublicKeyAuthError) {
+			if errors.Is(err, protocol.ErrPublicKeyAuth) {
 				return err
 			}
 
@@ -879,7 +879,7 @@ func (m *Miner) bfg(ctx context.Context) error {
 		if err := m.connectBFG(ctx); err != nil {
 			log.Debugf("connectBFG: %v", err)
 
-			if errors.Is(err, protocol.PublicKeyAuthError) {
+			if errors.Is(err, protocol.ErrPublicKeyAuth) {
 				return err
 			}
 		}

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -59,8 +59,7 @@ var (
 )
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -59,7 +59,10 @@ var (
 )
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 type Config struct {

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -1263,7 +1263,7 @@ func TestConnectToBFGAndPerformMineWithAuthError(t *testing.T) {
 	}()
 	if err := miner.Run(ctx); err != nil {
 		for err != nil {
-			if errors.Is(err, protocol.PublicKeyAuthError) {
+			if errors.Is(err, protocol.ErrPublicKeyAuth) {
 				return
 			}
 			err = errors.Unwrap(err)
@@ -1323,7 +1323,7 @@ func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string, keyst
 			}
 
 			if !found {
-				c.Close(protocol.PublicKeyAuthError.Code, protocol.PublicKeyAuthError.Reason)
+				c.Close(protocol.ErrPublicKeyAuth.Code, protocol.ErrPublicKeyAuth.Reason)
 				return
 			}
 

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -135,12 +135,12 @@ func (s *Server) mdHashHeight(ctx context.Context, key []byte) (*HashHeight, err
 	}, nil
 }
 
-// UtxoIndexHash returns the last hash that has been been UTxO indexed.
+// UtxoIndexHash returns the last hash that has been UTxO indexed.
 func (s *Server) UtxoIndexHash(ctx context.Context) (*HashHeight, error) {
 	return s.mdHashHeight(ctx, UtxoIndexHashKey)
 }
 
-// TxIndexHash returns the last hash that has been been Tx indexed.
+// TxIndexHash returns the last hash that has been Tx indexed.
 func (s *Server) TxIndexHash(ctx context.Context) (*HashHeight, error) {
 	return s.mdHashHeight(ctx, TxIndexHashKey)
 }
@@ -1320,9 +1320,9 @@ func (s *Server) IndexIsLinear(ctx context.Context, startHash, endHash *chainhas
 
 // SyncIndexersToHash tries to move the various indexers to the supplied
 // hash (inclusive).
-// Note: on unwind it means that it WILL unwind the the various indexers
-// including the hash that was passed in. E.g. if this unwinds from 1001 to
-// 1000 the indexes for block 1000 WILL be updated as well.
+// Note: on unwind it means that it WILL unwind the various indexers including
+// the hash that was passed in. E.g. if this unwinds from 1001 to 1000 the
+// indexes for block 1000 WILL be updated as well.
 func (s *Server) SyncIndexersToHash(ctx context.Context, hash *chainhash.Hash) error {
 	log.Tracef("SyncIndexersToHash")
 	defer log.Tracef("SyncIndexersToHash exit")

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -92,7 +92,7 @@ func lastCheckpointHeight(height uint64, hhm map[chainhash.Hash]uint64) uint64 {
 		c = append(c, HashHeight{Height: v, Hash: k})
 	}
 	sort.Slice(c, func(i, j int) bool {
-		return uint64(c[i].Height) > uint64(c[j].Height)
+		return c[i].Height > c[j].Height
 	})
 	for _, hh := range c {
 		if hh.Height > height {

--- a/service/tbc/mempool.go
+++ b/service/tbc/mempool.go
@@ -112,7 +112,7 @@ func (m *mempool) stats(ctx context.Context) (int, int) {
 	return len(m.txs), m.size + (len(m.txs) * chainhash.HashSize)
 }
 
-func (m *mempool) dump(ctx context.Context) string {
+func (m *mempool) Dump(ctx context.Context) string {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/service/tbc/peer/peer.go
+++ b/service/tbc/peer/peer.go
@@ -36,7 +36,10 @@ var (
 )
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // AlreadyPendingError is an error returned when a message is already pending

--- a/service/tbc/peer/peer.go
+++ b/service/tbc/peer/peer.go
@@ -36,8 +36,7 @@ var (
 )
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/service/tbc/peer/rawpeer/rawpeer.go
+++ b/service/tbc/peer/rawpeer/rawpeer.go
@@ -36,20 +36,27 @@ var (
 )
 
 func init() {
-	loggo.ConfigureLoggers(logLevel)
+	err := loggo.ConfigureLoggers(logLevel)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // XXX wire could use some contexts.
 
 func writeTimeout(timeout time.Duration, conn net.Conn, msg wire.Message, pver uint32, btcnet wire.BitcoinNet) error {
-	conn.SetWriteDeadline(time.Now().Add(timeout))
+	if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+		return err
+	}
 	_, err := wire.WriteMessageWithEncodingN(conn, msg, pver, btcnet,
 		wire.LatestEncoding)
 	return err
 }
 
 func readTimeout(timeout time.Duration, conn net.Conn, pver uint32, btcnet wire.BitcoinNet) (wire.Message, error) {
-	conn.SetReadDeadline(time.Now().Add(timeout))
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, err
+	}
 	_, msg, _, err := wire.ReadMessageWithEncodingN(conn, pver, btcnet,
 		wire.LatestEncoding)
 	return msg, err
@@ -111,9 +118,13 @@ func (r *RawPeer) Write(timeout time.Duration, msg wire.Message) error {
 	}
 
 	if timeout == 0 {
-		conn.SetWriteDeadline(time.Time{})
+		if err := conn.SetWriteDeadline(time.Time{}); err != nil {
+			return err
+		}
 	} else {
-		conn.SetWriteDeadline(time.Now().Add(timeout))
+		if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+			return err
+		}
 	}
 	// XXX contexts would be nice
 	_, err := wire.WriteMessageWithEncodingN(conn, msg, r.protocolVersion,
@@ -133,9 +144,13 @@ func (r *RawPeer) Read(timeout time.Duration) (wire.Message, []byte, error) {
 	}
 
 	if timeout == 0 {
-		conn.SetReadDeadline(time.Time{})
+		if err := conn.SetReadDeadline(time.Time{}); err != nil {
+			return nil, nil, err
+		}
 	} else {
-		conn.SetReadDeadline(time.Now().Add(timeout))
+		if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+			return nil, nil, err
+		}
 	}
 	// XXX contexts would be nice
 	_, msg, buf, err := wire.ReadMessageWithEncodingN(conn, r.protocolVersion,

--- a/service/tbc/peer/rawpeer/rawpeer.go
+++ b/service/tbc/peer/rawpeer/rawpeer.go
@@ -36,8 +36,7 @@ var (
 )
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/service/tbc/peermanager.go
+++ b/service/tbc/peermanager.go
@@ -361,7 +361,7 @@ func (pm *PeerManager) connect(ctx context.Context, p *rawpeer.RawPeer) error {
 	defer log.Tracef("connect exit: %v %v", p.Id(), p)
 
 	if err := p.Connect(ctx); err != nil {
-		return fmt.Errorf("new peer: %v", err)
+		return fmt.Errorf("new peer: %w", err)
 	}
 
 	pm.mtx.Lock()

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -431,7 +431,7 @@ func (s *Server) handleUtxosByAddressRawRequest(ctx context.Context, req *tbcapi
 		}, nil
 	}
 
-	var responseUtxos []api.ByteSlice
+	responseUtxos := make([]api.ByteSlice, 0, len(utxos))
 	for _, utxo := range utxos {
 		responseUtxos = append(responseUtxos, utxo[:])
 	}
@@ -459,7 +459,7 @@ func (s *Server) handleUtxosByAddressRequest(ctx context.Context, req *tbcapi.UT
 		}, nil
 	}
 
-	var responseUtxos []*tbcapi.UTXO
+	responseUtxos := make([]*tbcapi.UTXO, 0, len(utxos))
 	for _, utxo := range utxos {
 		txId, err := chainhash.NewHash(utxo.ScriptHashSlice())
 		if err != nil {

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -252,8 +252,7 @@ func (s *Server) handlePingRequest(ctx context.Context, ws *tbcWs, payload any, 
 	log.Tracef("responding with %v", spew.Sdump(res))
 
 	if err := tbcapi.Write(ctx, ws.conn, id, res); err != nil {
-		return fmt.Errorf("handlePingRequest write: %v %v",
-			ws.addr, err)
+		return fmt.Errorf("handlePingRequest write: %v %w", ws.addr, err)
 	}
 
 	// Ping request processed successfully

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1109,7 +1109,7 @@ func (s *Server) RemoveExternalHeaders(ctx context.Context, headers *wire.MsgHea
 				dbnames.MetadataDB)
 		}
 		level.BatchAppend(ctx, b.Batch, []tbcd.Row{
-			{Key: upstreamStateIdKey, Value: upstreamStateId[:]},
+			{Key: upstreamStateIdKey, Value: upstreamStateId},
 		})
 		return nil
 	}
@@ -1159,7 +1159,7 @@ func (s *Server) AddExternalHeaders(ctx context.Context, headers *wire.MsgHeader
 				dbnames.MetadataDB)
 		}
 		level.BatchAppend(ctx, b.Batch, []tbcd.Row{
-			{Key: upstreamStateIdKey, Value: upstreamStateId[:]},
+			{Key: upstreamStateIdKey, Value: upstreamStateId},
 		})
 		return nil
 	}
@@ -2012,7 +2012,7 @@ func (s *Server) UpstreamStateId(ctx context.Context) (*[32]byte, error) {
 		return nil, err
 	}
 	var x [32]byte
-	copy(x[:], usi[:])
+	copy(x[:], usi)
 	return &x, nil
 }
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -991,7 +991,6 @@ func (s *Server) syncBlocks(ctx context.Context) {
 				return
 
 			default:
-				//nolint:errorlint // The error type is being printed separately.
 				panic(fmt.Errorf("sync blocks: %T %w", err, err))
 			}
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -356,8 +356,7 @@ func (s *Server) pingPeer(ctx context.Context, p *rawpeer.RawPeer) {
 	// Cancel outstanding ping, should not happen
 	peer := p.String()
 	// No need to check error; this always races and simply is not an error.
-	// nolint:errcheck
-	s.pings.Cancel(peer)
+	_ = s.pings.Cancel(peer)
 
 	// We don't really care about the response. We just want to
 	// write to the connection to make it fail if the other side
@@ -490,8 +489,7 @@ func (s *Server) handlePeer(ctx context.Context, p *rawpeer.RawPeer) error {
 		log.Infof("Disconnected: %v blocks %v pings %v%v", p, blks, pings, re)
 
 		// Not an interesting error since it races.
-		// nolint:errcheck
-		s.pm.Bad(ctx, p.String()) // always close peer
+		_ = s.pm.Bad(ctx, p.String()) // always close peer
 	}()
 
 	// Ensure peer height is greater than ours.
@@ -1333,8 +1331,7 @@ func (s *Server) handleBlock(ctx context.Context, p *rawpeer.RawPeer, msg *wire.
 	block := btcutil.NewBlock(msg)
 	bhs := block.Hash().String()
 	// Not an error due to normal racing conditions.
-	// nolint:errcheck
-	s.blocks.Delete(bhs) // remove block from ttl regardless of insert result
+	_, _ = s.blocks.Delete(bhs) // remove block from ttl regardless of insert result
 
 	// Whatever happens, kick cache in the nuts on the way out.
 	defer func() {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -813,7 +813,7 @@ func (s *Server) downloadBlockFromRandomPeer(ctx context.Context, block *chainha
 	s.blocks.Put(ctx, defaultBlockPendingTimeout, block.String(), rp,
 		s.blockExpired, nil)
 	// Not an error. Checking and logging this will fill up logs with EOF.
-	// nolint:errcheck
+	//nolint:errcheck // Error is intentionally ignored.
 	go s.downloadBlock(ctx, rp, block)
 
 	return nil
@@ -991,7 +991,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 				return
 
 			default:
-				// nolint:errorlint
+				//nolint:errorlint // The error type is being printed separately.
 				panic(fmt.Errorf("sync blocks: %T %w", err, err))
 			}
 
@@ -1474,7 +1474,7 @@ func (s *Server) handleInv(ctx context.Context, p *rawpeer.RawPeer, msg *wire.Ms
 
 	if s.cfg.MempoolEnabled && txsFound {
 		if err := s.mempool.invTxsInsert(ctx, msg); err != nil {
-			// nolint:errcheck
+			//nolint:errcheck // Error is intentionally ignored.
 			go s.downloadMissingTx(ctx, p)
 		}
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -991,6 +991,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 				return
 
 			default:
+				// nolint:errorlint
 				panic(fmt.Errorf("sync blocks: %T %w", err, err))
 			}
 
@@ -1963,7 +1964,7 @@ func (s *Server) FeesAtHeight(ctx context.Context, height, count int64) (uint64,
 
 		// walk block tx'
 		if err = feesFromTransactions(b.Transactions()); err != nil {
-			return 0, fmt.Errorf("fees from transactions %v %v: %v",
+			return 0, fmt.Errorf("fees from transactions %v %v: %w",
 				height, b.Hash(), err)
 		}
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1599,7 +1599,7 @@ func (s *Server) RawBlockHeadersByHeight(ctx context.Context, height uint64) ([]
 		return nil, err
 	}
 
-	var headers []api.ByteSlice
+	headers := make([]api.ByteSlice, 0, len(bhs))
 	for _, bh := range bhs {
 		headers = append(headers, bh.Header[:])
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -74,8 +74,7 @@ var (
 var log = loggo.GetLogger(appName)
 
 func init() {
-	err := loggo.ConfigureLoggers(logLevel)
-	if err != nil {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
 		panic(err)
 	}
 }

--- a/web/integrationtest/integrationtest.go
+++ b/web/integrationtest/integrationtest.go
@@ -31,7 +31,10 @@ func main() {
 		if err != nil {
 			fmt.Println(err)
 		}
-		rw.Write(byteArray)
+		_, err = rw.Write(byteArray)
+		if err != nil {
+			fmt.Println(err)
+		}
 	})
 
 	if err := http.ListenAndServe(listen, nil); err != nil {

--- a/web/integrationtest/integrationtest.go
+++ b/web/integrationtest/integrationtest.go
@@ -31,8 +31,7 @@ func main() {
 		if err != nil {
 			fmt.Println(err)
 		}
-		_, err = rw.Write(byteArray)
-		if err != nil {
+		if _, err = rw.Write(byteArray); err != nil {
 			fmt.Println(err)
 		}
 	})


### PR DESCRIPTION
**Summary**
Most `golangci-lint` errors are trash but work around them so that we can enable all vs some.

**Changes**
<!-- A list of changes made by this pull request. -->
