### PR TITLE
all: fix various spelling errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/config/config.go
+++ b/config/config.go
@@ -104,7 +104,7 @@ func Parse(c CfgMap) error {
 				value.Set(reflect.AppendSlice(value, reflect.ValueOf(strings.Split(envValue, ","))))
 
 			default:
-				return fmt.Errorf("unsuported type for %v: %v",
+				return fmt.Errorf("unsupported type for %v: %v",
 					k, reflect.TypeOf(v.Value).Elem().Kind())
 			}
 		}

--- a/database/bfgd/scripts/0004.sql
+++ b/database/bfgd/scripts/0004.sql
@@ -17,7 +17,7 @@ CREATE FUNCTION notify_event() RETURNS TRIGGER AS $$
 		data_old = row_to_json(OLD);
 		data_new = row_to_json(NEW);
 
-		-- Contruct the notification as a JSON string.
+		-- Construct the notification as a JSON string.
 		notification = json_build_object(
 			'table', TG_TABLE_NAME,
 			'action', TG_OP,

--- a/database/bfgd/scripts/0004.sql
+++ b/database/bfgd/scripts/0004.sql
@@ -1,4 +1,4 @@
--- Copyright (c) 2024 Hemi Labs, Inc.
+-- Copyright (c) 2024-2025 Hemi Labs, Inc.
 -- Use of this source code is governed by the MIT License,
 -- which can be found in the LICENSE file.
 

--- a/hemi/hemi.go
+++ b/hemi/hemi.go
@@ -124,7 +124,7 @@ func NewHeaderFromBytes(b []byte) (*Header, error) {
 		copy(h.StateRoot[:], b[29:61])
 		copy(h.EPHash[:], b[61:73])
 	default:
-		return nil, fmt.Errorf("unsuported version: %v", h.Version)
+		return nil, fmt.Errorf("unsupported version: %v", h.Version)
 	}
 	return h, nil
 }

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -145,7 +145,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		cmdsProcessed: prometheus.NewCounter(prometheus.CounterOpts{
 			Subsystem: promSubsystem,
 			Name:      "rpc_calls_total",
-			Help:      "The total number of succesful RPC commands",
+			Help:      "The total number of successful RPC commands",
 		}),
 		requestTimeout: defaultRequestTimeout,
 		bfgCallTimeout: 20 * time.Second,

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -370,7 +370,7 @@ func (b *btcNode) handleGetData(m *wire.MsgGetData) (*wire.MsgBlock, error) {
 
 	v := m.InvList[0]
 	if v.Type != wire.InvTypeBlock {
-		return nil, fmt.Errorf("unsuported data type: %v", v.Type)
+		return nil, fmt.Errorf("unsupported data type: %v", v.Type)
 	}
 
 	blk, ok := b.chain[v.Hash.String()]


### PR DESCRIPTION
1. **`config.go`**:
   - Corrected "unsuported" to "unsupported" in an error message.

2. **`0004.sql`**:
   - Fixed "Contruct" to "Construct" in a comment.

3. **`hemi.go`**:
   - Updated "unsuported" to "unsupported" in an error message.

4. **`bss.go`**:
   - Corrected "succesful" to "successful" in a help description.

5. **`tbcfork_test.go`**:
   - Fixed "unsuported" to "unsupported" in an error message.