### PR TITLE
bfgd: simpler finality calculations with new table

### DIFF
--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -46,7 +46,7 @@ type Database interface {
 
 	L2KeystoneLowestBtcBlockUpsert(ctx context.Context, l2KeystoneAbrevHash database.ByteArray) error
 
-	BackfillL2KeystonesLowestBtcBlocks(ctx context.Context) error
+	BackfillL2KeystonesLowestBtcBlocks(ctx context.Context, pageSize uint32) error
 }
 
 // NotificationName identifies a database notification type.

--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -19,7 +19,7 @@ type Database interface {
 	// L2 keystone table
 	L2KeystonesInsert(ctx context.Context, l2ks []L2Keystone) error
 	L2KeystoneByAbrevHash(ctx context.Context, aHash [32]byte) (*L2Keystone, error)
-	L2KeystonesMostRecentN(ctx context.Context, n uint32) ([]L2Keystone, error)
+	L2KeystonesMostRecentN(ctx context.Context, n uint32, page uint32) ([]L2Keystone, error)
 
 	// Btc block table
 	BtcBlockInsert(ctx context.Context, bb *BtcBlock) error
@@ -43,6 +43,10 @@ type Database interface {
 	BtcTransactionBroadcastRequestConfirmBroadcast(ctx context.Context, txId string) error
 	BtcTransactionBroadcastRequestSetLastError(ctx context.Context, txId string, lastErr string) error
 	BtcTransactionBroadcastRequestTrim(ctx context.Context) error
+
+	L2KeystoneLowestBtcBlockUpsert(ctx context.Context, l2KeystoneAbrevHash database.ByteArray) error
+
+	BackfillL2KeystonesLowestBtcBlocks(ctx context.Context) error
 }
 
 // NotificationName identifies a database notification type.
@@ -50,6 +54,7 @@ const (
 	NotificationBtcBlocks             database.NotificationName = "btc_blocks"
 	NotificationAccessPublicKeyDelete database.NotificationName = "access_public_keys"
 	NotificationL2Keystones           database.NotificationName = "l2_keystones"
+	NotificationPopBasis              database.NotificationName = "pop_basis"
 )
 
 // NotificationPayload returns the data structure corresponding to the given
@@ -65,6 +70,7 @@ var notifications = map[database.NotificationName]any{
 	NotificationBtcBlocks:             BtcBlock{},
 	NotificationAccessPublicKeyDelete: AccessPublicKey{},
 	NotificationL2Keystones:           []L2Keystone{},
+	NotificationPopBasis:              PopBasis{},
 }
 
 // we use the `deep:"-"` tag to ignore checking for these
@@ -103,7 +109,7 @@ type PopBasis struct {
 	BtcMerklePath       []string
 	PopTxId             database.ByteArray
 	PopMinerPublicKey   database.ByteArray
-	L2KeystoneAbrevHash database.ByteArray
+	L2KeystoneAbrevHash database.ByteArray `json:"l2_keystone_abrev_hash"`
 	CreatedAt           database.Timestamp `deep:"-"`
 	UpdatedAt           database.Timestamp `deep:"-"`
 }

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1565,13 +1565,13 @@ func TestBtcBlockGetCanonicalChainWithForks(t *testing.T) {
 			l2BlockNumber := uint32(1000)
 			lastHash := []byte{}
 			for i, blockCountAtHeight := range tti.chainPattern {
-				_onChainBlocks := createBtcBlocksAtStaticHeight(ctx, t, db, blockCountAtHeight, true, height, lastHash, l2BlockNumber)
+				onChainBlocksTmp := createBtcBlocksAtStaticHeight(ctx, t, db, blockCountAtHeight, true, height, lastHash, l2BlockNumber)
 				l2BlockNumber++
 				height++
-				lastHash = _onChainBlocks[0].Hash
+				lastHash = onChainBlocksTmp[0].Hash
 
 				if (blockCountAtHeight > 1 && i == len(tti.chainPattern)-1) == false {
-					onChainBlocks = append(onChainBlocks, _onChainBlocks[0])
+					onChainBlocks = append(onChainBlocks, onChainBlocksTmp[0])
 				}
 			}
 
@@ -1645,8 +1645,8 @@ func TestPublications(t *testing.T) {
 
 			lastHash := []byte{}
 			for _, height := range tti.heightPattern {
-				_onChainBlocks := createBtcBlocksAtStaticHeight(ctx, t, db, 1, true, height, lastHash, l2BlockNumber)
-				lastHash = _onChainBlocks[0].Hash
+				onChainBlocksTmp := createBtcBlocksAtStaticHeight(ctx, t, db, 1, true, height, lastHash, l2BlockNumber)
+				lastHash = onChainBlocksTmp[0].Hash
 				l2BlockNumber++
 			}
 

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1789,7 +1789,7 @@ func TestL2KeystoneLowestBtcBlockUpsert(t *testing.T) {
 
 				for i := range tti.l2KeystoneAbrevHashes {
 					if withBackfill {
-						if err := db.BackfillL2KeystonesLowestBtcBlocks(ctx); err != nil {
+						if err := db.BackfillL2KeystonesLowestBtcBlocks(ctx, 1); err != nil {
 							t.Fatal(err)
 						}
 					} else {

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -565,7 +565,8 @@ func (p *pgdb) L2KeystoneLowestBtcBlockUpsert(ctx context.Context, l2KeystoneAbr
 			(SELECT hash FROM lowest_btc_block),
 			(SELECT height FROM lowest_btc_block)
 		)
-		ON CONFLICT (l2_keystone_abrev_hash) DO UPDATE SET btc_block_hash = EXCLUDED.btc_block_hash
+		ON CONFLICT (l2_keystone_abrev_hash) DO UPDATE SET btc_block_hash = EXCLUDED.btc_block_hash 
+		WHERE l2_keystones_lowest_btc_block.btc_block_hash != EXCLUDED.btc_block_hash
 	`
 
 	_, err := p.db.ExecContext(ctx, sql, l2KeystoneAbrevHash)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -563,8 +563,8 @@ func (p *pgdb) L2KeystoneLowestBtcBlockUpsert(ctx context.Context, l2KeystoneAbr
 // BackfillL2KeystonesLowestBtcBlocks (should only) runs on startup and is
 // a quick check that all existing keystones have an associated lowest btc
 // block if it exists.  this is essential for new deploys
-func (p *pgdb) BackfillL2KeystonesLowestBtcBlocks(ctx context.Context) error {
-	limit := uint32(1)
+func (p *pgdb) BackfillL2KeystonesLowestBtcBlocks(ctx context.Context, pageSize uint32) error {
+	limit := pageSize
 	page := uint32(0)
 
 	for {

--- a/database/bfgd/scripts/0013.sql
+++ b/database/bfgd/scripts/0013.sql
@@ -1,0 +1,18 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 13;
+
+CREATE TABLE l2_keystones_lowest_btc_block (
+    l2_keystone_abrev_hash BYTEA NOT NULL PRIMARY KEY REFERENCES l2_keystones(l2_keystone_abrev_hash),
+    btc_block_hash BYTEA REFERENCES btc_blocks(hash) DEFAULT NULL,
+    btc_block_height BIGINT NULL
+);
+
+CREATE TRIGGER pop_basis_upsert AFTER INSERT OR DELETE OR UPDATE
+	ON pop_basis FOR EACH ROW EXECUTE PROCEDURE notify_event();
+
+COMMIT;

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -307,7 +307,7 @@ func (s *Server) queueCheckForInvalidBlocks() {
 func (s *Server) backfillL2KeystonesLowestBtcBlocks(ctx context.Context) {
 	defer s.wg.Done()
 
-	if err := s.db.BackfillL2KeystonesLowestBtcBlocks(ctx); err != nil {
+	if err := s.db.BackfillL2KeystonesLowestBtcBlocks(ctx, 100); err != nil {
 		log.Errorf("error backfilling lowest block per keystone: %s", err)
 	}
 }


### PR DESCRIPTION
**Summary**
simpler finality calculations with new table

**Changes**
* add table who's rows each represent the lowest published btc block that an l2_keystone is found in
* on bfg startup, backfill existing l2_keystones' lowest btc block
* use pop_basis database notifications to continue to index these l2_keyston <-> lowest btc block
* update finality queries to use this
* add tests



more context:

this pr adds a database table `l2_keystones_lowest_btc_block`, which as `l2_keystone_abrev_hash` as a primary key.  this represents, for each distinct l2 keystone, the published lowest btc block this l2 keystone was found in. this way, we no longer have to calculate this at query time.
