### PR TITLE
tbcd, bfgd: add various hemi specific indexes

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hemilabs/heminetwork/api"
 	"github.com/hemilabs/heminetwork/api/protocol"
+	"github.com/hemilabs/heminetwork/hemi"
 )
 
 // XXX we should kill the wrapping types that are basically identical to wire.
@@ -76,6 +77,9 @@ const (
 
 	CmdBlockDownloadAsyncRawRequest  = "tbcapi-block-download-async-raw-request"
 	CmdBlockDownloadAsyncRawResponse = "tbcapi-block-download-async-raw-response"
+
+	CmdL2KeystoneAbrevByAbrevHashRequest  = "tbcapi-l2-keystone-abrev-by-abrev-hash-request"
+	CmdL2KeystoneAbrevByAbrevHashResponse = "tbcapi-l2-keystone-abrev-by-abrev-hash-response"
 )
 
 var (
@@ -284,6 +288,15 @@ type BlockInsertRawRequest struct {
 	Block api.ByteSlice `json:"block"`
 }
 
+type L2KeystoneAbrevByAbrevHashRequest struct {
+	L2KeystoneAbrevHash api.ByteSlice `json:"l2_keystones_abrev_hash"`
+}
+
+type L2KeystoneAbrevByAbrevHashResponse struct {
+	L2KeystoneAbrev *hemi.L2KeystoneAbrev `json:"l2_keystone_abrev"`
+	Error           *protocol.Error       `json:"error,omitempty"`
+}
+
 type BlockInsertRawResponse struct {
 	BlockHash *chainhash.Hash `json:"block_hash"`
 	Error     *protocol.Error `json:"error,omitempty"`
@@ -315,42 +328,44 @@ type BlockDownloadAsyncRawResponse struct {
 }
 
 var commands = map[protocol.Command]reflect.Type{
-	CmdPingRequest:                     reflect.TypeOf(PingRequest{}),
-	CmdPingResponse:                    reflect.TypeOf(PingResponse{}),
-	CmdBlockByHashRequest:              reflect.TypeOf(BlockByHashRequest{}),
-	CmdBlockByHashResponse:             reflect.TypeOf(BlockByHashResponse{}),
-	CmdBlockByHashRawRequest:           reflect.TypeOf(BlockByHashRawRequest{}),
-	CmdBlockByHashRawResponse:          reflect.TypeOf(BlockByHashRawResponse{}),
-	CmdBlockHeadersByHeightRawRequest:  reflect.TypeOf(BlockHeadersByHeightRawRequest{}),
-	CmdBlockHeadersByHeightRawResponse: reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
-	CmdBlockHeadersByHeightRequest:     reflect.TypeOf(BlockHeadersByHeightRequest{}),
-	CmdBlockHeadersByHeightResponse:    reflect.TypeOf(BlockHeadersByHeightResponse{}),
-	CmdBlockHeaderBestRawRequest:       reflect.TypeOf(BlockHeaderBestRawRequest{}),
-	CmdBlockHeaderBestRawResponse:      reflect.TypeOf(BlockHeaderBestRawResponse{}),
-	CmdBlockHeaderBestRequest:          reflect.TypeOf(BlockHeaderBestRequest{}),
-	CmdBlockHeaderBestResponse:         reflect.TypeOf(BlockHeaderBestResponse{}),
-	CmdBalanceByAddressRequest:         reflect.TypeOf(BalanceByAddressRequest{}),
-	CmdBalanceByAddressResponse:        reflect.TypeOf(BalanceByAddressResponse{}),
-	CmdUTXOsByAddressRawRequest:        reflect.TypeOf(UTXOsByAddressRawRequest{}),
-	CmdUTXOsByAddressRawResponse:       reflect.TypeOf(UTXOsByAddressRawResponse{}),
-	CmdUTXOsByAddressRequest:           reflect.TypeOf(UTXOsByAddressRequest{}),
-	CmdUTXOsByAddressResponse:          reflect.TypeOf(UTXOsByAddressResponse{}),
-	CmdTxByIdRawRequest:                reflect.TypeOf(TxByIdRawRequest{}),
-	CmdTxByIdRawResponse:               reflect.TypeOf(TxByIdRawResponse{}),
-	CmdTxByIdRequest:                   reflect.TypeOf(TxByIdRequest{}),
-	CmdTxByIdResponse:                  reflect.TypeOf(TxByIdResponse{}),
-	CmdTxBroadcastRequest:              reflect.TypeOf(TxBroadcastRequest{}),
-	CmdTxBroadcastResponse:             reflect.TypeOf(TxBroadcastResponse{}),
-	CmdTxBroadcastRawRequest:           reflect.TypeOf(TxBroadcastRawRequest{}),
-	CmdTxBroadcastRawResponse:          reflect.TypeOf(TxBroadcastRawResponse{}),
-	CmdBlockInsertRequest:              reflect.TypeOf(BlockInsertRequest{}),
-	CmdBlockInsertResponse:             reflect.TypeOf(BlockInsertResponse{}),
-	CmdBlockInsertRawRequest:           reflect.TypeOf(BlockInsertRawRequest{}),
-	CmdBlockInsertRawResponse:          reflect.TypeOf(BlockInsertRawResponse{}),
-	CmdBlockDownloadAsyncRequest:       reflect.TypeOf(BlockDownloadAsyncRequest{}),
-	CmdBlockDownloadAsyncResponse:      reflect.TypeOf(BlockDownloadAsyncResponse{}),
-	CmdBlockDownloadAsyncRawRequest:    reflect.TypeOf(BlockDownloadAsyncRawRequest{}),
-	CmdBlockDownloadAsyncRawResponse:   reflect.TypeOf(BlockDownloadAsyncRawResponse{}),
+	CmdPingRequest:                        reflect.TypeOf(PingRequest{}),
+	CmdPingResponse:                       reflect.TypeOf(PingResponse{}),
+	CmdBlockByHashRequest:                 reflect.TypeOf(BlockByHashRequest{}),
+	CmdBlockByHashResponse:                reflect.TypeOf(BlockByHashResponse{}),
+	CmdBlockByHashRawRequest:              reflect.TypeOf(BlockByHashRawRequest{}),
+	CmdBlockByHashRawResponse:             reflect.TypeOf(BlockByHashRawResponse{}),
+	CmdBlockHeadersByHeightRawRequest:     reflect.TypeOf(BlockHeadersByHeightRawRequest{}),
+	CmdBlockHeadersByHeightRawResponse:    reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
+	CmdBlockHeadersByHeightRequest:        reflect.TypeOf(BlockHeadersByHeightRequest{}),
+	CmdBlockHeadersByHeightResponse:       reflect.TypeOf(BlockHeadersByHeightResponse{}),
+	CmdBlockHeaderBestRawRequest:          reflect.TypeOf(BlockHeaderBestRawRequest{}),
+	CmdBlockHeaderBestRawResponse:         reflect.TypeOf(BlockHeaderBestRawResponse{}),
+	CmdBlockHeaderBestRequest:             reflect.TypeOf(BlockHeaderBestRequest{}),
+	CmdBlockHeaderBestResponse:            reflect.TypeOf(BlockHeaderBestResponse{}),
+	CmdBalanceByAddressRequest:            reflect.TypeOf(BalanceByAddressRequest{}),
+	CmdBalanceByAddressResponse:           reflect.TypeOf(BalanceByAddressResponse{}),
+	CmdUTXOsByAddressRawRequest:           reflect.TypeOf(UTXOsByAddressRawRequest{}),
+	CmdUTXOsByAddressRawResponse:          reflect.TypeOf(UTXOsByAddressRawResponse{}),
+	CmdUTXOsByAddressRequest:              reflect.TypeOf(UTXOsByAddressRequest{}),
+	CmdUTXOsByAddressResponse:             reflect.TypeOf(UTXOsByAddressResponse{}),
+	CmdTxByIdRawRequest:                   reflect.TypeOf(TxByIdRawRequest{}),
+	CmdTxByIdRawResponse:                  reflect.TypeOf(TxByIdRawResponse{}),
+	CmdTxByIdRequest:                      reflect.TypeOf(TxByIdRequest{}),
+	CmdTxByIdResponse:                     reflect.TypeOf(TxByIdResponse{}),
+	CmdTxBroadcastRequest:                 reflect.TypeOf(TxBroadcastRequest{}),
+	CmdTxBroadcastResponse:                reflect.TypeOf(TxBroadcastResponse{}),
+	CmdTxBroadcastRawRequest:              reflect.TypeOf(TxBroadcastRawRequest{}),
+	CmdTxBroadcastRawResponse:             reflect.TypeOf(TxBroadcastRawResponse{}),
+	CmdBlockInsertRequest:                 reflect.TypeOf(BlockInsertRequest{}),
+	CmdBlockInsertResponse:                reflect.TypeOf(BlockInsertResponse{}),
+	CmdBlockInsertRawRequest:              reflect.TypeOf(BlockInsertRawRequest{}),
+	CmdBlockInsertRawResponse:             reflect.TypeOf(BlockInsertRawResponse{}),
+	CmdBlockDownloadAsyncRequest:          reflect.TypeOf(BlockDownloadAsyncRequest{}),
+	CmdBlockDownloadAsyncResponse:         reflect.TypeOf(BlockDownloadAsyncResponse{}),
+	CmdBlockDownloadAsyncRawRequest:       reflect.TypeOf(BlockDownloadAsyncRawRequest{}),
+	CmdBlockDownloadAsyncRawResponse:      reflect.TypeOf(BlockDownloadAsyncRawResponse{}),
+	CmdL2KeystoneAbrevByAbrevHashRequest:  reflect.TypeOf(L2KeystoneAbrevByAbrevHashRequest{}),
+	CmdL2KeystoneAbrevByAbrevHashResponse: reflect.TypeOf(L2KeystoneAbrevByAbrevHashResponse{}),
 }
 
 type tbcAPI struct{}

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -78,8 +78,8 @@ const (
 	CmdBlockDownloadAsyncRawRequest  = "tbcapi-block-download-async-raw-request"
 	CmdBlockDownloadAsyncRawResponse = "tbcapi-block-download-async-raw-response"
 
-	CmdL2KeystoneAbrevByAbrevHashRequest  = "tbcapi-l2-keystone-abrev-by-abrev-hash-request"
-	CmdL2KeystoneAbrevByAbrevHashResponse = "tbcapi-l2-keystone-abrev-by-abrev-hash-response"
+	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashRequest  = "tbcapi-l2-keystone-abrev-by-abrev-hash-request"
+	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashResponse = "tbcapi-l2-keystone-abrev-by-abrev-hash-response"
 )
 
 var (
@@ -288,11 +288,11 @@ type BlockInsertRawRequest struct {
 	Block api.ByteSlice `json:"block"`
 }
 
-type L2KeystoneAbrevByAbrevHashRequest struct {
+type BlockKeystoneAbrevByL2KeystoneAbrevHashRequest struct {
 	L2KeystoneAbrevHash api.ByteSlice `json:"l2_keystones_abrev_hash"`
 }
 
-type L2KeystoneAbrevByAbrevHashResponse struct {
+type BlockKeystoneAbrevByL2KeystoneAbrevHashResponse struct {
 	L2KeystoneAbrev *hemi.L2KeystoneAbrev `json:"l2_keystone_abrev"`
 	Error           *protocol.Error       `json:"error,omitempty"`
 }
@@ -328,44 +328,44 @@ type BlockDownloadAsyncRawResponse struct {
 }
 
 var commands = map[protocol.Command]reflect.Type{
-	CmdPingRequest:                        reflect.TypeOf(PingRequest{}),
-	CmdPingResponse:                       reflect.TypeOf(PingResponse{}),
-	CmdBlockByHashRequest:                 reflect.TypeOf(BlockByHashRequest{}),
-	CmdBlockByHashResponse:                reflect.TypeOf(BlockByHashResponse{}),
-	CmdBlockByHashRawRequest:              reflect.TypeOf(BlockByHashRawRequest{}),
-	CmdBlockByHashRawResponse:             reflect.TypeOf(BlockByHashRawResponse{}),
-	CmdBlockHeadersByHeightRawRequest:     reflect.TypeOf(BlockHeadersByHeightRawRequest{}),
-	CmdBlockHeadersByHeightRawResponse:    reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
-	CmdBlockHeadersByHeightRequest:        reflect.TypeOf(BlockHeadersByHeightRequest{}),
-	CmdBlockHeadersByHeightResponse:       reflect.TypeOf(BlockHeadersByHeightResponse{}),
-	CmdBlockHeaderBestRawRequest:          reflect.TypeOf(BlockHeaderBestRawRequest{}),
-	CmdBlockHeaderBestRawResponse:         reflect.TypeOf(BlockHeaderBestRawResponse{}),
-	CmdBlockHeaderBestRequest:             reflect.TypeOf(BlockHeaderBestRequest{}),
-	CmdBlockHeaderBestResponse:            reflect.TypeOf(BlockHeaderBestResponse{}),
-	CmdBalanceByAddressRequest:            reflect.TypeOf(BalanceByAddressRequest{}),
-	CmdBalanceByAddressResponse:           reflect.TypeOf(BalanceByAddressResponse{}),
-	CmdUTXOsByAddressRawRequest:           reflect.TypeOf(UTXOsByAddressRawRequest{}),
-	CmdUTXOsByAddressRawResponse:          reflect.TypeOf(UTXOsByAddressRawResponse{}),
-	CmdUTXOsByAddressRequest:              reflect.TypeOf(UTXOsByAddressRequest{}),
-	CmdUTXOsByAddressResponse:             reflect.TypeOf(UTXOsByAddressResponse{}),
-	CmdTxByIdRawRequest:                   reflect.TypeOf(TxByIdRawRequest{}),
-	CmdTxByIdRawResponse:                  reflect.TypeOf(TxByIdRawResponse{}),
-	CmdTxByIdRequest:                      reflect.TypeOf(TxByIdRequest{}),
-	CmdTxByIdResponse:                     reflect.TypeOf(TxByIdResponse{}),
-	CmdTxBroadcastRequest:                 reflect.TypeOf(TxBroadcastRequest{}),
-	CmdTxBroadcastResponse:                reflect.TypeOf(TxBroadcastResponse{}),
-	CmdTxBroadcastRawRequest:              reflect.TypeOf(TxBroadcastRawRequest{}),
-	CmdTxBroadcastRawResponse:             reflect.TypeOf(TxBroadcastRawResponse{}),
-	CmdBlockInsertRequest:                 reflect.TypeOf(BlockInsertRequest{}),
-	CmdBlockInsertResponse:                reflect.TypeOf(BlockInsertResponse{}),
-	CmdBlockInsertRawRequest:              reflect.TypeOf(BlockInsertRawRequest{}),
-	CmdBlockInsertRawResponse:             reflect.TypeOf(BlockInsertRawResponse{}),
-	CmdBlockDownloadAsyncRequest:          reflect.TypeOf(BlockDownloadAsyncRequest{}),
-	CmdBlockDownloadAsyncResponse:         reflect.TypeOf(BlockDownloadAsyncResponse{}),
-	CmdBlockDownloadAsyncRawRequest:       reflect.TypeOf(BlockDownloadAsyncRawRequest{}),
-	CmdBlockDownloadAsyncRawResponse:      reflect.TypeOf(BlockDownloadAsyncRawResponse{}),
-	CmdL2KeystoneAbrevByAbrevHashRequest:  reflect.TypeOf(L2KeystoneAbrevByAbrevHashRequest{}),
-	CmdL2KeystoneAbrevByAbrevHashResponse: reflect.TypeOf(L2KeystoneAbrevByAbrevHashResponse{}),
+	CmdPingRequest:                                     reflect.TypeOf(PingRequest{}),
+	CmdPingResponse:                                    reflect.TypeOf(PingResponse{}),
+	CmdBlockByHashRequest:                              reflect.TypeOf(BlockByHashRequest{}),
+	CmdBlockByHashResponse:                             reflect.TypeOf(BlockByHashResponse{}),
+	CmdBlockByHashRawRequest:                           reflect.TypeOf(BlockByHashRawRequest{}),
+	CmdBlockByHashRawResponse:                          reflect.TypeOf(BlockByHashRawResponse{}),
+	CmdBlockHeadersByHeightRawRequest:                  reflect.TypeOf(BlockHeadersByHeightRawRequest{}),
+	CmdBlockHeadersByHeightRawResponse:                 reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
+	CmdBlockHeadersByHeightRequest:                     reflect.TypeOf(BlockHeadersByHeightRequest{}),
+	CmdBlockHeadersByHeightResponse:                    reflect.TypeOf(BlockHeadersByHeightResponse{}),
+	CmdBlockHeaderBestRawRequest:                       reflect.TypeOf(BlockHeaderBestRawRequest{}),
+	CmdBlockHeaderBestRawResponse:                      reflect.TypeOf(BlockHeaderBestRawResponse{}),
+	CmdBlockHeaderBestRequest:                          reflect.TypeOf(BlockHeaderBestRequest{}),
+	CmdBlockHeaderBestResponse:                         reflect.TypeOf(BlockHeaderBestResponse{}),
+	CmdBalanceByAddressRequest:                         reflect.TypeOf(BalanceByAddressRequest{}),
+	CmdBalanceByAddressResponse:                        reflect.TypeOf(BalanceByAddressResponse{}),
+	CmdUTXOsByAddressRawRequest:                        reflect.TypeOf(UTXOsByAddressRawRequest{}),
+	CmdUTXOsByAddressRawResponse:                       reflect.TypeOf(UTXOsByAddressRawResponse{}),
+	CmdUTXOsByAddressRequest:                           reflect.TypeOf(UTXOsByAddressRequest{}),
+	CmdUTXOsByAddressResponse:                          reflect.TypeOf(UTXOsByAddressResponse{}),
+	CmdTxByIdRawRequest:                                reflect.TypeOf(TxByIdRawRequest{}),
+	CmdTxByIdRawResponse:                               reflect.TypeOf(TxByIdRawResponse{}),
+	CmdTxByIdRequest:                                   reflect.TypeOf(TxByIdRequest{}),
+	CmdTxByIdResponse:                                  reflect.TypeOf(TxByIdResponse{}),
+	CmdTxBroadcastRequest:                              reflect.TypeOf(TxBroadcastRequest{}),
+	CmdTxBroadcastResponse:                             reflect.TypeOf(TxBroadcastResponse{}),
+	CmdTxBroadcastRawRequest:                           reflect.TypeOf(TxBroadcastRawRequest{}),
+	CmdTxBroadcastRawResponse:                          reflect.TypeOf(TxBroadcastRawResponse{}),
+	CmdBlockInsertRequest:                              reflect.TypeOf(BlockInsertRequest{}),
+	CmdBlockInsertResponse:                             reflect.TypeOf(BlockInsertResponse{}),
+	CmdBlockInsertRawRequest:                           reflect.TypeOf(BlockInsertRawRequest{}),
+	CmdBlockInsertRawResponse:                          reflect.TypeOf(BlockInsertRawResponse{}),
+	CmdBlockDownloadAsyncRequest:                       reflect.TypeOf(BlockDownloadAsyncRequest{}),
+	CmdBlockDownloadAsyncResponse:                      reflect.TypeOf(BlockDownloadAsyncResponse{}),
+	CmdBlockDownloadAsyncRawRequest:                    reflect.TypeOf(BlockDownloadAsyncRawRequest{}),
+	CmdBlockDownloadAsyncRawResponse:                   reflect.TypeOf(BlockDownloadAsyncRawResponse{}),
+	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashRequest:  reflect.TypeOf(BlockKeystoneAbrevByL2KeystoneAbrevHashRequest{}),
+	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashResponse: reflect.TypeOf(BlockKeystoneAbrevByL2KeystoneAbrevHashResponse{}),
 }
 
 type tbcAPI struct{}

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -78,8 +78,8 @@ const (
 	CmdBlockDownloadAsyncRawRequest  = "tbcapi-block-download-async-raw-request"
 	CmdBlockDownloadAsyncRawResponse = "tbcapi-block-download-async-raw-response"
 
-	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashRequest  = "tbcapi-l2-keystone-abrev-by-abrev-hash-request"
-	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashResponse = "tbcapi-l2-keystone-abrev-by-abrev-hash-response"
+	CmdBlockKeystoneByL2KeystoneAbrevHashRequest  = "tbcapi-l2-keystone-abrev-by-abrev-hash-request"
+	CmdBlockKeystoneByL2KeystoneAbrevHashResponse = "tbcapi-l2-keystone-abrev-by-abrev-hash-response"
 )
 
 var (
@@ -288,12 +288,13 @@ type BlockInsertRawRequest struct {
 	Block api.ByteSlice `json:"block"`
 }
 
-type BlockKeystoneAbrevByL2KeystoneAbrevHashRequest struct {
-	L2KeystoneAbrevHash api.ByteSlice `json:"l2_keystones_abrev_hash"`
+type BlockKeystoneByL2KeystoneAbrevHashRequest struct {
+	L2KeystoneAbrevHash *chainhash.Hash `json:"l2_keystones_abrev_hash"`
 }
 
-type BlockKeystoneAbrevByL2KeystoneAbrevHashResponse struct {
+type BlockKeystoneByL2KeystoneAbrevHashResponse struct {
 	L2KeystoneAbrev *hemi.L2KeystoneAbrev `json:"l2_keystone_abrev"`
+	BtcBlockHash    *chainhash.Hash       `json:"btc_block_hash"`
 	Error           *protocol.Error       `json:"error,omitempty"`
 }
 
@@ -328,44 +329,44 @@ type BlockDownloadAsyncRawResponse struct {
 }
 
 var commands = map[protocol.Command]reflect.Type{
-	CmdPingRequest:                                     reflect.TypeOf(PingRequest{}),
-	CmdPingResponse:                                    reflect.TypeOf(PingResponse{}),
-	CmdBlockByHashRequest:                              reflect.TypeOf(BlockByHashRequest{}),
-	CmdBlockByHashResponse:                             reflect.TypeOf(BlockByHashResponse{}),
-	CmdBlockByHashRawRequest:                           reflect.TypeOf(BlockByHashRawRequest{}),
-	CmdBlockByHashRawResponse:                          reflect.TypeOf(BlockByHashRawResponse{}),
-	CmdBlockHeadersByHeightRawRequest:                  reflect.TypeOf(BlockHeadersByHeightRawRequest{}),
-	CmdBlockHeadersByHeightRawResponse:                 reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
-	CmdBlockHeadersByHeightRequest:                     reflect.TypeOf(BlockHeadersByHeightRequest{}),
-	CmdBlockHeadersByHeightResponse:                    reflect.TypeOf(BlockHeadersByHeightResponse{}),
-	CmdBlockHeaderBestRawRequest:                       reflect.TypeOf(BlockHeaderBestRawRequest{}),
-	CmdBlockHeaderBestRawResponse:                      reflect.TypeOf(BlockHeaderBestRawResponse{}),
-	CmdBlockHeaderBestRequest:                          reflect.TypeOf(BlockHeaderBestRequest{}),
-	CmdBlockHeaderBestResponse:                         reflect.TypeOf(BlockHeaderBestResponse{}),
-	CmdBalanceByAddressRequest:                         reflect.TypeOf(BalanceByAddressRequest{}),
-	CmdBalanceByAddressResponse:                        reflect.TypeOf(BalanceByAddressResponse{}),
-	CmdUTXOsByAddressRawRequest:                        reflect.TypeOf(UTXOsByAddressRawRequest{}),
-	CmdUTXOsByAddressRawResponse:                       reflect.TypeOf(UTXOsByAddressRawResponse{}),
-	CmdUTXOsByAddressRequest:                           reflect.TypeOf(UTXOsByAddressRequest{}),
-	CmdUTXOsByAddressResponse:                          reflect.TypeOf(UTXOsByAddressResponse{}),
-	CmdTxByIdRawRequest:                                reflect.TypeOf(TxByIdRawRequest{}),
-	CmdTxByIdRawResponse:                               reflect.TypeOf(TxByIdRawResponse{}),
-	CmdTxByIdRequest:                                   reflect.TypeOf(TxByIdRequest{}),
-	CmdTxByIdResponse:                                  reflect.TypeOf(TxByIdResponse{}),
-	CmdTxBroadcastRequest:                              reflect.TypeOf(TxBroadcastRequest{}),
-	CmdTxBroadcastResponse:                             reflect.TypeOf(TxBroadcastResponse{}),
-	CmdTxBroadcastRawRequest:                           reflect.TypeOf(TxBroadcastRawRequest{}),
-	CmdTxBroadcastRawResponse:                          reflect.TypeOf(TxBroadcastRawResponse{}),
-	CmdBlockInsertRequest:                              reflect.TypeOf(BlockInsertRequest{}),
-	CmdBlockInsertResponse:                             reflect.TypeOf(BlockInsertResponse{}),
-	CmdBlockInsertRawRequest:                           reflect.TypeOf(BlockInsertRawRequest{}),
-	CmdBlockInsertRawResponse:                          reflect.TypeOf(BlockInsertRawResponse{}),
-	CmdBlockDownloadAsyncRequest:                       reflect.TypeOf(BlockDownloadAsyncRequest{}),
-	CmdBlockDownloadAsyncResponse:                      reflect.TypeOf(BlockDownloadAsyncResponse{}),
-	CmdBlockDownloadAsyncRawRequest:                    reflect.TypeOf(BlockDownloadAsyncRawRequest{}),
-	CmdBlockDownloadAsyncRawResponse:                   reflect.TypeOf(BlockDownloadAsyncRawResponse{}),
-	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashRequest:  reflect.TypeOf(BlockKeystoneAbrevByL2KeystoneAbrevHashRequest{}),
-	CmdBlockKeystoneAbrevByL2KeystoneAbrevHashResponse: reflect.TypeOf(BlockKeystoneAbrevByL2KeystoneAbrevHashResponse{}),
+	CmdPingRequest:                                reflect.TypeOf(PingRequest{}),
+	CmdPingResponse:                               reflect.TypeOf(PingResponse{}),
+	CmdBlockByHashRequest:                         reflect.TypeOf(BlockByHashRequest{}),
+	CmdBlockByHashResponse:                        reflect.TypeOf(BlockByHashResponse{}),
+	CmdBlockByHashRawRequest:                      reflect.TypeOf(BlockByHashRawRequest{}),
+	CmdBlockByHashRawResponse:                     reflect.TypeOf(BlockByHashRawResponse{}),
+	CmdBlockHeadersByHeightRawRequest:             reflect.TypeOf(BlockHeadersByHeightRawRequest{}),
+	CmdBlockHeadersByHeightRawResponse:            reflect.TypeOf(BlockHeadersByHeightRawResponse{}),
+	CmdBlockHeadersByHeightRequest:                reflect.TypeOf(BlockHeadersByHeightRequest{}),
+	CmdBlockHeadersByHeightResponse:               reflect.TypeOf(BlockHeadersByHeightResponse{}),
+	CmdBlockHeaderBestRawRequest:                  reflect.TypeOf(BlockHeaderBestRawRequest{}),
+	CmdBlockHeaderBestRawResponse:                 reflect.TypeOf(BlockHeaderBestRawResponse{}),
+	CmdBlockHeaderBestRequest:                     reflect.TypeOf(BlockHeaderBestRequest{}),
+	CmdBlockHeaderBestResponse:                    reflect.TypeOf(BlockHeaderBestResponse{}),
+	CmdBalanceByAddressRequest:                    reflect.TypeOf(BalanceByAddressRequest{}),
+	CmdBalanceByAddressResponse:                   reflect.TypeOf(BalanceByAddressResponse{}),
+	CmdUTXOsByAddressRawRequest:                   reflect.TypeOf(UTXOsByAddressRawRequest{}),
+	CmdUTXOsByAddressRawResponse:                  reflect.TypeOf(UTXOsByAddressRawResponse{}),
+	CmdUTXOsByAddressRequest:                      reflect.TypeOf(UTXOsByAddressRequest{}),
+	CmdUTXOsByAddressResponse:                     reflect.TypeOf(UTXOsByAddressResponse{}),
+	CmdTxByIdRawRequest:                           reflect.TypeOf(TxByIdRawRequest{}),
+	CmdTxByIdRawResponse:                          reflect.TypeOf(TxByIdRawResponse{}),
+	CmdTxByIdRequest:                              reflect.TypeOf(TxByIdRequest{}),
+	CmdTxByIdResponse:                             reflect.TypeOf(TxByIdResponse{}),
+	CmdTxBroadcastRequest:                         reflect.TypeOf(TxBroadcastRequest{}),
+	CmdTxBroadcastResponse:                        reflect.TypeOf(TxBroadcastResponse{}),
+	CmdTxBroadcastRawRequest:                      reflect.TypeOf(TxBroadcastRawRequest{}),
+	CmdTxBroadcastRawResponse:                     reflect.TypeOf(TxBroadcastRawResponse{}),
+	CmdBlockInsertRequest:                         reflect.TypeOf(BlockInsertRequest{}),
+	CmdBlockInsertResponse:                        reflect.TypeOf(BlockInsertResponse{}),
+	CmdBlockInsertRawRequest:                      reflect.TypeOf(BlockInsertRawRequest{}),
+	CmdBlockInsertRawResponse:                     reflect.TypeOf(BlockInsertRawResponse{}),
+	CmdBlockDownloadAsyncRequest:                  reflect.TypeOf(BlockDownloadAsyncRequest{}),
+	CmdBlockDownloadAsyncResponse:                 reflect.TypeOf(BlockDownloadAsyncResponse{}),
+	CmdBlockDownloadAsyncRawRequest:               reflect.TypeOf(BlockDownloadAsyncRawRequest{}),
+	CmdBlockDownloadAsyncRawResponse:              reflect.TypeOf(BlockDownloadAsyncRawResponse{}),
+	CmdBlockKeystoneByL2KeystoneAbrevHashRequest:  reflect.TypeOf(BlockKeystoneByL2KeystoneAbrevHashRequest{}),
+	CmdBlockKeystoneByL2KeystoneAbrevHashResponse: reflect.TypeOf(BlockKeystoneByL2KeystoneAbrevHashResponse{}),
 }
 
 type tbcAPI struct{}

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -61,8 +61,14 @@ var (
 		},
 		"TBC_BLOCK_SANITY": config.Config{
 			Value:        &cfg.BlockSanity,
-			DefaultValue: false,
+			DefaultValue: true,
 			Help:         "enable/disable block sanity checks before inserting",
+			Print:        config.PrintAll,
+		},
+		"TBC_HEMI_INDEX": config.Config{
+			Value:        &cfg.HemiIndex,
+			DefaultValue: false,
+			Help:         "enable/disable various hemi related indexes",
 			Print:        config.PrintAll,
 		},
 		"TBC_LEVELDB_HOME": config.Config{
@@ -75,6 +81,12 @@ var (
 			Value:        &cfg.LogLevel,
 			DefaultValue: defaultLogLevel,
 			Help:         "loglevel for various packages; INFO, DEBUG and TRACE",
+			Print:        config.PrintAll,
+		},
+		"TBC_MAX_CACHED_KEYSTONES": config.Config{
+			Value:        &cfg.MaxCachedKeystones,
+			DefaultValue: int(1e6),
+			Help:         "maximum cached keystones during indexing",
 			Print:        config.PrintAll,
 		},
 		"TBC_MAX_CACHED_TXS": config.Config{

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -85,7 +85,7 @@ var (
 		},
 		"TBC_MAX_CACHED_KEYSTONES": config.Config{
 			Value:        &cfg.MaxCachedKeystones,
-			DefaultValue: int(1e6),
+			DefaultValue: int(1e5),
 			Help:         "maximum cached keystones during indexing",
 			Print:        config.PrintAll,
 		},

--- a/database/level/level.go
+++ b/database/level/level.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/database/level/level.go
+++ b/database/level/level.go
@@ -29,6 +29,7 @@ const (
 	BlockHeadersDB  = "blockheaders"
 	BlocksMissingDB = "blocksmissing"
 	MetadataDB      = "metadata"
+	KeystonesDB     = "keystones"
 	HeightHashDB    = "heighthash"
 	PeersDB         = "peers"
 	OutputsDB       = "outputs"
@@ -220,6 +221,10 @@ func New(ctx context.Context, home string, version int) (*Database, error) {
 	err = l.openDB(TransactionsDB, nil)
 	if err != nil {
 		return nil, fmt.Errorf("leveldb %v: %w", TransactionsDB, err)
+	}
+	err = l.openDB(KeystonesDB, nil)
+	if err != nil {
+		return nil, fmt.Errorf("leveldb %v: %w", KeystonesDB, err)
 	}
 
 	// Blocks database is special

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -21,6 +21,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/hemilabs/heminetwork/database"
+	"github.com/hemilabs/heminetwork/hemi"
 )
 
 type InsertType int
@@ -125,8 +126,8 @@ type Database interface {
 }
 
 type Keystone struct {
-	BlockHash           chainhash.Hash // Block that contains abbreviated keystone
-	AbbreviatedKeystone []byte         // Abbreviated keystone
+	BlockHash           chainhash.Hash                 // Block that contains abbreviated keystone
+	AbbreviatedKeystone [hemi.L2KeystoneAbrevSize]byte // Abbreviated keystone
 }
 
 // XXX there exist various types in this file that need to be reevaluated.

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -109,7 +109,7 @@ type Database interface {
 	// Transactions
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput) error
 	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue) error
-	BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash][]byte) error
+	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash][]byte) error
 	BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error)
 	SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]SpentInfo, error)
 

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -109,6 +109,7 @@ type Database interface {
 	// Transactions
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput) error
 	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue) error
+	BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Outpoint) error
 	BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error)
 	SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]SpentInfo, error)
 

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -21,7 +21,6 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/hemilabs/heminetwork/database"
-	"github.com/hemilabs/heminetwork/hemi"
 )
 
 type InsertType int
