### PR TITLE
fix definition of materialized view; don't resort to height fallback if we can connect header[5,32]->hash

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	bfgdVersion = 14
+	bfgdVersion = 15
 
 	logLevel = "INFO"
 	verbose  = false

--- a/database/bfgd/scripts/0015.sql
+++ b/database/bfgd/scripts/0015.sql
@@ -1,0 +1,61 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 15;
+
+-- this sql file updates the materialized view that represents the 
+-- canonical chain in BFG.  we redefine the materialized view, but the change is very
+-- small, I will leave a comment
+
+DROP MATERIALIZED VIEW btc_blocks_can;
+
+CREATE MATERIALIZED VIEW btc_blocks_can AS 
+
+WITH RECURSIVE bb AS (
+			SELECT hash, header, height FROM btc_blocks
+			WHERE height = (
+				SELECT MAX(height) as height
+				FROM __highest
+				WHERE c = 1
+			)
+		
+			UNION 
+		
+			SELECT 
+				btc_blocks.hash, 
+				btc_blocks.header,
+				btc_blocks.height
+			FROM btc_blocks, bb
+			WHERE 
+
+			(
+				substr(bb.header, 5, 32) = btc_blocks.hash 
+				AND bb.height > btc_blocks.height
+			)
+			OR
+
+			(
+				btc_blocks.hash = (
+				SELECT hash FROM btc_blocks 
+				WHERE height < bb.height ORDER BY height DESC LIMIT 1)
+
+                -- this is the change; ensure that we can't connect a block
+                -- before resorting to the fallback.  this ensures that 
+                -- BOTH results don't get included in the canonical chain
+				AND NOT EXISTS (
+					SELECT * FROM btc_blocks WHERE
+					substr(bb.header, 5, 32) = btc_blocks.hash 
+					AND bb.height > btc_blocks.height
+				)
+			)
+		), __highest AS (
+			SELECT height, count(*) AS c
+			FROM btc_blocks
+			GROUP BY height
+		)
+SELECT * FROM bb;
+
+COMMIT;


### PR DESCRIPTION
fix definition of materialized view that was hidden by a missing test case, ensure that fallback of "height" in canonical chain does not also include the header -> hash relationship

**Summary**
When we were first developing BFG, since we were communicating with electrumx, and we relied on electrumx for defining the "best chain", we defined the tip as:
> The highest block that we received from electrumx that has no siblings

This was susceptible to re-orgs and that needed to be taken into account.

So we defined the canonical chain as so:
* try to connect blocks by `header[5,32] -> prevBlock.hash`
* if we could not find a link from the above, then go by next highest
* when we receive new blocks, check for "orphaned" blocks and fetch the current block at that height (according to electrumx)

while going by height is incorrect, the bulletpoint that does so only really does near the tip where re-orgs are frequent.  and each new block we check for orphaned ones to fix the disconnect

In implementing the above, there was a bug in the SQL that ran the "fallback" (second bullet point), this ran as an `OR` statement, so if you had a block connected by `header[5,32] -> prevBlock.hash` OR "next highest", then you would get _both blocks_ in the canonical chain

for example:
```sql
-[ RECORD 1 ]--------------------------------------------------------------------------------------------------------------------------------------------------------------
hash   | \xb31e858def1e4dede3ecc8af5c37073a3626adc952334c666786290400000000
header | \x000000205b1ba4171494df8e5dbaff58f36529a811af0957786f62b7fb554dd300000000ae27c355094eed894f4f23f5a3fd67b779c89583e3cebe0b9ed427b7c5b206adea598567ffff001d9264e2b4
height | 3613238
-[ RECORD 2 ]--------------------------------------------------------------------------------------------------------------------------------------------------------------
hash   | \x5b1ba4171494df8e5dbaff58f36529a811af0957786f62b7fb554dd300000000
header | \x000000203497956f863b582c6a52a3624ac04d81c251db5c04481592da08b180000000008cdf7aa0686f55f1189eec51d2d0049344b8590e2e0410638513f44e9757eb7839558567ffff001d347fddaa
height | 3613237
-[ RECORD 3 ]--------------------------------------------------------------------------------------------------------------------------------------------------------------
hash   | \xfcb788fd53f75079fb43091a2da1460d3f4656dc1cf3d5a46a88131600000000
header | \x00000020f78b8929ca8868f15b9fe19c963f3cf4b6442596d30acf75b46b8adc00000000d65644558533460b95fe8d282ffd0627e037edad95200e85e47af4ddea0ef7e388508567ffff001d90d20e1b
height | 3613236
-[ RECORD 4 ]--------------------------------------------------------------------------------------------------------------------------------------------------------------
hash   | \x3497956f863b582c6a52a3624ac04d81c251db5c04481592da08b18000000000
header | \x00000020f78b8929ca8868f15b9fe19c963f3cf4b6442596d30acf75b46b8adc00000000197407a6e3268f25a702fdf558af0ece068feb4ddfd6e7ddf2a6b5dcb773960388508567ffff001db01db6c5
height | 3613236
```

Note that there are two blocks at `3613236` but there should be one, the correct one is `\x3497956f863b582c6a52a3624ac04d81c251db5c04481592da08b18000000000` but the "fallback" was hit in the `OR` statement so they were both included


**Changes**
Redefine the `MATERIALIZED VIEW` so that the fallback _only occurs_ when there the correct `header[5,32] -> hash` does not find a result.  

Add a test that tests this scenario and fails without the fix.

fixes #371 
