### PR TITLE
tbc: add keystone indexer to synced calculation

### DIFF
--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1293,7 +1293,7 @@ func (s *Server) indexKeystonesInBlocks(ctx context.Context, endHash *chainhash.
 		// Try not to overshoot the cache to prevent costly allocations
 		cp := len(kss) * 100 / s.cfg.MaxCachedKeystones
 		if bh.Height%10000 == 0 || cp > kssPercentage || blocksProcessed == 1 {
-			log.Infof("Tx indexer: %v tx cache %v%%", hh, cp)
+			log.Infof("Keystone indexer: %v tx cache %v%%", hh, cp)
 		}
 		if cp > kssPercentage {
 			// Set kssMax to the largest tx capacity seen
@@ -1535,7 +1535,7 @@ func (s *Server) KeystoneIndexer(ctx context.Context, endHash *chainhash.Hash) e
 	log.Tracef("KeystoneIndexer")
 	defer log.Tracef("KeystoneIndexer exit")
 
-	// XXX this is basically duplicate from TxIndexIsLinear
+	// XXX this is basically duplicate from KeystoneIndexIsLinear
 
 	if !s.cfg.HemiIndex {
 		return errors.New("disabled")

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -666,6 +666,12 @@ func (s *Server) promTx() float64 {
 	return deucalion.Uint64ToFloat(s.prom.syncInfo.Tx.Height)
 }
 
+func (s *Server) promKeystone() float64 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return deucalion.Uint64ToFloat(s.prom.syncInfo.Keystone.Height)
+}
+
 func (s *Server) promConnectedPeers() float64 {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -2416,6 +2422,14 @@ func (s *Server) Collectors() []prometheus.Collector {
 				Name:      "block_cache_items",
 				Help:      "Number of cached blocks",
 			}, s.promBlockCacheItems),
+		}
+		if s.cfg.HemiIndex {
+			s.promCollectors = append(s.promCollectors,
+				prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+					Namespace: s.cfg.PrometheusNamespace,
+					Name:      "keystone_sync_height",
+					Help:      "Height of the keystone indexer",
+				}, s.promKeystone))
 		}
 	}
 	return s.promCollectors


### PR DESCRIPTION
**Summary**
I forgot to add a check for keystone indexer when calculating synced.

**Changes**
Add logic to determine if chain is synced when keystone indexers are enabled.