@@ -122,7 +121,7 @@ type Database interface {
 
 	// Hemi
 	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Keystone) error
-	BlockKeystoneAbrevByL2KeystoneAbrevHash(ctx context.Context, abrevhash []byte) (*hemi.L2KeystoneAbrev, error)
+	BlockKeystoneByL2KeystoneAbrevHash(ctx context.Context, abrevhash chainhash.Hash) (*Keystone, error)
 }
 
 type Keystone struct {

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -109,7 +109,7 @@ type Database interface {
 	// Transactions
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput) error
 	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue) error
-	BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Outpoint) error
+	BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash][]byte) error
 	BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error)
 	SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]SpentInfo, error)
 

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -21,6 +21,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/hemilabs/heminetwork/database"
+	"github.com/hemilabs/heminetwork/hemi"
 )
 
 type InsertType int
@@ -121,6 +122,7 @@ type Database interface {
 
 	// Hemi
 	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Keystone) error
+	L2KeystoneAbrevByAbrevHash(ctx context.Context, abrevhash []byte) (*hemi.L2KeystoneAbrev, error)
 }
 
 type Keystone struct {

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -234,13 +234,13 @@ func NewOutpoint(txid [32]byte, index uint32) (op Outpoint) {
 	return
 }
 
-// CacheOutput is a densely packed representation of a bitcoin UTXo. The fields are
-// script_hash + value + out_index. It is packed for
-// memory conservation reasons.
+// CacheOutput is a densely packed representation of a bitcoin UTXo. The fields
+// are script_hash + value + out_index. It is packed for memory conservation
+// reasons.
 type CacheOutput [32 + 8 + 4]byte // script_hash + value + out_idx
 
-// String returns pretty printable CacheOutput. Hash is not reversed since it is an
-// opaque pointer. It prints satoshis@script_hash:output_index
+// String returns pretty printable CacheOutput. Hash is not reversed since it
+// is an opaque pointer. It prints satoshis@script_hash:output_index
 func (c CacheOutput) String() string {
 	return fmt.Sprintf("%d @ %x:%d", binary.BigEndian.Uint64(c[32:40]),
 		c[0:32], binary.BigEndian.Uint32(c[40:]))
@@ -301,8 +301,8 @@ func NewDeleteCacheOutput(hash [32]byte, outIndex uint32) (co CacheOutput) {
 // Utxo packs a transaction id, the value and the out index.
 type Utxo [32 + 8 + 4]byte // tx_id + value + out_idx
 
-// String returns pretty printable CacheOutput. Hash is not reversed since it is an
-// opaque pointer. It prints satoshis@script_hash:output_index
+// String returns pretty printable CacheOutput. Hash is not reversed since it
+// is an opaque pointer. It prints satoshis@script_hash:output_index
 func (u Utxo) String() string {
 	ch, _ := chainhash.NewHash(u[0:32])
 	return fmt.Sprintf("%d @ %v:%d", binary.BigEndian.Uint64(u[32:40]),

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -109,7 +109,6 @@ type Database interface {
 	// Transactions
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput) error
 	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue) error
-	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash][]byte) error
 	BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error)
 	SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]SpentInfo, error)
 
