### PR TITLE
bfgd: reduce finality notification log to trace

### DIFF
--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1361,7 +1361,7 @@ func (s *Server) handleL2KeystonesRequest(ctx context.Context, l2kr *bfgapi.L2Ke
 
 func writeNotificationResponse(bws *bfgWs, response any) {
 	if err := bfgapi.Write(bws.requestContext, bws.conn, "", response); err != nil {
-		log.Errorf("handleBtcFinalityNotification write: %v %v", bws.addr, err)
+		log.Tracef("handleBtcFinalityNotification write: %v %v", bws.addr, err)
 	}
 }
 


### PR DESCRIPTION
**Summary**
Reduce the level of the `handleBtcFinalityNotification write: <ip> <err>` log to `trace`.

**Changes**
