### PR TITLE
tbcd: move block header cache from items to size

### DIFF
--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -25,7 +25,7 @@ const (
 	defaultLogLevel = daemonName + "=INFO;tbc=INFO;level=INFO"
 	defaultNetwork  = "testnet3" // XXX make this mainnet
 	defaultHome     = "~/." + daemonName
-	bDefaultSize    = "2gb"   // ~1280 blocks on mainnet
+	bDefaultSize    = "1gb"   // ~640 blocks on mainnet
 	bhsDefaultSize  = "128mb" // enough for mainnet
 )
 

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -25,6 +25,7 @@ const (
 	defaultLogLevel = daemonName + "=INFO;tbc=INFO;level=INFO"
 	defaultNetwork  = "testnet3" // XXX make this mainnet
 	defaultHome     = "~/." + daemonName
+	bDefaultSize    = "2gb"   // ~1280 blocks on mainnet
 	bhsDefaultSize  = "128mb" // enough for mainnet
 )
 
@@ -46,10 +47,10 @@ var (
 			Help:         "enable auto utxo and tx indexes",
 			Print:        config.PrintAll,
 		},
-		"TBC_BLOCK_CACHE": config.Config{
-			Value:        &cfg.BlockCache,
-			DefaultValue: 250,
-			Help:         "number of cached blocks",
+		"TBC_BLOCK_CACHE_SIZE": config.Config{
+			Value:        &cfg.BlockCacheSize,
+			DefaultValue: bDefaultSize,
+			Help:         "size of block cache",
 			Print:        config.PrintAll,
 		},
 		"TBC_BLOCKHEADER_CACHE_SIZE": config.Config{

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -25,7 +25,7 @@ const (
 	defaultLogLevel = daemonName + "=INFO;tbc=INFO;level=INFO"
 	defaultNetwork  = "testnet3" // XXX make this mainnet
 	defaultHome     = "~/." + daemonName
-	bhsDefault      = int(1e6) // enough for mainnet
+	bhsDefaultSize  = "128mb" // enough for mainnet
 )
 
 var (
@@ -52,10 +52,10 @@ var (
 			Help:         "number of cached blocks",
 			Print:        config.PrintAll,
 		},
-		"TBC_BLOCKHEADER_CACHE": config.Config{
-			Value:        &cfg.BlockheaderCache,
-			DefaultValue: bhsDefault,
-			Help:         "number of cached blockheaders",
+		"TBC_BLOCKHEADER_CACHE_SIZE": config.Config{
+			Value:        &cfg.BlockheaderCacheSize,
+			DefaultValue: bhsDefaultSize,
+			Help:         "size of blockheader cache",
 			Print:        config.PrintAll,
 		},
 		"TBC_BLOCK_SANITY": config.Config{

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -103,6 +103,7 @@ type Database interface {
 	BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error)
 	// BlocksInsert(ctx context.Context, bs []*btcutil.Block) (int64, error)
 	BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error)
+	BlockCacheStats() CacheStats
 
 	// Transactions
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput) error
@@ -412,4 +413,13 @@ func TxIdBlockHashFromTxKey(txKey TxKey) (*chainhash.Hash, *chainhash.Hash, erro
 		return nil, nil, fmt.Errorf("invalid block hash: %w", err)
 	}
 	return txId, blockHash, nil
+}
+
+// Cache
+type CacheStats struct {
+	Hits   int
+	Misses int
+	Purges int
+	Size   int
+	Items  int
 }

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -91,6 +91,7 @@ type Database interface {
 	BlockHeaderBest(ctx context.Context) (*BlockHeader, error) // return canonical
 	BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*BlockHeader, error)
 	BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader, height uint64, diff *big.Int) error
+	BlockHeaderCacheStats() CacheStats
 
 	// Block headers
 	BlockHeadersByHeight(ctx context.Context, height uint64) ([]BlockHeader, error)

--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package level
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+const blockSize = 1677721 // ~1.6MB rough size of a mainnet block as of Jan 2025
+
+type lowIQLRU struct {
+	mtx sync.RWMutex
+
+	size int // this is the approximate max size
+
+	m         map[chainhash.Hash][]byte
+	totalSize int
+}
+
+func (l *lowIQLRU) Put(v *btcutil.Block) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	hash := v.Hash()
+	if _, ok := l.m[*hash]; ok {
+		return
+	}
+
+	block, err := v.Bytes()
+	if err != nil {
+		panic(err)
+		// XXX don't cache but panic for now for diagnostic
+	}
+
+	// XXX add eviction here
+	if l.totalSize+len(block) >= l.size {
+		panic("evict")
+	}
+
+	l.m[*hash] = block
+	l.totalSize += len(block)
+}
+
+func (l *lowIQLRU) Get(k *chainhash.Hash) (*btcutil.Block, bool) {
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
+
+	be, ok := l.m[*k]
+	if !ok {
+		return nil, false
+	}
+	b, err := btcutil.NewBlockFromBytes(be)
+	if err != nil {
+		panic(err) // XXX delete from cache and return nil, false but panic for diagnostics at this time
+	}
+	return b, true
+}
+
+func lowIQLRUNewSize(size int) (*lowIQLRU, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid size: %v", size)
+	}
+	// approximate number of blocks
+	count := size / blockSize
+	if count <= 0 {
+		return nil, fmt.Errorf("invalid count: %v", count)
+	}
+	return &lowIQLRU{
+		size: size,
+		m:    make(map[chainhash.Hash][]byte, count),
+	}, nil
+}