@@ -119,6 +118,14 @@ type Database interface {
 	ScriptHashByOutpoint(ctx context.Context, op Outpoint) (*ScriptHash, error)
 	UtxosByScriptHash(ctx context.Context, sh ScriptHash, start uint64, count uint64) ([]Utxo, error)
 	UtxosByScriptHashCount(ctx context.Context, sh ScriptHash) (uint64, error)
+
+	// Hemi
+	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Keystone) error
+}
+
+type Keystone struct {
+	BlockHash           chainhash.Hash // Block that contains abbreviated keystone
+	AbbreviatedKeystone []byte         // Abbreviated keystone
 }
 
 // XXX there exist various types in this file that need to be reevaluated.

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -122,7 +122,7 @@ type Database interface {
 
 	// Hemi
 	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Keystone) error
-	L2KeystoneAbrevByAbrevHash(ctx context.Context, abrevhash []byte) (*hemi.L2KeystoneAbrev, error)
+	BlockKeystoneAbrevByL2KeystoneAbrevHash(ctx context.Context, abrevhash []byte) (*hemi.L2KeystoneAbrev, error)
 }
 
 type Keystone struct {

--- a/database/tbcd/level/encodedecode_test.go
+++ b/database/tbcd/level/encodedecode_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/hemilabs/heminetwork/hemi"
 )
 
