### PR TITLE
tbc: add UtxosByScriptHashCount

### DIFF
--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -117,6 +117,7 @@ type Database interface {
 	BlockInTxIndex(ctx context.Context, hash *chainhash.Hash) (bool, error)
 	ScriptHashByOutpoint(ctx context.Context, op Outpoint) (*ScriptHash, error)
 	UtxosByScriptHash(ctx context.Context, sh ScriptHash, start uint64, count uint64) ([]Utxo, error)
+	UtxosByScriptHashCount(ctx context.Context, sh ScriptHash) (uint64, error)
 }
 
 // XXX there exist various types in this file that need to be reevaluated.

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1551,6 +1551,27 @@ func (l *ldb) UtxosByScriptHash(ctx context.Context, sh tbcd.ScriptHash, start u
 	return utxos, nil
 }
 
+func (l *ldb) UtxosByScriptHashCount(ctx context.Context, sh tbcd.ScriptHash) (uint64, error) {
+	log.Tracef("UtxosByScriptHashCount")
+	defer log.Tracef("UtxosByScriptHashCount exit")
+
+	var prefix [33]byte
+	prefix[0] = 'h'
+	copy(prefix[1:], sh[:])
+	oDB := l.pool[level.OutputsDB]
+	it := oDB.NewIterator(util.BytesPrefix(prefix[:]), nil)
+	defer it.Release()
+	var x uint64
+	for it.Next() {
+		x++
+	}
+	if err := it.Error(); err != nil {
+		return 0, IteratorError(err)
+	}
+
+	return x, nil
+}
+
 func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd.Outpoint]tbcd.CacheOutput) error {
 	log.Tracef("BlockUtxoUpdate")
 	defer log.Tracef("BlockUtxoUpdate exit")

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1825,10 +1825,23 @@ func (s *Server) UtxosByScriptHash(ctx context.Context, hash tbcd.ScriptHash, st
 	defer log.Tracef("UtxosByScriptHash exit")
 
 	if s.cfg.ExternalHeaderMode {
-		return nil, errors.New("cannot call UtxosByScriptHash on TBC running in External Header mode")
+		return nil, errors.New("cannot call UtxosByScriptHash on " +
+			"TBC running in External Header mode")
 	}
 
 	return s.db.UtxosByScriptHash(ctx, hash, start, count)
+}
+
+func (s *Server) UtxosByScriptHashCount(ctx context.Context, hash tbcd.ScriptHash) (uint64, error) {
+	log.Tracef("UtxosByScriptHashCount")
+	defer log.Tracef("UtxosByScriptHashCount exit")
+
+	if s.cfg.ExternalHeaderMode {
+		return 0, errors.New("cannot call UtxosByScriptHashCount on " +
+			"TBC running in External Header mode")
+	}
+
+	return s.db.UtxosByScriptHashCount(ctx, hash)
 }
 
 // ScriptHashAvailableToSpend returns a boolean which indicates whether


### PR DESCRIPTION
**Summary**
We need a way to count all utxos for a specified scripthash. Unfortunately this does mean iterating through all utxos since leveldb does not have the upper limit as a call.