### PR TITLE
remove un-used index

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	bfgdVersion = 16
+	bfgdVersion = 17
 
 	logLevel = "INFO"
 	verbose  = false

--- a/database/bfgd/scripts/0017.sql
+++ b/database/bfgd/scripts/0017.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 17;
+
+DROP INDEX btc_txid_unconfirmed;
+
+COMMIT;
+


### PR DESCRIPTION
**Summary**
since removing the "canonical chain" logic from bfg, we now handle what this index was doing within a db trigger (transaction) called clean_pop_basis.  leaving this index (the contraint) in would cause issues where ON UPDATE SET NULL may set more than one instance of the same pop basis to "unpublished", where it should in turn be deleted by the clean_pop_basis trigger.  but the index is throwing an error and not allowing that trigger to be hit

removing the index allows for the following to happen all in one transaction: any pop_bases that were re-orged off of the chain, set btc_block_hash to null (via ON UPDATE SET NULL) then delete them via clean_pop_basis.


**Changes**
remove index
