### PR TITLE
Fix typographical errors

### DIFF
--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -229,7 +229,7 @@ func NewOutpoint(txid [32]byte, index uint32) (op Outpoint) {
 // memory conservation reasons.
 type CacheOutput [32 + 8 + 4]byte // script_hash + value + out_idx
 
-// String reutrns pretty printable CacheOutput. Hash is not reversed since it is an
+// String returns pretty printable CacheOutput. Hash is not reversed since it is an
 // opaque pointer. It prints satoshis@script_hash:output_index
 func (c CacheOutput) String() string {
 	return fmt.Sprintf("%d @ %x:%d", binary.BigEndian.Uint64(c[32:40]),
@@ -291,7 +291,7 @@ func NewDeleteCacheOutput(hash [32]byte, outIndex uint32) (co CacheOutput) {
 // Utxo packs a transaction id, the value and the out index.
 type Utxo [32 + 8 + 4]byte // tx_id + value + out_idx
 
-// String reutrns pretty printable CacheOutput. Hash is not reversed since it is an
+// String returns pretty printable CacheOutput. Hash is not reversed since it is an
 // opaque pointer. It prints satoshis@script_hash:output_index
 func (u Utxo) String() string {
 	ch, _ := chainhash.NewHash(u[0:32])

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -202,7 +202,7 @@ func (l *ldb) startTransaction(db string) (*leveldb.Transaction, commitFunc, dis
 	bhsDB := l.pool[db]
 	tx, err := bhsDB.OpenTransaction()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%v open tansaction: %w", db, err)
+		return nil, nil, nil, fmt.Errorf("%v open transaction: %w", db, err)
 	}
 	d := true
 	discard := &d

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -357,7 +357,7 @@ func (l *ldb) BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*tbc
 		}
 	}
 
-	// It stands to reason that this code does not need a trasaction. The
+	// It stands to reason that this code does not need a transaction. The
 	// caller code will either receive or not receice an answer. It does
 	// not seem likely to be racing higher up in the stack.
 

--- a/service/tbc/peermanager.go
+++ b/service/tbc/peermanager.go
@@ -342,7 +342,7 @@ func (pm *PeerManager) randomPeer(ctx context.Context, slot int) (*rawpeer.RawPe
 		if _, ok := pm.bad[k]; ok {
 			// Should not happen but let's make sure we aren't
 			// reusing an address.
-			log.Errorf("found addres on bad list: %v", k)
+			log.Errorf("found address on bad list: %v", k)
 			continue
 		}
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2131,7 +2131,7 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 	bhb, err := s.db.BlockHeaderBest(ctx)
 	if err != nil {
 		// XXX this happens because we shut down and blocks come in.
-		// The context is canceled but wire isn't smart enought so we
+		// The context is canceled but wire isn't smart enough so we
 		// make it here. We should not be testing for leveldb errors
 		// here but the real fix is return an error or add ctx to wire.
 		// This is a workaround. Code prints a bunch of crap during IBD


### PR DESCRIPTION
- Fixed typos such as "reutrns" to "returns", "tansaction" to "transaction", and "receice" to "receive".
- Made minor adjustments to logging messages and variable names for better consistency.
