### PR TITLE
golangci: fix copyright header linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -85,12 +85,14 @@ linters-settings:
       - "github.com/coder/websocket" # Currently uses our fork with a bug fix.
 
   # Enforces copyright header
-  goheader:
+  goheader: # TODO: Replace goheader, autofix is too buggy.
     values:
       const:
         COMPANY: "Hemi Labs, Inc."
+      regexp:
+        YEAR_RANGE: "(\\d{4}-{{MOD-YEAR}})|({{MOD-YEAR}})"
     template: |-
-      Copyright (c) {{ YEAR }} {{ COMPANY }}
+      Copyright (c) {{ YEAR_RANGE }} {{ COMPANY }}
       Use of this source code is governed by the MIT License,
       which can be found in the LICENSE file.
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ build:
 install: $(cmds)
 
 lint:
-	$(shell go env GOPATH)/bin/golangci-lint run --fix ./...
+	# TODO: re-enable autofix with --fix, after removing buggy goheader linter
+	$(shell go env GOPATH)/bin/golangci-lint run ./...
 
 lint-deps:
 	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62


### PR DESCRIPTION
**Summary**
Fix copyright header linting in golangci-lint. The previous config expected the YEAR variable to always be the current year, instead of the last modification year.

This now expects the copyright year to be either the year the file was last modified in (e.g. `2024`), or a range of years up-to the year the file was last modified in (e.g. `2024-2025`).

**Changes**
- Match copyright year against `(\\d{4}-{{MOD-YEAR}})|({{MOD-YEAR}})` (where `{{MOD-YEAR}}` is replaced with the modification year of the file) in goheader linter.
