### PR TITLE
add wait groups to tbc fork tests

### DIFF
--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -853,9 +853,11 @@ func errorIsOneOf(err error, errs []error) bool {
 }
 
 func TestFork(t *testing.T) {
+	wg := sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		cancel()
+		wg.Wait()
 	}()
 
 	n, err := newFakeNode(t, "18444") // TODO: should use random free port
@@ -911,7 +913,10 @@ func TestFork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		log.Infof("s run")
 		defer log.Infof("s run done")
 		err := s.Run(ctx)
@@ -1104,9 +1109,11 @@ func TestWork(t *testing.T) {
 }
 
 func TestIndexNoFork(t *testing.T) {
+	wg := sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		cancel()
+		wg.Wait()
 	}()
 
 	n, err := newFakeNode(t, "18444")
@@ -1149,7 +1156,9 @@ func TestIndexNoFork(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		err := s.Run(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, rawpeer.ErrNoConn) {
 			panic(err)
@@ -1277,9 +1286,11 @@ func TestIndexNoFork(t *testing.T) {
 }
 
 func TestIndexFork(t *testing.T) {
+	wg := sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		cancel()
+		wg.Wait()
 	}()
 
 	n, err := newFakeNode(t, "18444")
@@ -1320,7 +1331,10 @@ func TestIndexFork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		err := s.Run(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, rawpeer.ErrNoConn) {
 			panic(err)


### PR DESCRIPTION


**Summary**
During tests, the test tbc server would be shut down (sometimes) after the `t.Tempdir()` was deleted.  When leveldb attempts to do something with files in that directory for the server's sake, it may show an error:
```
2025-01-06T16:47:13.1276786Z 2025-01-06 16:47:01 INFO tbc tbc.go:2310 RPC server shutdown cleanly
2025-01-06T16:47:13.1277485Z 2025-01-06 16:47:01 ERROR level level.go:85 close metadata: open /tmp/TestIndexNoFork742784104/001/localnet/metadata: no such file or directory
```

**Changes**
add wait groups to tbc fork tests to prevent `t.Tempdir()` from being deleted prior to tbc servers being torn down cleanly