--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -61,20 +61,14 @@ func (l *lowIQLRU) Put(v *btcutil.Block) {
 		// LET THEM EAT PANIC
 		re := l.l.Front()
 		rha := l.l.Remove(re)
-		// fmt.Printf("rha %v\n", spew.Sdump(rha))
-		// fmt.Printf("==== re %T rha %T\n", re, rha)
-		rh := rha.(*list.Element).Value.(*chainhash.Hash)
+		rh := rha.(*chainhash.Hash)
 		l.totalSize -= len(l.m[*rh].block)
 		delete(l.m, *rh)
 		l.c.Purges++
 	}
 
-	// lru list
-	element := &list.Element{Value: hash}
-	l.l.PushBack(element)
-
-	// block lookup
-	l.m[*hash] = blockElement{element: element, block: block}
+	// block lookup and lru append
+	l.m[*hash] = blockElement{element: l.l.PushBack(hash), block: block}
 	l.totalSize += len(block)
 }
 

--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -23,7 +23,7 @@ type blockElement struct {
 }
 
 type lowIQLRU struct {
-	mtx sync.RWMutex
+	mtx sync.Mutex
 
 	size int // this is the approximate max size
 
@@ -71,8 +71,8 @@ func (l *lowIQLRU) Put(v *btcutil.Block) {
 }
 
 func (l *lowIQLRU) Get(k *chainhash.Hash) (*btcutil.Block, bool) {
-	l.mtx.RLock()
-	defer l.mtx.RUnlock()
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
 
 	be, ok := l.m[*k]
 	if !ok {
@@ -94,8 +94,8 @@ func (l *lowIQLRU) Get(k *chainhash.Hash) (*btcutil.Block, bool) {
 }
 
 func (l *lowIQLRU) Stats() tbcd.CacheStats {
-	l.mtx.RLock()
-	defer l.mtx.RUnlock()
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
 	l.c.Items = len(l.m)
 	return l.c
 }

--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -100,7 +100,7 @@ func (l *lowIQLRU) Stats() tbcd.CacheStats {
 	return l.c
 }
 
-func lowIQLRUNewSize(size int) (*lowIQLRU, error) {
+func lowIQLRUSizeNew(size int) (*lowIQLRU, error) {
 	if size <= 0 {
 		return nil, fmt.Errorf("invalid size: %v", size)
 	}

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -61,5 +61,25 @@ func TestLRUCache(t *testing.T) {
 		prevHash = h
 	}
 
-	t.Logf("%v", spew.Sdump(l.Stats()))
+	// verify purges are maxBlocks
+	s = l.Stats()
+	if s.Hits != 10 && s.Misses != 0 && s.Purges != 10 {
+		t.Fatal(spew.Sdump(s))
+	}
+
+	// retrieve purged blocks
+	for k := range blocks {
+		if k >= maxCache {
+			break
+		}
+		if _, ok := l.Get(&blocks[k]); ok {
+			t.Fatalf("block found: %v", blocks[k])
+		}
+	}
+
+	// verify misses are maxBlocks
+	s = l.Stats()
+	if s.Hits != 10 && s.Misses != 10 && s.Purges != 10 {
+		t.Fatal(spew.Sdump(s))
+	}
 }

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -171,16 +171,16 @@ func intHash(b int) chainhash.Hash {
 }
 
 func TestHC(t *testing.T) {
-	_, err := lowIQMapNewSize(0)
+	_, err := lowIQMapSizeNew(0)
 	if err == nil {
 		t.Fatalf("expected invalid size error for size <= 0")
 	}
-	_, err = lowIQMapNewSize(1)
+	_, err = lowIQMapSizeNew(1)
 	if err == nil {
 		t.Fatalf("expected invalid count error for count <= 0")
 	}
 	size := 1024
-	l, err := lowIQMapNewSize(size)
+	l, err := lowIQMapSizeNew(size)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -21,7 +21,7 @@ func newBlock(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *btcutil.
 func TestLRUCache(t *testing.T) {
 	maxCache := 10
 	blockSize = 81 // we'll use empty blocks
-	l, err := lowIQLRUNewSize(blockSize * maxCache)
+	l, err := lowIQLRUSizeNew(blockSize * maxCache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func newHeader(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *tbcd.Bl
 
 func TestMapCache(t *testing.T) {
 	maxCacheCount := 10
-	l, err := lowIQMapNewCount(maxCacheCount)
+	l, err := lowIQMapCountNew(maxCacheCount)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -82,4 +82,6 @@ func TestLRUCache(t *testing.T) {
 	if s.Hits != 10 && s.Misses != 10 && s.Purges != 10 {
 		t.Fatal(spew.Sdump(s))
 	}
+
+	t.Logf(spew.Sdump(s))
 }

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -1,12 +1,15 @@
 package level
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
+
+	"github.com/hemilabs/heminetwork/database/tbcd"
 )
 
 func newBlock(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *btcutil.Block) {
@@ -35,7 +38,7 @@ func TestLRUCache(t *testing.T) {
 
 	// verify stats are 0
 	s := l.Stats()
-	if s.Hits != 0 && s.Misses != 0 && s.Purges != 0 {
+	if !(s.Hits == 0 && s.Misses == 0 && s.Purges == 0) {
 		t.Fatal(spew.Sdump(s))
 	}
 
@@ -48,7 +51,7 @@ func TestLRUCache(t *testing.T) {
 
 	// verify hits are maxBlocks
 	s = l.Stats()
-	if s.Hits != 10 && s.Misses != 0 && s.Purges != 0 {
+	if !(s.Hits == 10 && s.Misses == 0 && s.Purges == 0) {
 		t.Fatal(spew.Sdump(s))
 	}
 
@@ -63,7 +66,7 @@ func TestLRUCache(t *testing.T) {
 
 	// verify purges are maxBlocks
 	s = l.Stats()
-	if s.Hits != 10 && s.Misses != 0 && s.Purges != 10 {
+	if !(s.Hits == 10 && s.Misses == 0 && s.Purges == 10) {
 		t.Fatal(spew.Sdump(s))
 	}
 
@@ -79,7 +82,84 @@ func TestLRUCache(t *testing.T) {
 
 	// verify misses are maxBlocks
 	s = l.Stats()
-	if s.Hits != 10 && s.Misses != 10 && s.Purges != 10 {
+	if !(s.Hits == 10 && s.Misses == 10 && s.Purges == 10) {
+		t.Fatal(spew.Sdump(s))
+	}
+
+	t.Logf(spew.Sdump(s))
+}
+
+func newHeader(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *tbcd.BlockHeader) {
+	bh := wire.NewBlockHeader(0, prevHash, &chainhash.Hash{}, 0, uint32(nonce))
+	return bh.BlockHash(), &tbcd.BlockHeader{
+		Hash:       bh.BlockHash(),
+		Height:     uint64(nonce),
+		Header:     h2b(bh),
+		Difficulty: big.Int{},
+	}
+}
+
+func TestMapCache(t *testing.T) {
+	maxCacheCount := 10
+	l, err := lowIQMapNewCount(maxCacheCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevHash := chainhash.Hash{} // genesis
+	headers := make([]chainhash.Hash, 0, maxCacheCount*2)
+	for i := 0; i < maxCacheCount; i++ {
+		h, bh := newHeader(&prevHash, uint32(i))
+		t.Logf("%v: %v", i, h)
+		headers = append(headers, h)
+		l.Put(bh)
+		prevHash = h
+	}
+
+	// verify stats are 0
+	s := l.Stats()
+	if !(s.Hits == 0 && s.Misses == 0 && s.Purges == 0) {
+		t.Fatal(spew.Sdump(s))
+	}
+
+	// retrieve all headers
+	for k := range headers {
+		if _, ok := l.Get(&headers[k]); !ok {
+			t.Fatalf("header not found: %v", headers[k])
+		}
+	}
+
+	// verify hits are maxBlocks
+	s = l.Stats()
+	if !(s.Hits == 10 && s.Misses == 0 && s.Purges == 0) {
+		t.Fatal(spew.Sdump(s))
+	}
+
+	// purge random cache entries
+	for i := maxCacheCount; i < maxCacheCount*2; i++ {
+		h, bh := newHeader(&prevHash, uint32(i))
+		t.Logf("%v: %v", i, h)
+		headers = append(headers, h)
+		l.Put(bh)
+		prevHash = h
+	}
+
+	// verify purges are maxBlocks
+	s = l.Stats()
+	if !(s.Hits == 10 && s.Misses == 0 && s.Purges == 10) {
+		t.Fatal(spew.Sdump(s))
+	}
+
+	// Force a random miss
+	hm, _ := newHeader(&chainhash.Hash{}, 0xdeadbeef)
+	_, ok := l.Get(&hm)
+	if ok {
+		t.Fatal("non cached header found")
+	}
+
+	// verify misses
+	s = l.Stats()
+	if !(s.Hits == 10 && s.Misses == 1 && s.Purges == 10) {
 		t.Fatal(spew.Sdump(s))
 	}
 

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -1,0 +1,65 @@
+package level
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func newBlock(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *btcutil.Block) {
+	bh := wire.NewBlockHeader(0, prevHash, &chainhash.Hash{}, 0, uint32(nonce))
+	b := wire.NewMsgBlock(bh)
+	return bh.BlockHash(), btcutil.NewBlock(b)
+}
+
+func TestLRUCache(t *testing.T) {
+	maxCache := 10
+	blockSize = 81 // we'll use empty blocks
+	l, err := lowIQLRUNewSize(blockSize * maxCache)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevHash := chainhash.Hash{} // genesis
+	blocks := make([]chainhash.Hash, 0, maxCache*2)
+	for i := 0; i < maxCache; i++ {
+		h, b := newBlock(&prevHash, uint32(i))
+		t.Logf("%v: %v", i, h)
+		blocks = append(blocks, h)
+		l.Put(b)
+		prevHash = h
+	}
+
+	// verify stats are 0
+	s := l.Stats()
+	if s.Hits != 0 && s.Misses != 0 && s.Purges != 0 {
+		t.Fatal(spew.Sdump(s))
+	}
+
+	// retrieve all blocks
+	for k := range blocks {
+		if _, ok := l.Get(&blocks[k]); !ok {
+			t.Fatalf("block not found: %v", blocks[k])
+		}
+	}
+
+	// verify hits are maxBlocks
+	s = l.Stats()
+	if s.Hits != 10 && s.Misses != 0 && s.Purges != 0 {
+		t.Fatal(spew.Sdump(s))
+	}
+
+	// purge oldest cache entries
+	for i := maxCache; i < maxCache*2; i++ {
+		h, b := newBlock(&prevHash, uint32(i))
+		t.Logf("%v: %v", i, h)
+		blocks = append(blocks, h)
+		l.Put(b)
+		prevHash = h
+	}
+
+	t.Logf("%v", spew.Sdump(l.Stats()))
+}

--- a/database/tbcd/level/headercache.go
+++ b/database/tbcd/level/headercache.go
@@ -50,9 +50,16 @@ func (l *lowIQMap) Get(k *chainhash.Hash) (*tbcd.BlockHeader, bool) {
 	return bh, ok
 }
 
+func (l *lowIQMap) Purge(k *chainhash.Hash) {
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
+
+	delete(l.m, *k)
+}
+
 func lowIQMapNewCount(count int) (*lowIQMap, error) {
 	if count <= 0 {
-		return nil, fmt.Errorf("invalid size %v", count)
+		return nil, fmt.Errorf("invalid count %v", count)
 	}
 	return &lowIQMap{
 		count: count,
@@ -69,5 +76,5 @@ func lowIQMapNewSize(size int) (*lowIQMap, error) {
 		return nil, fmt.Errorf("invalid size %v", size)
 	}
 	// approximate number of headers
-	return lowIQMapNewCount(blockHeaderSize / size)
+	return lowIQMapNewCount(size / blockHeaderSize)
 }

--- a/database/tbcd/level/headercache.go
+++ b/database/tbcd/level/headercache.go
@@ -77,7 +77,7 @@ func (l *lowIQMap) Stats() tbcd.CacheStats {
 	return l.c
 }
 
-func lowIQMapNewCount(count int) (*lowIQMap, error) {
+func lowIQMapCountNew(count int) (*lowIQMap, error) {
 	if count <= 0 {
 		return nil, fmt.Errorf("invalid count: %v", count)
 	}
@@ -91,10 +91,10 @@ func lowIQMapNewCount(count int) (*lowIQMap, error) {
 // Since it is an estimate it will overflow if Difficulty becomes bigger than
 // 64 bits. This is not an issue since 100MB caches all of mainnet in Jan 2025
 // (~819200 items).
-func lowIQMapNewSize(size int) (*lowIQMap, error) {
+func lowIQMapSizeNew(size int) (*lowIQMap, error) {
 	if size <= 0 {
 		return nil, fmt.Errorf("invalid size: %v", size)
 	}
 	// approximate number of headers
-	return lowIQMapNewCount(size / blockHeaderSize)
+	return lowIQMapCountNew(size / blockHeaderSize)
 }

--- a/database/tbcd/level/headercache.go
+++ b/database/tbcd/level/headercache.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hemilabs/heminetwork/database/tbcd"
 )
 
-const blockHeaderSize = 8 + 32 + 80 + 8
+const blockHeaderSize = 8 + 32 + 80 + 8 // rough size of tbcd.BlockHeader
 
 type lowIQMap struct {
 	mtx sync.RWMutex

--- a/database/tbcd/level/headercache.go
+++ b/database/tbcd/level/headercache.go
@@ -50,13 +50,6 @@ func (l *lowIQMap) Get(k *chainhash.Hash) (*tbcd.BlockHeader, bool) {
 	return bh, ok
 }
 
-func (l *lowIQMap) Purge(k *chainhash.Hash) {
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
-
-	delete(l.m, *k)
-}
-
 func (l *lowIQMap) PurgeBatch(ks []*chainhash.Hash) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -161,7 +161,6 @@ func New(ctx context.Context, cfg *Config) (*ldb, error) {
 	if cfg.blockheaderCacheSize > 0 {
 		l.headerCache, err = lowIQMapNewSize(cfg.blockheaderCacheSize)
 		if err != nil {
-			panic(spew.Sdump(cfg))
 			return nil, fmt.Errorf("couldn't setup block header cache: %w", err)
 		}
 		log.Infof("blockheader cache: %v",

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -161,7 +161,7 @@ func New(ctx context.Context, cfg *Config) (*ldb, error) {
 	}
 
 	if cfg.blockCacheSize > 0 {
-		l.blockCache, err = lowIQLRUNewSize(cfg.blockCacheSize)
+		l.blockCache, err = lowIQLRUSizeNew(cfg.blockCacheSize)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't setup block cache: %w", err)
 		}
@@ -170,7 +170,7 @@ func New(ctx context.Context, cfg *Config) (*ldb, error) {
 		log.Infof("block cache: DISABLED")
 	}
 	if cfg.blockheaderCacheSize > 0 {
-		l.headerCache, err = lowIQMapNewSize(cfg.blockheaderCacheSize)
+		l.headerCache, err = lowIQMapSizeNew(cfg.blockheaderCacheSize)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't setup block header cache: %w", err)
 		}

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -126,7 +126,7 @@ func NewConfig(home string) *Config {
 		panic("invalid blockheaderCacheSize")
 	}
 
-	blockCacheSizeS := "2gb" // ~512 blocks on mainnet
+	blockCacheSizeS := "1gb" // ~640 blocks on mainnet
 	blockCacheSize, err := humanize.ParseBytes(blockCacheSizeS)
 	if err != nil {
 		panic(err)
@@ -1654,4 +1654,8 @@ func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxK
 	}
 
 	return nil
+}
+
+func (l *ldb) BlockCacheStats() tbcd.CacheStats {
+	return l.blockCache.Stats()
 }

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1656,6 +1656,10 @@ func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxK
 	return nil
 }
 
+func (l *ldb) BlockHeaderCacheStats() tbcd.CacheStats {
+	return l.headerCache.Stats()
+}
+
 func (l *ldb) BlockCacheStats() tbcd.CacheStats {
 	return l.blockCache.Stats()
 }

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -161,9 +161,9 @@ func New(ctx context.Context, cfg *Config) (*ldb, error) {
 	if cfg.blockheaderCacheSize > 0 {
 		l.headerCache, err = lowIQMapNewSize(cfg.blockheaderCacheSize)
 		if err != nil {
+			panic(spew.Sdump(cfg))
 			return nil, fmt.Errorf("couldn't setup block header cache: %w", err)
 		}
-
 		log.Infof("blockheader cache: %v",
 			humanize.Bytes(uint64(cfg.blockheaderCacheSize)))
 	} else {
@@ -845,6 +845,10 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 		bhash := headersParsed[i].BlockHash()
 		fh := fullHeadersFromDb[i]
 		bhsBatch.Delete(bhash[:])
+		// Make batch
+		if l.cfg.blockheaderCacheSize > 0 {
+			l.headerCache.Purge(&bhash)
+		}
 
 		// Delete height mapping for header i
 		hhKey := heightHashToKey(fh.Height, bhash[:])

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/go-test/deep v1.1.1
-	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/juju/loggo v1.0.0
 	github.com/lib/pq v1.10.9
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,6 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
-github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
-github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hemilabs/websocket v0.0.0-20240813101919-bf33653e9aa5 h1:rNJaauce7ZAC5tv7NaiwDtF6afSVeTvWejhFuK5gY6I=
 github.com/hemilabs/websocket v0.0.0-20240813101919-bf33653e9aa5/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/holiman/uint256 v1.3.1 h1:JfTzmih28bittyHM8z360dCjIA9dbPIBlcTI6lmctQs=

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -717,7 +717,6 @@ func (s *Server) promPoll(ctx context.Context) error {
 		//	s.prom.mempoolCount, s.prom.mempoolSize = s.mempool.stats(ctx)
 		//}
 
-		s.promPollVerbose = true
 		if s.promPollVerbose {
 			s.mtx.RLock()
 			log.Infof("Pending blocks %v/%v connected peers %v "+

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -174,13 +174,6 @@ func NewServer(cfg *Config) (*Server, error) {
 	if cfg == nil {
 		cfg = NewDefaultConfig()
 	}
-	if cfg.BlockheaderCacheSize != "" {
-		var err error
-		cfg.blockheaderCacheSize, err = humanize.ParseBytes(cfg.BlockheaderCacheSize)
-		if err != nil {
-			return nil, fmt.Errorf("invalid blockheader cache size: %w", err)
-		}
-	}
 
 	if cfg.MempoolEnabled {
 		log.Infof("mempool forced disabled")

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -81,7 +81,7 @@ func init() {
 
 type Config struct {
 	AutoIndex               bool
-	BlockCache              int
+	BlockCacheSize          string
 	BlockheaderCacheSize    string
 	BlockSanity             bool
 	LevelDBHome             string
@@ -108,7 +108,7 @@ type Config struct {
 func NewDefaultConfig() *Config {
 	return &Config{
 		ListenAddress:        tbcapi.DefaultListen,
-		BlockCache:           250,
+		BlockCacheSize:       "2gb",
 		BlockheaderCacheSize: "128mb",
 		LogLevel:             logLevel,
 		MaxCachedTxs:         defaultMaxCachedTxs,
@@ -2142,7 +2142,7 @@ func (s *Server) DBOpen(ctx context.Context) error {
 	// Open db.
 	var err error
 	cfg := level.NewConfig(filepath.Join(s.cfg.LevelDBHome, s.cfg.Network))
-	cfg.BlockCache = s.cfg.BlockCache
+	cfg.BlockCacheSize = s.cfg.BlockCacheSize
 	cfg.BlockheaderCacheSize = s.cfg.BlockheaderCacheSize
 	s.db, err = level.New(ctx, cfg)
 	if err != nil {

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1054,7 +1054,7 @@ func createTbcServerExternalHeaderMode(ctx context.Context, t *testing.T) *Serve
 	cfg.ExternalHeaderMode = true
 	cfg.Network = networkLocalnet
 	cfg.BlockCache = 0
-	cfg.BlockheaderCache = 0
+	cfg.BlockheaderCacheSize = "1mb"
 	cfg.MempoolEnabled = false
 
 	tbcServer, err := NewServer(cfg)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1054,7 +1054,7 @@ func createTbcServerExternalHeaderMode(ctx context.Context, t *testing.T) *Serve
 	cfg.ExternalHeaderMode = true
 	cfg.Network = networkLocalnet
 	cfg.BlockCache = 0
-	cfg.BlockheaderCacheSize = "1mb"
+	cfg.BlockheaderCacheSize = ""
 	cfg.MempoolEnabled = false
 
 	tbcServer, err := NewServer(cfg)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1053,7 +1053,7 @@ func createTbcServerExternalHeaderMode(ctx context.Context, t *testing.T) *Serve
 	cfg.LevelDBHome = home
 	cfg.ExternalHeaderMode = true
 	cfg.Network = networkLocalnet
-	cfg.BlockCache = 0
+	cfg.BlockCacheSize = ""
 	cfg.BlockheaderCacheSize = ""
 	cfg.MempoolEnabled = false
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -894,7 +894,7 @@ func TestFork(t *testing.T) {
 	// Connect tbc service
 	cfg := &Config{
 		AutoIndex:            false,
-		BlockCache:           1000,
+		BlockCacheSize:       "10mb",
 		BlockheaderCacheSize: "1mb",
 		BlockSanity:          false,
 		LevelDBHome:          t.TempDir(),
@@ -1131,7 +1131,7 @@ func TestIndexNoFork(t *testing.T) {
 	// Connect tbc service
 	cfg := &Config{
 		AutoIndex:            false,
-		BlockCache:           1000,
+		BlockCacheSize:       "10mb",
 		BlockheaderCacheSize: "1mb",
 		BlockSanity:          false,
 		LevelDBHome:          t.TempDir(),
@@ -1302,7 +1302,7 @@ func TestIndexFork(t *testing.T) {
 	// Connect tbc service
 	cfg := &Config{
 		AutoIndex:            false,
-		BlockCache:           1000,
+		BlockCacheSize:       "10mb",
 		BlockheaderCacheSize: "1mb",
 		BlockSanity:          false,
 		LevelDBHome:          t.TempDir(),

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -893,11 +893,11 @@ func TestFork(t *testing.T) {
 
 	// Connect tbc service
 	cfg := &Config{
-		AutoIndex:        false,
-		BlockCache:       1000,
-		BlockheaderCache: 1000,
-		BlockSanity:      false,
-		LevelDBHome:      t.TempDir(),
+		AutoIndex:            false,
+		BlockCache:           1000,
+		BlockheaderCacheSize: "1mb",
+		BlockSanity:          false,
+		LevelDBHome:          t.TempDir(),
 		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 		MaxCachedTxs:            1000, // XXX
 		Network:                 networkLocalnet,
@@ -1130,12 +1130,12 @@ func TestIndexNoFork(t *testing.T) {
 
 	// Connect tbc service
 	cfg := &Config{
-		AutoIndex:        false,
-		BlockCache:       1000,
-		BlockheaderCache: 1000,
-		BlockSanity:      false,
-		LevelDBHome:      t.TempDir(),
-		ListenAddress:    "localhost:8882",
+		AutoIndex:            false,
+		BlockCache:           1000,
+		BlockheaderCacheSize: "1mb",
+		BlockSanity:          false,
+		LevelDBHome:          t.TempDir(),
+		ListenAddress:        "localhost:8882",
 		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 		MaxCachedTxs:            1000, // XXX
 		Network:                 networkLocalnet,
@@ -1301,12 +1301,12 @@ func TestIndexFork(t *testing.T) {
 
 	// Connect tbc service
 	cfg := &Config{
-		AutoIndex:        false,
-		BlockCache:       1000,
-		BlockheaderCache: 1000,
-		BlockSanity:      false,
-		LevelDBHome:      t.TempDir(),
-		ListenAddress:    "localhost:8883",
+		AutoIndex:            false,
+		BlockCache:           1000,
+		BlockheaderCacheSize: "1mb",
+		BlockSanity:          false,
+		LevelDBHome:          t.TempDir(),
+		ListenAddress:        "localhost:8883",
 		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 		MaxCachedTxs:            1000, // XXX
 		Network:                 networkLocalnet,


### PR DESCRIPTION
**Summary**
We really should use size as the metric to determine cache size. This flips that for blockheaders.

**Changes**
This fixes a major bug in headers only mode where headers were not purged from the cache. This may have caused problems we had not diagnosed.