-func fillOutBytes(prefix string, size int) []byte {
-	result := []byte(prefix)
-	for len(result) < size {
-		result = append(result, '_')
-	}
-	return result
-}
-
 func TestKeystoneEncodeDecode(t *testing.T) {
 	hks := hemi.L2Keystone{
 		Version:            1,

--- a/database/tbcd/level/encodedecode_test.go
+++ b/database/tbcd/level/encodedecode_test.go
@@ -1,0 +1,41 @@
+package level
+
+import (
+	"reflect"
+	"testing"
+
+	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
+
+	"github.com/hemilabs/heminetwork/database/tbcd"
+	"github.com/hemilabs/heminetwork/hemi"
+)
+
+func fillOutBytes(prefix string, size int) []byte {
+	result := []byte(prefix)
+	for len(result) < size {
+		result = append(result, '_')
+	}
+	return result
+}
+
+func TestKeystoneEncodeDecode(t *testing.T) {
+	hks := hemi.L2Keystone{
+		Version:            1,
+		L1BlockNumber:      5,
+		L2BlockNumber:      44,
+		ParentEPHash:       fillOutBytes("v1parentephash", 32),
+		PrevKeystoneEPHash: fillOutBytes("v1prevkeystoneephash", 32),
+		StateRoot:          fillOutBytes("v1stateroot", 32),
+		EPHash:             fillOutBytes("v1ephash", 32),
+	}
+	abrvKs := hemi.L2KeystoneAbbreviate(hks).Serialize()
+	ks := tbcd.Keystone{
+		BlockHash:           btcchainhash.Hash(fillOutBytes("blockhash", 32)),
+		AbbreviatedKeystone: abrvKs,
+	}
+	eks := encodeKeystone(ks)
+	nks := decodeKeystone(eks[:])
+	if !reflect.DeepEqual(nks, ks) {
+		t.Fatal("decoded keystone not equal")
+	}
+}

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1769,7 +1769,7 @@ func (l *ldb) BlockKeystoneUpdate(ctx context.Context, direction int, keystones 
 				// Only store unknown keystones
 				continue
 			}
-			var value [chainhash.HashSize + hemi.L2KeystoneAbrevSize + 7]byte
+			var value [chainhash.HashSize + hemi.L2KeystoneAbrevSize]byte
 			copy(value[0:32], v.BlockHash[:])
 			copy(value[32:], v.AbbreviatedKeystone)
 			kssBatch.Put(k[:], value[:])

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1707,9 +1707,9 @@ func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxK
 	return nil
 }
 
-func (l *ldb) BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash][]byte) error {
-	log.Tracef("BlockHemiUpdate")
-	defer log.Tracef("BlockHemiUpdate exit")
+func (l *ldb) BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash][]byte) error {
+	log.Tracef("BlockKeystoneUpdate")
+	defer log.Tracef("BlockKeystoneUpdate exit")
 
 	if !(direction == 1 || direction == -1) {
 		return fmt.Errorf("invalid direction: %v", direction)

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -214,8 +214,12 @@ func (l *ldb) startTransaction(db string) (*leveldb.Transaction, commitFunc, dis
 		}
 	}
 	cf := func() error {
-		if err = tx.Commit(); err != nil {
-			return fmt.Errorf("%v discard: %w", db, err)
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("%v commit: %w", db, err)
+		}
+		// Always flush transaction to disk
+		if err := bhsDB.CompactRange(util.Range{}); err != nil {
+			return fmt.Errorf("%v compact: %w", db, err)
 		}
 		*discard = false
 		return nil

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1707,6 +1707,17 @@ func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxK
 	return nil
 }
 
+func (l *ldb) BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]tbcd.Outpoint) error {
+	log.Tracef("BlockHemiUpdate")
+	defer log.Tracef("BlockHemiUpdate exit")
+
+	if !(direction == 1 || direction == -1) {
+		return fmt.Errorf("invalid direction: %v", direction)
+	}
+
+	return fmt.Errorf("not yet")
+}
+
 func (l *ldb) BlockHeaderCacheStats() tbcd.CacheStats {
 	if l.cfg.blockheaderCacheSize == 0 {
 		return noStats

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -284,9 +284,9 @@ func (l *ldb) MetadataBatchGet(ctx context.Context, allOrNone bool, keys [][]byt
 	return l.transactionBatchGet(ctx, mdDB, allOrNone, keys)
 }
 
-func (l *ldb) L2KeystoneAbrevByAbrevHash(ctx context.Context, abrevhash []byte) (*hemi.L2KeystoneAbrev, error) {
-	log.Tracef("L2KeystoneAbrevByAbrevHash")
-	defer log.Tracef("L2KeystoneAbrevByAbrevHash exit")
+func (l *ldb) BlockKeystoneAbrevByL2KeystoneAbrevHash(ctx context.Context, abrevhash []byte) (*hemi.L2KeystoneAbrev, error) {
+	log.Tracef("BlockKeystoneAbrevByL2KeystoneAbrevHash")
+	defer log.Tracef("BlockKeystoneAbrevByL2KeystoneAbrevHash exit")
 
 	kssDB := l.pool[level.KeystonesDB]
 	eks, err := kssDB.Get(abrevhash, nil)

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1707,7 +1707,7 @@ func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxK
 	return nil
 }
 
-func (l *ldb) BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]tbcd.Outpoint) error {
+func (l *ldb) BlockHemiUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash][]byte) error {
 	log.Tracef("BlockHemiUpdate")
 	defer log.Tracef("BlockHemiUpdate exit")
 

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1778,7 +1778,6 @@ func (l *ldb) BlockKeystoneUpdate(ctx context.Context, direction int, keystones 
 			// Only delete keystone if it is in the previously found block.
 			if ks.BlockHash.IsEqual(&v.BlockHash) {
 				kssBatch.Delete(k[:])
-			} else {
 			}
 		case 1:
 			has, err := kssTx.Has(k[:], nil)

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-test/deep"
 
 	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
+
 	"github.com/hemilabs/heminetwork/database"
 	"github.com/hemilabs/heminetwork/database/tbcd"
 	"github.com/hemilabs/heminetwork/database/tbcd/level"
@@ -132,7 +133,7 @@ func makeKssMap(kssList []hemi.L2Keystone) map[chainhash.Hash]tbcd.Keystone {
 		abrvKs := hemi.L2KeystoneAbbreviate(l2Keystone).Serialize()
 		kssMap[*hemi.L2KeystoneAbbreviate(l2Keystone).Hash()] = tbcd.Keystone{
 			BlockHash:           btcchainhash.Hash(fillOutBytes("blockhash", 32)),
-			AbbreviatedKeystone: abrvKs[:],
+			AbbreviatedKeystone: abrvKs,
 		}
 	}
 	return kssMap
@@ -151,7 +152,8 @@ func TestKeystoneUpdate(t *testing.T) {
 			PrevKeystoneEPHash: fillOutBytes("v1prevkeystoneephash", 32),
 			StateRoot:          fillOutBytes("v1stateroot", 32),
 			EPHash:             fillOutBytes("v1ephash", 32),
-		}, {
+		},
+		{
 			Version:            1,
 			L1BlockNumber:      6,
 			L2BlockNumber:      44,
@@ -168,7 +170,8 @@ func TestKeystoneUpdate(t *testing.T) {
 			PrevKeystoneEPHash: fillOutBytes("i1prevkeystoneephash", 32),
 			StateRoot:          fillOutBytes("i1stateroot", 32),
 			EPHash:             fillOutBytes("i1ephash", 32),
-		}, {
+		},
+		{
 			Version:            1,
 			L1BlockNumber:      6,
 			L2BlockNumber:      44,
@@ -176,7 +179,8 @@ func TestKeystoneUpdate(t *testing.T) {
 			PrevKeystoneEPHash: fillOutBytes("i2prevkeystoneephash", 32),
 			StateRoot:          fillOutBytes("i2stateroot", 32),
 			EPHash:             fillOutBytes("i2ephash", 32),
-		}}
+		},
+	}
 
 	type testTableItem struct {
 		name           string
@@ -254,7 +258,6 @@ func TestKeystoneUpdate(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-
 			home := t.TempDir()
 			t.Logf("temp: %v", home)
 

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -472,12 +472,15 @@ func TestKeystoneDBCache(t *testing.T) {
 		}
 	}()
 
-	const KSSNUM = 1 //XXX make this higher when cache fixed
-	const CYCLES = 1 //XXX make this higher when cache fixed
+	//XXX make these higher when cache fixed
+	const (
+		kssNum = 1
+		cycles = 1
+	)
 
-	for i := range CYCLES {
-		ksm := make(map[chainhash.Hash]tbcd.Keystone, KSSNUM)
-		for j := range KSSNUM {
+	for i := range cycles {
+		ksm := make(map[chainhash.Hash]tbcd.Keystone, kssNum)
+		for j := range kssNum {
 			blkHash := chainhash.Hash{byte(i)}
 			ksHash, ks := newKeystone(&blkHash, uint32(j), uint32(j))
 			ksm[*ksHash] = ks

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -295,9 +295,8 @@ func TestKeystoneUpdate(t *testing.T) {
 				if err == nil {
 					t.Fatalf("keystone in db: %v", spew.Sdump(v))
 				} else {
-					_, ok := err.(database.NotFoundError)
-					if !ok {
-						t.Fatal(ok)
+					if !errors.Is(err, database.ErrNotFound) {
+						t.Fatalf("expected '%v', got '%v'", database.ErrNotFound, err)
 					}
 				}
 			}

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -139,23 +139,24 @@ func makeKssMap(kssList []hemi.L2Keystone, blockHashSeed string) map[chainhash.H
 }
 
 func TestKssEncoding(t *testing.T) {
-	keystones := []hemi.L2Keystone{{
-		Version:            1,
-		L1BlockNumber:      5,
-		L2BlockNumber:      44,
-		ParentEPHash:       fillOutBytes("parentephash", 32),
-		PrevKeystoneEPHash: fillOutBytes("prevkeystoneephash", 32),
-		StateRoot:          fillOutBytes("stateroot", 32),
-		EPHash:             fillOutBytes("ephash", 32),
-	}, {
-		Version:            1,
-		L1BlockNumber:      5,
-		L2BlockNumber:      44,
-		ParentEPHash:       fillOutBytes("altparentephash", 32),
-		PrevKeystoneEPHash: fillOutBytes("altprevkeystoneephash", 32),
-		StateRoot:          fillOutBytes("altstateroot", 32),
-		EPHash:             fillOutBytes("altephash", 32),
-	},
+	keystones := []hemi.L2Keystone{
+		{
+			Version:            1,
+			L1BlockNumber:      5,
+			L2BlockNumber:      44,
+			ParentEPHash:       fillOutBytes("parentephash", 32),
+			PrevKeystoneEPHash: fillOutBytes("prevkeystoneephash", 32),
+			StateRoot:          fillOutBytes("stateroot", 32),
+			EPHash:             fillOutBytes("ephash", 32),
+		}, {
+			Version:            1,
+			L1BlockNumber:      5,
+			L2BlockNumber:      44,
+			ParentEPHash:       fillOutBytes("altparentephash", 32),
+			PrevKeystoneEPHash: fillOutBytes("altprevkeystoneephash", 32),
+			StateRoot:          fillOutBytes("altstateroot", 32),
+			EPHash:             fillOutBytes("altephash", 32),
+		},
 	}
 
 	altKeystone := hemi.L2Keystone{
@@ -195,7 +196,6 @@ func TestKssEncoding(t *testing.T) {
 			t.Fatalf("abrv Ks diff: %v", diff)
 		}
 	}
-
 }
 
 func TestKeystoneUpdate(t *testing.T) {
@@ -397,8 +397,8 @@ func TestKeystoneDBWindUnwind(t *testing.T) {
 	home := t.TempDir()
 	t.Logf("temp: %v", home)
 
-	cfg := level.NewConfig(home, "", "")
-	db, err := level.New(ctx, cfg)
+	cfg := NewConfig(home, "", "")
+	db, err := New(ctx, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -4,14 +4,27 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"maps"
 	"reflect"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/go-test/deep"
 
+	btcchaincfg "github.com/btcsuite/btcd/chaincfg"
+	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
+	btctxscript "github.com/btcsuite/btcd/txscript"
+	btcwire "github.com/btcsuite/btcd/wire"
+	dcrsecp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	dcrecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 	"github.com/hemilabs/heminetwork/database"
 	"github.com/hemilabs/heminetwork/database/tbcd"
 	"github.com/hemilabs/heminetwork/database/tbcd/level"
+	"github.com/hemilabs/heminetwork/hemi"
+	"github.com/hemilabs/heminetwork/hemi/pop"
 )
 
 func TestMD(t *testing.T) {
@@ -111,4 +124,266 @@ func TestMD(t *testing.T) {
 	if rv != nil {
 		t.Fatal("expected no return value")
 	}
+}
+
+func mergeKssMaps(source ...*map[chainhash.Hash]tbcd.Keystone) map[chainhash.Hash]tbcd.Keystone {
+	final := make(map[chainhash.Hash]tbcd.Keystone)
+
+	for _, mp := range source {
+		maps.Copy(final, *mp)
+	}
+
+	return final
+}
+
+func TestKeystoneUpdate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	home := t.TempDir()
+	t.Logf("temp: %v", home)
+
+	cfg := level.NewConfig(home, "", "")
+	db, err := level.New(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	allKss := []hemi.L2Keystone{
+		{
+			Version:            1,
+			L1BlockNumber:      5,
+			L2BlockNumber:      44,
+			ParentEPHash:       fillOutBytes("v1parentephash", 32),
+			PrevKeystoneEPHash: fillOutBytes("v1prevkeystoneephash", 32),
+			StateRoot:          fillOutBytes("v1stateroot", 32),
+			EPHash:             fillOutBytes("v1ephash", 32),
+		}, {
+			Version:            1,
+			L1BlockNumber:      6,
+			L2BlockNumber:      44,
+			ParentEPHash:       fillOutBytes("v2parentephash", 32),
+			PrevKeystoneEPHash: fillOutBytes("v2prevkeystoneephash", 32),
+			StateRoot:          fillOutBytes("v2stateroot", 32),
+			EPHash:             fillOutBytes("v2ephash", 32),
+		},
+		{
+			Version:            1,
+			L1BlockNumber:      5,
+			L2BlockNumber:      44,
+			ParentEPHash:       fillOutBytes("i1parentephash", 32),
+			PrevKeystoneEPHash: fillOutBytes("i1prevkeystoneephash", 32),
+			StateRoot:          fillOutBytes("i1stateroot", 32),
+			EPHash:             fillOutBytes("i1ephash", 32),
+		}, {
+			Version:            1,
+			L1BlockNumber:      6,
+			L2BlockNumber:      44,
+			ParentEPHash:       fillOutBytes("i2parentephash", 32),
+			PrevKeystoneEPHash: fillOutBytes("i2prevkeystoneephash", 32),
+			StateRoot:          fillOutBytes("i2stateroot", 32),
+			EPHash:             fillOutBytes("i2ephash", 32),
+		}}
+
+	btcBlockHash := btcchainhash.Hash(fillOutBytes("blockhash", 32))
+	validKssCache := make(map[chainhash.Hash]tbcd.Keystone)
+	invalidKssCache := make(map[chainhash.Hash]tbcd.Keystone)
+
+	// first 2 keystones will be inserted into db, rest are created but not inserted
+	for i, l2Keystone := range allKss {
+
+		btx := createBtcTx(t, 199, &l2Keystone, []byte{1, 2, 3})
+
+		aPoPTx, err := pop.ParseTransactionL2FromOpReturn(btx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		abrvKss := aPoPTx.L2Keystone.Serialize()
+
+		kssCache := validKssCache
+		if i > 2 {
+			kssCache = invalidKssCache
+		}
+
+		kssCache[*hemi.L2KeystoneAbbreviate(l2Keystone).Hash()] = tbcd.Keystone{
+			BlockHash:           btcBlockHash,
+			AbbreviatedKeystone: abrvKss[:],
+		}
+	}
+
+	if err := db.BlockKeystoneUpdate(ctx, 1, validKssCache); err != nil {
+		t.Fatal(err)
+	}
+
+	type testTableItem struct {
+		name          string
+		direction     []int
+		kssMap        map[chainhash.Hash]tbcd.Keystone
+		expectedInDB  map[chainhash.Hash]tbcd.Keystone
+		expectedOutDB map[chainhash.Hash]tbcd.Keystone
+		expectedError error
+	}
+
+	testTable := []testTableItem{
+		{
+			name:          "invalidDirection",
+			direction:     []int{0},
+			expectedInDB:  validKssCache,
+			expectedOutDB: invalidKssCache,
+			expectedError: fmt.Errorf("invalid direction: %v", 0),
+		},
+		{
+			name:          "nilMap",
+			direction:     []int{-1, 1},
+			expectedInDB:  validKssCache,
+			expectedOutDB: invalidKssCache,
+		},
+		{
+			name:          "emptyMap",
+			direction:     []int{-1, 1},
+			kssMap:        mergeKssMaps(),
+			expectedInDB:  validKssCache,
+			expectedOutDB: invalidKssCache,
+		},
+
+		{
+			name:          "duplicateInsert",
+			direction:     []int{1},
+			expectedError: nil,
+			kssMap:        validKssCache,
+			expectedInDB:  validKssCache,
+			expectedOutDB: invalidKssCache,
+		},
+
+		{
+			name:          "invalidRemove",
+			direction:     []int{-1},
+			kssMap:        invalidKssCache,
+			expectedInDB:  validKssCache,
+			expectedOutDB: invalidKssCache,
+		},
+		{
+			name:         "validInsert",
+			direction:    []int{1},
+			kssMap:       invalidKssCache,
+			expectedInDB: mergeKssMaps(&validKssCache, &invalidKssCache),
+		},
+		{
+			name:          "validRemove",
+			direction:     []int{-1},
+			kssMap:        invalidKssCache,
+			expectedInDB:  validKssCache,
+			expectedOutDB: invalidKssCache,
+		},
+		{
+			name:          "mixedRemove",
+			direction:     []int{-1},
+			kssMap:        mergeKssMaps(&validKssCache, &invalidKssCache),
+			expectedOutDB: mergeKssMaps(&validKssCache, &invalidKssCache),
+		},
+		{
+			name:          "validInsert2",
+			direction:     []int{1},
+			kssMap:        validKssCache,
+			expectedInDB:  validKssCache,
+			expectedOutDB: invalidKssCache,
+		},
+		{
+			name:         "mixedInsert",
+			direction:    []int{1},
+			kssMap:       mergeKssMaps(&validKssCache, &invalidKssCache),
+			expectedInDB: validKssCache,
+		},
+	}
+
+	for _, tti := range testTable {
+		t.Run(tti.name, func(t *testing.T) {
+			for _, dir := range tti.direction {
+				err := db.BlockKeystoneUpdate(ctx, dir, tti.kssMap)
+				if diff := deep.Equal(err, tti.expectedError); len(diff) > 0 {
+					t.Fatalf("(direction %v) unexpected error diff: %s", dir, diff)
+				}
+			}
+
+			for v := range tti.expectedInDB {
+				_, err := db.BlockKeystoneByL2KeystoneAbrevHash(ctx, v)
+				if err != nil {
+					t.Fatalf("keystone not in db: %v", err)
+				}
+			}
+
+			for k, v := range tti.expectedOutDB {
+				_, err := db.BlockKeystoneByL2KeystoneAbrevHash(ctx, k)
+				if err == nil {
+					t.Fatalf("keystone in db: %v", spew.Sdump(v))
+				}
+			}
+		})
+	}
+}
+
+func fillOutBytes(prefix string, size int) []byte {
+	result := []byte(prefix)
+	for len(result) < size {
+		result = append(result, '_')
+	}
+	return result
+}
+
+func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, minerPrivateKeyBytes []byte) []byte {
+	btx := &btcwire.MsgTx{
+		Version:  2,
+		LockTime: uint32(btcHeight),
+	}
+
+	popTx := pop.TransactionL2{
+		L2Keystone: hemi.L2KeystoneAbbreviate(*l2Keystone),
+	}
+
+	popTxOpReturn, err := popTx.EncodeToOpReturn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey := dcrsecp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
+	publicKey := privateKey.PubKey()
+	pubKeyBytes := publicKey.SerializeCompressed()
+	btcAddress, err := btcutil.NewAddressPubKey(pubKeyBytes, &btcchaincfg.TestNet3Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payToScript, err := btctxscript.PayToAddrScript(btcAddress.AddressPubKeyHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(payToScript) != 25 {
+		t.Fatalf("incorrect length for pay to public key script (%d != 25)", len(payToScript))
+	}
+
+	outPoint := btcwire.OutPoint{Hash: btcchainhash.Hash(fillOutBytes("hash", 32)), Index: 0}
+	btx.TxIn = []*btcwire.TxIn{btcwire.NewTxIn(&outPoint, payToScript, nil)}
+
+	changeAmount := int64(100)
+	btx.TxOut = []*btcwire.TxOut{btcwire.NewTxOut(changeAmount, payToScript)}
+
+	btx.TxOut = append(btx.TxOut, btcwire.NewTxOut(0, popTxOpReturn))
+
+	sig := dcrecdsa.Sign(privateKey, []byte{})
+	sigBytes := append(sig.Serialize(), byte(btctxscript.SigHashAll))
+	sigScript, err := btctxscript.NewScriptBuilder().AddData(sigBytes).AddData(pubKeyBytes).Script()
+	if err != nil {
+		t.Fatal(err)
+	}
+	btx.TxIn[0].SignatureScript = sigScript
+
+	return btx.TxOut[1].PkScript
 }

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -774,7 +774,7 @@ func TestNewL2Keystone(t *testing.T) {
 		}
 	}
 
-	l2KeystoneAbrevHash := hemi.L2KeystoneAbbreviate(l2KeystoneRequest.L2Keystone).Hash()
+	l2KeystoneAbrevHash := hemi.L2KeystoneAbbreviate(l2KeystoneRequest.L2Keystone).HashB()
 
 	time.Sleep(2 * time.Second)
 
@@ -1475,7 +1475,7 @@ func TestBitcoinBroadcast(t *testing.T) {
 	// go away in the future once we add "missing keystone" logic and
 	// functionality
 	if diff := deep.Equal(l2k, []bfgd.L2Keystone{
-		bfgd.L2Keystone{
+		{
 			Version:            1,
 			L1BlockNumber:      5,
 			L2BlockNumber:      44,
@@ -1483,7 +1483,7 @@ func TestBitcoinBroadcast(t *testing.T) {
 			PrevKeystoneEPHash: fillOutBytesWith0s("prevkeystone", 32),
 			StateRoot:          fillOutBytes("stateroot", 32),
 			EPHash:             fillOutBytesWith0s("ephash______", 32),
-			Hash:               hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
+			Hash:               hemi.L2KeystoneAbbreviate(l2Keystone).HashB(),
 		},
 	}); len(diff) > 0 {
 		t.Fatalf("unexpected diff: %s", diff)
@@ -1586,7 +1586,7 @@ func TestBitcoinBroadcastDuplicate(t *testing.T) {
 	publicKeyUncompressed := publicKey.SerializeUncompressed()
 
 	// 3
-	popBases, err := db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()), false, 0)
+	popBases, err := db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).HashB()), false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1600,7 +1600,7 @@ func TestBitcoinBroadcastDuplicate(t *testing.T) {
 
 	diff := deep.Equal(popBases, []bfgd.PopBasis{
 		{
-			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
+			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(l2Keystone).HashB(),
 			PopMinerPublicKey:   publicKeyUncompressed,
 			BtcRawTx:            btx,
 			BtcTxId:             btcTxId[:],
@@ -1760,7 +1760,7 @@ loop:
 	// go away in the future once we add "missing keystone" logic and
 	// functionality
 	if diff := deep.Equal(l2k, []bfgd.L2Keystone{
-		bfgd.L2Keystone{
+		{
 			Version:            1,
 			L1BlockNumber:      5,
 			L2BlockNumber:      44,
@@ -1768,7 +1768,7 @@ loop:
 			PrevKeystoneEPHash: fillOutBytesWith0s("prevkeystone", 32),
 			StateRoot:          fillOutBytes("stateroot", 32),
 			EPHash:             fillOutBytesWith0s("ephash______", 32),
-			Hash:               hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
+			Hash:               hemi.L2KeystoneAbbreviate(l2Keystone).HashB(),
 		},
 	}); len(diff) > 0 {
 		t.Fatalf("unexpected diff: %s", diff)
@@ -1829,7 +1829,7 @@ loop:
 		case <-lctx.Done():
 			break loop
 		case <-time.After(1 * time.Second):
-			popBases, err = db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()), false, 0)
+			popBases, err = db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).HashB()), false, 0)
 			if len(popBases) > 0 {
 				break loop
 			}
@@ -1876,7 +1876,7 @@ loop:
 			BtcHeaderHash:       btcHeaderHash,
 			BtcTxIndex:          &txIndex,
 			PopTxId:             popTxId,
-			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
+			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(l2Keystone).HashB(),
 			BtcRawTx:            btx,
 			PopMinerPublicKey:   publicKeyUncompressed,
 			BtcMerklePath:       mockMerkleHashes,
@@ -1899,7 +1899,7 @@ loop:
 	// go away in the future once we add "missing keystone" logic and
 	// functionality
 	if diff := deep.Equal(l2k, []bfgd.L2Keystone{
-		bfgd.L2Keystone{
+		{
 			Version:            1,
 			L1BlockNumber:      5,
 			L2BlockNumber:      44,
@@ -1907,7 +1907,7 @@ loop:
 			PrevKeystoneEPHash: fillOutBytesWith0s("prevkeystone", 32),
 			StateRoot:          fillOutBytes("stateroot", 32),
 			EPHash:             fillOutBytesWith0s("ephash______", 32),
-			Hash:               hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
+			Hash:               hemi.L2KeystoneAbbreviate(l2Keystone).HashB(),
 		},
 	}); len(diff) > 0 {
 		t.Fatalf("unexpected diff: %s", diff)
@@ -2025,7 +2025,7 @@ loop:
 		case <-lctx.Done():
 			break loop
 		case <-time.After(1 * time.Second):
-			popBases, err = db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).Hash()), true, 0)
+			popBases, err = db.PopBasisByL2KeystoneAbrevHash(ctx, [32]byte(hemi.L2KeystoneAbbreviate(l2Keystone).HashB()), true, 0)
 			if len(popBases) > 0 {
 				break loop
 			}
@@ -2061,7 +2061,7 @@ loop:
 			BtcHeaderHash:       btcHeaderHash,
 			BtcTxIndex:          &txIndex,
 			PopTxId:             popTxId,
-			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
+			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(l2Keystone).HashB(),
 			BtcRawTx:            btx,
 			PopMinerPublicKey:   publicKeyUncompressed,
 			BtcMerklePath:       mockMerkleHashes,
@@ -2150,7 +2150,7 @@ func TestPopPayouts(t *testing.T) {
 		BtcTxId:             fillOutBytes("btctxid1", 32),
 		BtcRawTx:            []byte("btcrawtx1"),
 		PopTxId:             fillOutBytes("poptxid1", 32),
-		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).Hash(),
+		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).HashB(),
 		PopMinerPublicKey:   publicKeyUncompressed,
 		BtcHeaderHash:       btcHeaderHash,
 		BtcTxIndex:          &txIndex,
@@ -2167,7 +2167,7 @@ func TestPopPayouts(t *testing.T) {
 		BtcTxId:             fillOutBytes("btctxid2", 32),
 		BtcRawTx:            []byte("btcrawtx2"),
 		PopTxId:             fillOutBytes("poptxid2", 32),
-		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).Hash(),
+		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).HashB(),
 		PopMinerPublicKey:   otherPublicKeyUncompressed,
 		BtcHeaderHash:       btcHeaderHash,
 		BtcTxIndex:          &txIndex,
@@ -2184,7 +2184,7 @@ func TestPopPayouts(t *testing.T) {
 		BtcTxId:             fillOutBytes("btctxid3", 32),
 		BtcRawTx:            []byte("btcrawtx3"),
 		PopTxId:             fillOutBytes("poptxid3", 32),
-		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).Hash(),
+		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).HashB(),
 		PopMinerPublicKey:   publicKeyUncompressed,
 		BtcHeaderHash:       btcHeaderHash,
 		BtcTxIndex:          &txIndex,
@@ -2201,7 +2201,7 @@ func TestPopPayouts(t *testing.T) {
 		BtcTxId:             fillOutBytes("btctxid4", 32),
 		BtcRawTx:            []byte("btcrawtx4"),
 		PopTxId:             fillOutBytes("poptxid4", 32),
-		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(differentL2Keystone).Hash(),
+		L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(differentL2Keystone).HashB(),
 		PopMinerPublicKey:   publicKeyUncompressed,
 		BtcHeaderHash:       btcHeaderHash,
 		BtcTxIndex:          &txIndex,
@@ -2354,7 +2354,7 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 			BtcTxId:             fillOutBytes("btctxid1", 32),
 			BtcRawTx:            []byte("btcrawtx1"),
 			PopTxId:             fillOutBytes("poptxid1", 32),
-			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).Hash(),
+			L2KeystoneAbrevHash: hemi.L2KeystoneAbbreviate(includedL2Keystone).HashB(),
 			PopMinerPublicKey:   publicKeyUncompressed,
 			BtcHeaderHash:       btcHeaderHash,
 			BtcTxIndex:          &txIndex,
@@ -3692,7 +3692,7 @@ func createBtcBlock(ctx context.Context, t *testing.T, db bfgd.Database, count i
 		L2BlockNumber:      l2BlockNumber,
 	}
 
-	l2KeystoneAbrevHash := hemi.L2KeystoneAbbreviate(hemiL2Keystone).Hash()
+	l2KeystoneAbrevHash := hemi.L2KeystoneAbbreviate(hemiL2Keystone).HashB()
 	l2Keystone := bfgd.L2Keystone{
 		Hash:               l2KeystoneAbrevHash,
 		ParentEPHash:       parentEpHash,

--- a/hemi/hemi.go
+++ b/hemi/hemi.go
@@ -200,13 +200,24 @@ func L2KeystoneAbrevDeserialize(r RawAbreviatedL2Keystone) *L2KeystoneAbrev {
 	return &a
 }
 
-func (a *L2KeystoneAbrev) Hash() []byte {
+func (a *L2KeystoneAbrev) HashB() []byte {
 	b := a.Serialize()
 	return chainhash.DoubleHashB(b[:])
 }
 
-func HashSerializedL2KeystoneAbrev(s []byte) []byte {
+func HashSerializedL2KeystoneAbrevB(s []byte) []byte {
 	return chainhash.DoubleHashB(s)
+}
+
+func (a *L2KeystoneAbrev) Hash() *chainhash.Hash {
+	b := a.Serialize()
+	h := chainhash.DoubleHashH(b[:])
+	return &h
+}
+
+func HashSerializedL2KeystoneAbrev(s []byte) *chainhash.Hash {
+	h := chainhash.DoubleHashH(s)
+	return &h
 }
 
 func L2KeystoneAbbreviate(l2ks L2Keystone) *L2KeystoneAbrev {
@@ -233,7 +244,7 @@ func NewL2KeystoneAbrevFromBytes(b []byte) (*L2KeystoneAbrev, error) {
 	switch ka.Version {
 	case L2KeystoneAbrevVersion:
 		if len(b) != L2KeystoneAbrevSize {
-			return nil, fmt.Errorf("invalid keystone sbrev length (%d)",
+			return nil, fmt.Errorf("invalid keystone abrev length (%d)",
 				len(b))
 		}
 		ka.L1BlockNumber = binary.BigEndian.Uint32(b[1:5])

--- a/hemi/pop/pop.go
+++ b/hemi/pop/pop.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -39,7 +39,7 @@ func MinerAddressFromString(address string) (*MinerAddress, error) {
 
 // TransactionL2 rename to Transaction and fixup this code
 type TransactionL2 struct {
-	L2Keystone *hemi.L2KeystoneAbrev
+	L2Keystone *hemi.L2KeystoneAbrev // XXX wtf is this a pointer?
 }
 
 // Serialize serializes a PoP transaction to its byte representation.

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -441,7 +441,7 @@ func (s *Server) handleOneBroadcastRequest(pctx context.Context, highPriority bo
 		return
 	}
 
-	log.Infof("successfully broadcast tx %s, for l2 keystone %s", mb.TxID(), hex.EncodeToString(tl2.L2Keystone.Hash()))
+	log.Infof("successfully broadcast tx %s, for l2 keystone %s", mb.TxID(), tl2.L2Keystone.Hash())
 }
 
 func (s *Server) bitcoinBroadcastWorker(ctx context.Context, highPriority bool) {
@@ -696,7 +696,7 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 			BtcHeaderHash:       btcHeaderHash,
 			BtcTxIndex:          &btcTxIndex,
 			PopTxId:             popTxId,
-			L2KeystoneAbrevHash: tl2.L2Keystone.Hash(),
+			L2KeystoneAbrevHash: tl2.L2Keystone.HashB(),
 			BtcRawTx:            rtx,
 			PopMinerPublicKey:   publicKeyUncompressed,
 			BtcMerklePath:       merkleHashes,
@@ -1195,7 +1195,7 @@ func (s *Server) handlePopTxsForL2Block(ctx context.Context, ptl2 *bfgapi.PopTxs
 
 	hash := hemi.HashSerializedL2KeystoneAbrev(ptl2.L2Block)
 	var h [32]byte
-	copy(h[:], hash)
+	copy(h[:], hash[:])
 
 	response := &bfgapi.PopTxsForL2BlockResponse{}
 
@@ -1264,7 +1264,7 @@ func (s *Server) handleBtcFinalityByKeystonesRequest(ctx context.Context, bfkr *
 	l2KeystoneAbrevHashes := make([]database.ByteArray, 0, len(bfkr.L2Keystones))
 	for _, l := range bfkr.L2Keystones {
 		a := hemi.L2KeystoneAbbreviate(l)
-		l2KeystoneAbrevHashes = append(l2KeystoneAbrevHashes, a.Hash())
+		l2KeystoneAbrevHashes = append(l2KeystoneAbrevHashes, a.HashB())
 	}
 
 	finalities, err := s.db.L2BTCFinalityByL2KeystoneAbrevHash(
@@ -1417,7 +1417,7 @@ func hemiL2KeystoneAbrevToDb(l2ks hemi.L2KeystoneAbrev) bfgd.L2Keystone {
 	}
 
 	return bfgd.L2Keystone{
-		Hash:               l2ks.Hash(),
+		Hash:               l2ks.HashB(),
 		Version:            uint32(l2ks.Version),
 		L1BlockNumber:      l2ks.L1BlockNumber,
 		L2BlockNumber:      l2ks.L2BlockNumber,
@@ -1430,7 +1430,7 @@ func hemiL2KeystoneAbrevToDb(l2ks hemi.L2KeystoneAbrev) bfgd.L2Keystone {
 
 func hemiL2KeystoneToDb(l2ks hemi.L2Keystone) bfgd.L2Keystone {
 	return bfgd.L2Keystone{
-		Hash:               hemi.L2KeystoneAbbreviate(l2ks).Hash(),
+		Hash:               hemi.L2KeystoneAbbreviate(l2ks).HashB(),
 		Version:            uint32(l2ks.Version),
 		L1BlockNumber:      l2ks.L1BlockNumber,
 		L2BlockNumber:      l2ks.L2BlockNumber,

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hemilabs/heminetwork/database"
 	"github.com/hemilabs/heminetwork/database/tbcd"
+	"github.com/hemilabs/heminetwork/hemi"
 	"github.com/hemilabs/heminetwork/hemi/pop"
 )
 
@@ -1228,6 +1229,11 @@ func processKeystones(blockHash *chainhash.Hash, txs []*btcutil.Tx, kssCache map
 			}
 			if _, ok := kssCache[*aPoPTx.L2Keystone.Hash()]; ok {
 				// Multiple keystones may exist in block, only store first
+				continue
+			}
+			if len(txOut.PkScript) != hemi.L2KeystoneAbrevSize {
+				log.Errorf("keystone pkscript invalid length: %v",
+					len(txOut.PkScript))
 				continue
 			}
 

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1231,16 +1231,8 @@ func processKeystones(blockHash *chainhash.Hash, txs []*btcutil.Tx, kssCache map
 				// Multiple keystones may exist in block, only store first
 				continue
 			}
-			/*
-				if len(txOut.PkScript) != hemi.L2KeystoneAbrevSize {
-					log.Errorf("keystone pkscript invalid length: %v",
-						len(txOut.PkScript))
-					continue
-				}
-			*/
 
 			abvKss := aPoPTx.L2Keystone.Serialize()
-
 			kssCache[*aPoPTx.L2Keystone.Hash()] = tbcd.Keystone{
 				BlockHash:           *blockHash,
 				AbbreviatedKeystone: abvKss[:],

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1333,9 +1333,9 @@ func (s *Server) indexKeystonesInBlocks(ctx context.Context, endHash *chainhash.
 	return blocksProcessed, last, nil
 }
 
-// unindexKeystonesInBlocks indexes keystones from the last processed block
+// unindexKeystonesInBlocks unindexes keystones from the last processed block
 // until the provided end hash, inclusive. It returns the number of blocks
-// processed and the last hash it has processedd.
+// processed and the last hash it processed.
 func (s *Server) unindexKeystonesInBlocks(ctx context.Context, endHash *chainhash.Hash, kss map[chainhash.Hash]tbcd.Keystone) (int, *HashHeight, error) {
 	log.Tracef("unindexKeystonesInBlocks")
 	defer log.Tracef("unindexKeystonesInBlocks exit")

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1241,7 +1241,7 @@ func processKeystones(blockHash *chainhash.Hash, txs []*btcutil.Tx, kssCache map
 			abvKss := aPoPTx.L2Keystone.Serialize()
 			kssCache[*aPoPTx.L2Keystone.Hash()] = tbcd.Keystone{
 				BlockHash:           *blockHash,
-				AbbreviatedKeystone: abvKss[:],
+				AbbreviatedKeystone: abvKss,
 			}
 		}
 	}

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1250,7 +1250,7 @@ func processKeystones(blockHash *chainhash.Hash, txs []*btcutil.Tx, kssCache map
 
 // indexKeystonesInBlocks indexes txs from the last processed block until the
 // provided end hash, inclusive. It returns the number of blocks processed and
-// the last hash it has processedd.
+// the last hash it processed.
 func (s *Server) indexKeystonesInBlocks(ctx context.Context, endHash *chainhash.Hash, kss map[chainhash.Hash]tbcd.Keystone) (int, *HashHeight, error) {
 	log.Tracef("indexKeystonesInBlocks")
 	defer log.Tracef("indexKeystonesInBlocks exit")

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1225,6 +1225,7 @@ func processKeystones(blockHash *chainhash.Hash, txs []*btcutil.Tx, kssCache map
 		for _, txOut := range tx.MsgTx().TxOut {
 			aPoPTx, err := pop.ParseTransactionL2FromOpReturn(txOut.PkScript)
 			if err != nil {
+				log.Errorf("error parsing tx l2: %s", err)
 				continue
 			}
 			if _, ok := kssCache[*aPoPTx.L2Keystone.Hash()]; ok {

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/hemilabs/heminetwork/database"
 	"github.com/hemilabs/heminetwork/database/tbcd"
-	"github.com/hemilabs/heminetwork/hemi"
 	"github.com/hemilabs/heminetwork/hemi/pop"
 )
 
@@ -1232,15 +1231,19 @@ func processKeystones(blockHash *chainhash.Hash, txs []*btcutil.Tx, kssCache map
 				// Multiple keystones may exist in block, only store first
 				continue
 			}
-			if len(txOut.PkScript) != hemi.L2KeystoneAbrevSize {
-				log.Errorf("keystone pkscript invalid length: %v",
-					len(txOut.PkScript))
-				continue
-			}
+			/*
+				if len(txOut.PkScript) != hemi.L2KeystoneAbrevSize {
+					log.Errorf("keystone pkscript invalid length: %v",
+						len(txOut.PkScript))
+					continue
+				}
+			*/
+
+			abvKss := aPoPTx.L2Keystone.Serialize()
 
 			kssCache[*aPoPTx.L2Keystone.Hash()] = tbcd.Keystone{
 				BlockHash:           *blockHash,
-				AbbreviatedKeystone: txOut.PkScript,
+				AbbreviatedKeystone: abvKss[:],
 			}
 		}
 	}

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -175,7 +175,13 @@ func (s *Server) KeystoneIndexHash(ctx context.Context) (*HashHeight, error) {
 		if !errors.Is(err, database.ErrNotFound) {
 			return nil, err
 		}
-		h = s.hemiGenesis
+		// h = s.hemiGenesis // XXX disable this for now until we are
+		// sure we may or may not have to pass "genesis" around in the
+		// various functions.
+		h = &HashHeight{
+			Hash:   *s.chainParams.GenesisHash,
+			Height: 0,
+		}
 	}
 	return h, nil
 }
@@ -1548,7 +1554,7 @@ func (s *Server) KeystoneIndexer(ctx context.Context, endHash *chainhash.Hash) e
 	}
 	endBH, err := s.db.BlockHeaderByHash(ctx, endHash)
 	if err != nil {
-		return fmt.Errorf("blockheader hash: %w", err)
+		return fmt.Errorf("blockheader end hash: %w", err)
 	}
 
 	// Verify start point is not after the end point
@@ -1560,7 +1566,7 @@ func (s *Server) KeystoneIndexer(ctx context.Context, endHash *chainhash.Hash) e
 	// Make sure there is no gap between start and end or vice versa.
 	startBH, err := s.db.BlockHeaderByHash(ctx, &keystoneHH.Hash)
 	if err != nil {
-		return fmt.Errorf("blockheader hash: %w", err)
+		return fmt.Errorf("blockheader keystone hash: %w", err)
 	}
 	direction, err := s.KeystoneIndexIsLinear(ctx, endHash)
 	if err != nil {

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1224,7 +1224,7 @@ func processKeystones(blockHash *chainhash.Hash, txs []*btcutil.Tx, kssCache map
 		for _, txOut := range tx.MsgTx().TxOut {
 			aPoPTx, err := pop.ParseTransactionL2FromOpReturn(txOut.PkScript)
 			if err != nil {
-				log.Errorf("error parsing tx l2: %s", err)
+				// log.Tracef("error parsing tx l2: %s", err)
 				continue
 			}
 			if _, ok := kssCache[*aPoPTx.L2Keystone.Hash()]; ok {

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1870,7 +1870,7 @@ func (s *Server) syncIndexersToBest(ctx context.Context) error {
 	if err != nil {
 		log.Errorf("block header by hash: %v", err)
 	} else {
-		log.Infof("Syncing complete at: %v", bh.HH())
+		log.Infof("Syncing complete at: %v", bh.HH()) // XXX this prints too often
 	}
 
 	return nil

--- a/service/tbc/crawler_test.go
+++ b/service/tbc/crawler_test.go
@@ -123,3 +123,7 @@ func BenchmarkMap1000000(b *testing.B) {
 		allocateMap(1e6)
 	}
 }
+
+func TestProcessKeystones(t *testing.T) {
+
+}

--- a/service/tbc/crawler_test.go
+++ b/service/tbc/crawler_test.go
@@ -123,7 +123,3 @@ func BenchmarkMap1000000(b *testing.B) {
 		allocateMap(1e6)
 	}
 }
-
-func TestProcessKeystones(t *testing.T) {
-
-}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -191,10 +191,10 @@ func (s *Server) handleWebsocketRead(ctx context.Context, ws *tbcWs) {
 			}
 
 			go s.handleRequest(ctx, ws, id, cmd, handler)
-		case tbcapi.CmdL2KeystoneAbrevByAbrevHashRequest:
+		case tbcapi.CmdBlockKeystoneAbrevByL2KeystoneAbrevHashRequest:
 			handler := func(ctx context.Context) (any, error) {
-				req := payload.(*tbcapi.L2KeystoneAbrevByAbrevHashRequest)
-				return s.handleL2KeystoneAbrevByAbrevHashRequest(ctx, req)
+				req := payload.(*tbcapi.BlockKeystoneAbrevByL2KeystoneAbrevHashRequest)
+				return s.handleBlockKeystoneAbrevByL2KeystoneAbrevHashRequest(ctx, req)
 			}
 
 			go s.handleRequest(ctx, ws, id, cmd, handler)
@@ -633,20 +633,20 @@ func (s *Server) handleBlockInsertRawRequest(ctx context.Context, req *tbcapi.Bl
 	return &tbcapi.BlockInsertRawResponse{BlockHash: &hash}, nil
 }
 
-func (s *Server) handleL2KeystoneAbrevByAbrevHashRequest(ctx context.Context, req *tbcapi.L2KeystoneAbrevByAbrevHashRequest) (any, error) {
-	log.Tracef("handleL2KeystoneAbrevByAbrevHashRequest")
-	defer log.Tracef("handleL2KeystoneAbrevByAbrevHashRequest exit")
+func (s *Server) handleBlockKeystoneAbrevByL2KeystoneAbrevHashRequest(ctx context.Context, req *tbcapi.BlockKeystoneAbrevByL2KeystoneAbrevHashRequest) (any, error) {
+	log.Tracef("handleBlockKeystoneAbrevByL2KeystoneAbrevHashRequest")
+	defer log.Tracef("handleBlockKeystoneAbrevByL2KeystoneAbrevHashRequest exit")
 
-	ks, err := s.db.L2KeystoneAbrevByAbrevHash(ctx, req.L2KeystoneAbrevHash)
+	ks, err := s.db.BlockKeystoneAbrevByL2KeystoneAbrevHash(ctx, req.L2KeystoneAbrevHash)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
-			return &tbcapi.L2KeystoneAbrevByAbrevHashResponse{Error: protocol.RequestErrorf("could not find l2 keystone")}, nil
+			return &tbcapi.BlockKeystoneAbrevByL2KeystoneAbrevHashResponse{Error: protocol.RequestErrorf("could not find l2 keystone")}, nil
 		}
 		e := protocol.NewInternalError(err)
-		return &tbcapi.L2KeystoneAbrevByAbrevHashResponse{Error: e.ProtocolError()}, e
+		return &tbcapi.BlockKeystoneAbrevByL2KeystoneAbrevHashResponse{Error: e.ProtocolError()}, e
 	}
 
-	return &tbcapi.L2KeystoneAbrevByAbrevHashResponse{L2KeystoneAbrev: ks}, nil
+	return &tbcapi.BlockKeystoneAbrevByL2KeystoneAbrevHashResponse{L2KeystoneAbrev: ks}, nil
 }
 
 // handleBlockDownloadAsyncRequest handles tbcapi.BlockDownloadAsyncRequest.

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -558,8 +558,11 @@ func (s *Server) handleTxBroadcastRequest(ctx context.Context, req *tbcapi.TxBro
 
 	txid, err := s.TxBroadcast(ctx, req.Tx, req.Force)
 	if err != nil {
-		if errors.Is(err, ErrTxAlreadyBroadcast) || errors.Is(err, ErrTxBroadcastNoPeers) {
-			return &tbcapi.TxBroadcastResponse{Error: protocol.RequestError(err)}, err
+		if errors.Is(err, ErrTxAlreadyBroadcast) ||
+			errors.Is(err, ErrTxBroadcastNoPeers) {
+			return &tbcapi.TxBroadcastResponse{
+				Error: protocol.RequestError(err),
+			}, err
 		}
 		e := protocol.NewInternalError(err)
 		return &tbcapi.TxBroadcastResponse{Error: e.ProtocolError()}, e
@@ -581,8 +584,11 @@ func (s *Server) handleTxBroadcastRawRequest(ctx context.Context, req *tbcapi.Tx
 	}
 	txid, err := s.TxBroadcast(ctx, tx, req.Force)
 	if err != nil {
-		if errors.Is(err, ErrTxAlreadyBroadcast) || errors.Is(err, ErrTxBroadcastNoPeers) {
-			return &tbcapi.TxBroadcastResponse{Error: protocol.RequestError(err)}, err
+		if errors.Is(err, ErrTxAlreadyBroadcast) ||
+			errors.Is(err, ErrTxBroadcastNoPeers) {
+			return &tbcapi.TxBroadcastResponse{
+				Error: protocol.RequestError(err),
+			}, err
 		}
 		e := protocol.NewInternalError(err)
 		return &tbcapi.TxBroadcastResponse{Error: e.ProtocolError()}, e
@@ -639,17 +645,26 @@ func (s *Server) handleBlockKeystoneByL2KeystoneAbrevHashRequest(ctx context.Con
 	defer log.Tracef("handleBlockKeystoneByL2KeystoneAbrevHashRequest exit")
 
 	if req.L2KeystoneAbrevHash == nil {
-		return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{Error: protocol.RequestErrorf("invalid nil abrev hash")}, nil
+		return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{
+			Error: protocol.RequestErrorf("invalid nil abrev hash"),
+		}, nil
 	}
 	ks, err := s.db.BlockKeystoneByL2KeystoneAbrevHash(ctx, *req.L2KeystoneAbrevHash)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
-			return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{Error: protocol.RequestErrorf("could not find l2 keystone")}, nil
+			return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{
+				Error: protocol.RequestErrorf("could not find l2 keystone"),
+			}, nil
 		}
 		e := protocol.NewInternalError(err)
-		return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{Error: e.ProtocolError()}, e
+		return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{
+			Error: e.ProtocolError(),
+		}, e
 	}
-	return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{L2KeystoneAbrev: hemi.L2KeystoneAbrevDeserialize(hemi.RawAbreviatedL2Keystone(ks.AbbreviatedKeystone)), BtcBlockHash: &ks.BlockHash}, nil
+	return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{
+		L2KeystoneAbrev: hemi.L2KeystoneAbrevDeserialize(hemi.RawAbreviatedL2Keystone(ks.AbbreviatedKeystone)),
+		BtcBlockHash:    &ks.BlockHash,
+	}, nil
 }
 
 // handleBlockDownloadAsyncRequest handles tbcapi.BlockDownloadAsyncRequest.

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1594,7 +1594,7 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 
 			kssCache[*hemi.L2KeystoneAbbreviate(l2Keystone).Hash()] = tbcd.Keystone{
 				BlockHash:           btcBlockHash,
-				AbbreviatedKeystone: abrvKss[:],
+				AbbreviatedKeystone: abrvKss,
 			}
 
 			if err := s.db.BlockKeystoneUpdate(ctx, 1, kssCache); err != nil {

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1500,7 +1500,6 @@ func TestTxByIdNotFound(t *testing.T) {
 }
 
 func TestBlockKeystoneByL2KeystoneAbrevHash(t *testing.T) {
-
 	l2Keystone := hemi.L2Keystone{
 		Version:            1,
 		L1BlockNumber:      5,
@@ -1534,20 +1533,23 @@ func TestBlockKeystoneByL2KeystoneAbrevHash(t *testing.T) {
 		expectedBTCBlockHash    *chainhash.Hash
 	}
 
-	testTable := []testTableItem{{
-		name:          "nilL2KeystoneAbrevHash",
-		expectedError: protocol.RequestErrorf("invalid nil abrev hash"),
-	}, {
-		name:                "invalidL2KeystoneAbrevHash",
-		l2KeystoneAbrevHash: &invalidL2KeystoneAbrevHash,
-		expectedError:       protocol.RequestErrorf("could not find l2 keystone"),
-	},
+	testTable := []testTableItem{
+		{
+			name:          "nilL2KeystoneAbrevHash",
+			expectedError: protocol.RequestErrorf("invalid nil abrev hash"),
+		},
+		{
+			name:                "invalidL2KeystoneAbrevHash",
+			l2KeystoneAbrevHash: &invalidL2KeystoneAbrevHash,
+			expectedError:       protocol.RequestErrorf("could not find l2 keystone"),
+		},
 		{
 			name:                    "validL2KeystoneAbrevHash",
 			l2KeystoneAbrevHash:     hemi.L2KeystoneAbbreviate(l2Keystone).Hash(),
 			expectedL2KeystoneAbrev: hemi.L2KeystoneAbbreviate(l2Keystone),
 			expectedBTCBlockHash:    &btcBlockHash,
-		}}
+		},
+	}
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
@@ -1671,7 +1673,7 @@ func fillOutBytes(prefix string, size int) []byte {
 	return result
 }
 
-func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, minerPrivateKeyBytes []byte) []byte {
+func createBtcUtilTx(btcHeight uint64, l2Keystone *hemi.L2Keystone, minerPrivateKeyBytes []byte) (*btcutil.Tx, err) {
 	btx := &btcwire.MsgTx{
 		Version:  2,
 		LockTime: uint32(btcHeight),
@@ -1721,5 +1723,13 @@ func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, mi
 
 	t.Logf("%s", spew.Sdump(btx.TxOut[1].PkScript))
 
+	return btx.TxOut[1].PkScript, btx
+}
+
+func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, minerPrivateKeyBytes []byte) []byte {
+	btx, err := createBtcUtilTx(btcHeight)
+	if err != nil {
+		t.Fatal(err)
+	}
 	return btx.TxOut[1].PkScript
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2451,18 +2451,12 @@ func (s *Server) Run(pctx context.Context) error {
 	log.Infof("Starting block headers sync at %v height: %v time %v",
 		bhb, bhb.Height, bhb.Timestamp())
 	utxoHH, _ := s.UtxoIndexHash(ctx)
-	if s.hemiGenesis != utxoHH {
-		log.Infof("Utxo index %v", utxoHH)
-	}
+	log.Infof("Utxo index %v", utxoHH)
 	txHH, _ := s.TxIndexHash(ctx)
-	if s.hemiGenesis != txHH {
-		log.Infof("Tx index %v", txHH)
-	}
+	log.Infof("Tx index %v", txHH)
 	if s.cfg.HemiIndex {
 		hemiHH, _ := s.KeystoneIndexHash(ctx)
-		if s.hemiGenesis != hemiHH {
-			log.Infof("Keystone index %v", txHH)
-		}
+		log.Infof("Keystone index %v", hemiHH)
 	}
 
 	// HTTP server
@@ -2663,10 +2657,10 @@ func (s *Server) ExternalHeaderSetup(ctx context.Context, upstreamStateId []byte
 		}
 		gh := genesis.BlockHash()
 		if !bytes.Equal(gb[0].Hash[:], gh[:]) {
-			return fmt.Errorf("effective genesis block hash mismatch, db has %x but genesis should be %x", gb[0].Hash, gh)
+			return fmt.Errorf("effective genesis block hash mismatch, db has %v but genesis should be %v", gb[0].Hash, gh)
 		}
 	}
-	log.Infof("TBC set up in External Header Mode, effectiveGenesis=%x, tip=%x", genesis.BlockHash(), bhb.Hash)
+	log.Infof("TBC set up in External Header Mode, effectiveGenesis=%v, tip=%v", genesis.BlockHash(), bhb.Hash)
 
 	return nil
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2459,7 +2459,7 @@ func (s *Server) Run(pctx context.Context) error {
 		log.Infof("Tx index %v", txHH)
 	}
 	if s.cfg.HemiIndex {
-		hemiHH, _ := s.HemiIndexHash(ctx)
+		hemiHH, _ := s.KeystoneIndexHash(ctx)
 		if s.hemiGenesis != hemiHH {
 			log.Infof("Keystone index %v", txHH)
 		}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -51,6 +51,8 @@ const (
 	minPeersRequired     = 64  // minimum number of peers in good map before cache is purged
 	defaultPendingBlocks = 128 // 128 * ~4MB max memory use
 
+	defaultMaxCachedKeystones = 1e5 // number of cached keystones prior to flush
+
 	defaultMaxCachedTxs = 1e6 // dual purpose cache, max key 69, max value 36
 
 	networkLocalnet = "localnet" // XXX this needs to be rethought
@@ -84,9 +86,11 @@ type Config struct {
 	BlockCacheSize          string
 	BlockheaderCacheSize    string
 	BlockSanity             bool
+	HemiIndex               bool
 	LevelDBHome             string
 	ListenAddress           string
 	LogLevel                string
+	MaxCachedKeystones      int
 	MaxCachedTxs            int
 	MempoolEnabled          bool
 	Network                 string
@@ -111,6 +115,7 @@ func NewDefaultConfig() *Config {
 		BlockCacheSize:       "1gb",
 		BlockheaderCacheSize: "128mb",
 		LogLevel:             logLevel,
+		MaxCachedKeystones:   defaultMaxCachedKeystones,
 		MaxCachedTxs:         defaultMaxCachedTxs,
 		MempoolEnabled:       false, // XXX default to false until it is fixed
 		PeersWanted:          defaultPeersWanted,

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -706,7 +706,11 @@ func (b *btcNode) mine(name string, from *chainhash.Hash, payToAddress btcutil.A
 		if err != nil {
 			return nil, err
 		}
-		popTx, err := createPopTx(uint64(nextBlockHeight), &l2Keystone, signer.Serialize(), tx)
+		recipient, err := b.findKeyByName("pop")
+		if err != nil {
+			return nil, err
+		}
+		popTx, err := createPopTx(uint64(nextBlockHeight), &l2Keystone, signer.Serialize(), recipient.PubKey(), tx)
 		if err != nil {
 			return nil, err
 		}

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -249,7 +249,7 @@ func (b *btcNode) newSignedTxFromTx(name string, inTx *btcutil.Tx, amount btcuti
 	if err != nil {
 		return nil, err
 	}
-	b.t.Logf("rdeeem pkScript (%v): %x", name, pkScript)
+	b.t.Logf("redeem pkScript (%v): %x", name, pkScript)
 	b.t.Logf("redeem keys:")
 	b.t.Logf("  private    : %x", redeemPrivate.Serialize())
 	b.t.Logf("  public     : %x", redeemPublic.SerializeCompressed())

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -673,7 +673,10 @@ func (b *btcNode) mine(name string, from *chainhash.Hash, payToAddress btcutil.A
 		StateRoot:          fillOutBytes("stateroot", 32),
 		EPHash:             fillOutBytes("ephash", 32),
 	}
-	btx := createBtcTx(nil, 199, &l2Keystone, minerPrivateKeyBytes)
+	btx, err := createBtcUtilTx(199, &l2Keystone, minerPrivateKeyBytes)
+	if err != nil {
+		return nil, err
+	}
 	mempool = append(mempool, btx)
 
 	bt, err := newBlockTemplate(b.params, payToAddress, nextBlockHeight,

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -865,7 +865,7 @@ func (b *btcNode) mine(name string, from *chainhash.Hash, payToAddress btcutil.A
 		abrvKs := hemi.L2KeystoneAbbreviate(l2Keystone).Serialize()
 		blk.kss[*hemi.L2KeystoneAbbreviate(l2Keystone).Hash()] = tbcd.Keystone{
 			BlockHash:           *blk.Hash(),
-			AbbreviatedKeystone: abrvKs[:],
+			AbbreviatedKeystone: abrvKs,
 		}
 	}
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1001,10 +1001,12 @@ func mustHaveKss(ctx context.Context, t *testing.T, s *Server, blocks ...*block)
 
 		for kkss, vkss := range kssCache {
 			if !bytes.Equal(b.Hash()[:], vkss.BlockHash[:]) {
-				return nil, fmt.Errorf("block mismatch %v", vkss.BlockHash[:])
+				return nil, fmt.Errorf("block mismatch %v",
+					vkss.BlockHash[:])
 			}
 			if diff := deep.Equal(b.kss[kkss], vkss); len(diff) > 0 {
-				t.Fatalf("processKeystones: returned %v, expected %v", spew.Sdump(b.kss[kkss]), spew.Sdump(vkss))
+				t.Fatalf("processKeystones: returned %v, expected %v",
+					spew.Sdump(b.kss[kkss]), spew.Sdump(vkss))
 			}
 			txsInBlock++
 			processedKss = append(processedKss, kkss)


### PR DESCRIPTION
**Summary**
Hemi needs to keep track of L2 keystones in order to provide callers the bitcoin view of the hemi network.

**Changes**
This PR adds L2 keystone indexing and hides this behind a configuration flag.
