### PR TITLE
better error handling + sql update

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	bfgdVersion = 15
+	bfgdVersion = 16
 
 	logLevel = "INFO"
 	verbose  = false

--- a/database/bfgd/scripts/0015.sql
+++ b/database/bfgd/scripts/0015.sql
@@ -21,6 +21,6 @@ ALTER TABLE btc_blocks ADD UNIQUE (height);
 -- when a btc block becomes "invalid" (orphaned), delete it and all pop_bases 
 -- that referenced it
 ALTER TABLE pop_basis DROP CONSTRAINT pop_basis_btc_block_hash_fkey;
-ALTER TABLE pop_basis ADD CONSTRAINT pop_basis_btc_block_hash_fkey FOREIGN KEY (btc_block_hash) REFERENCES btc_blocks (hash) ON UPDATE CASCADE;
+ALTER TABLE pop_basis ADD CONSTRAINT pop_basis_btc_block_hash_fkey FOREIGN KEY (btc_block_hash) REFERENCES btc_blocks (hash) ON DELETE CASCADE;
 
 COMMIT;

--- a/database/bfgd/scripts/0015.sql
+++ b/database/bfgd/scripts/0015.sql
@@ -21,6 +21,6 @@ ALTER TABLE btc_blocks ADD UNIQUE (height);
 -- when a btc block becomes "invalid" (orphaned), delete it and all pop_bases 
 -- that referenced it
 ALTER TABLE pop_basis DROP CONSTRAINT pop_basis_btc_block_hash_fkey;
-ALTER TABLE pop_basis ADD CONSTRAINT pop_basis_btc_block_hash_fkey FOREIGN KEY (btc_block_hash) REFERENCES btc_blocks (hash) ON DELETE CASCADE;
+ALTER TABLE pop_basis ADD CONSTRAINT pop_basis_btc_block_hash_fkey FOREIGN KEY (btc_block_hash) REFERENCES btc_blocks (hash) ON UPDATE CASCADE;
 
 COMMIT;

--- a/database/bfgd/scripts/0016.sql
+++ b/database/bfgd/scripts/0016.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 16;
+
+ALTER TABLE pop_basis DROP CONSTRAINT pop_basis_btc_block_hash_fkey;
+
+-- upon a re-org, set all references to deleted btc block to NULL, then delete those rows via a trigger
+
+ALTER TABLE pop_basis ADD CONSTRAINT pop_basis_btc_block_hash_fkey FOREIGN KEY (btc_block_hash) REFERENCES btc_blocks (hash) ON UPDATE SET NULL;
+
+CREATE FUNCTION clean_pop_basis() RETURNS TRIGGER AS $clean_pop_basis$
+    BEGIN
+        DELETE FROM pop_basis WHERE btc_block_hash IS NULL;
+        RETURN NULL;
+    END;
+$clean_pop_basis$ LANGUAGE plpgsql;
+
+CREATE TRIGGER btc_blocks_clean AFTER INSERT OR UPDATE OR DELETE 
+	ON btc_blocks EXECUTE FUNCTION clean_pop_basis();
+
+COMMIT;

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -678,7 +678,8 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 
 		publicKeyUncompressed, err := pop.ParsePublicKeyFromSignatureScript(mtx.TxIn[0].SignatureScript)
 		if err != nil {
-			return fmt.Errorf("could not parse signature script: %w", err)
+			log.Errorf("could not parse signature script: %w", err)
+			continue
 		}
 
 		popTxIdFull := []byte{}


### PR DESCRIPTION
**Summary**
Found two bugs: 
if we stop iterating through txs due to a parse error, we can't finish the block.  don't stop parsing a block for an error like this
```
could not parse signature script: not a signature , found: 0x46
```

need to change `ON DELETE` to `ON UPDATE` and delete invalid `pop_basis`

**Changes**
* do not stop parsing a btc block if encountering a parse error, we may have a parse error partially down the block but we shouldn't halt parsing the rest of the txs for that

* sql update; delete invalid pop basis upon re-org
