### PR TITLE
revert: all: fix miscellaneous typos

### DIFF
--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -229,7 +229,7 @@ func (o Outpoint) TxIndexBytes() []byte {
 }
 
 func NewOutpoint(txid [32]byte, index uint32) (op Outpoint) {
-	op[0] = 'u' // match leveldb cache so that we prevent a bunch of bcopy
+	op[0] = 'u' // match leveldb cache so that we preven a bunch of bcopy
 	copy(op[1:33], txid[:])
 	binary.BigEndian.PutUint32(op[33:], index)
 	return

--- a/hemi/hemi.go
+++ b/hemi/hemi.go
@@ -172,10 +172,10 @@ func (a *L2KeystoneAbrev) Dump(w io.Writer) {
 	fmt.Fprintf(w, "===========================\n")
 }
 
-type RawAbbreviatedL2Keystone [L2KeystoneAbrevSize]byte
+type RawAbreviatedL2Keystone [L2KeystoneAbrevSize]byte
 
-func (a *L2KeystoneAbrev) Serialize() RawAbbreviatedL2Keystone {
-	var r RawAbbreviatedL2Keystone
+func (a *L2KeystoneAbrev) Serialize() RawAbreviatedL2Keystone {
+	var r RawAbreviatedL2Keystone
 	r[0] = a.Version
 	binary.BigEndian.PutUint32(r[1:5], a.L1BlockNumber)
 	binary.BigEndian.PutUint32(r[5:9], a.L2BlockNumber)
@@ -186,7 +186,7 @@ func (a *L2KeystoneAbrev) Serialize() RawAbbreviatedL2Keystone {
 	return r
 }
 
-func L2KeystoneAbrevDeserialize(r RawAbbreviatedL2Keystone) *L2KeystoneAbrev {
+func L2KeystoneAbrevDeserialize(r RawAbreviatedL2Keystone) *L2KeystoneAbrev {
 	a := L2KeystoneAbrev{}
 
 	a.Version = r[0]

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1093,7 +1093,7 @@ func (s *Server) handleWebsocketPublic(w http.ResponseWriter, r *http.Request) {
 	wao := &websocket.AcceptOptions{
 		CompressionMode:    websocket.CompressionContextTakeover,
 		OriginPatterns:     []string{"localhost:43111"},
-		InsecureSkipVerify: true, // XXX sucks but we don't want to whitelist every localhost port
+		InsecureSkipVerify: true, // XXX sucks but we don't want to whitelist every locahost port
 	}
 
 	conn, err := websocket.Accept(w, r, wao)


### PR DESCRIPTION
Reverts hemilabs/heminetwork#389

Does not compile. For some reason, CI was passing properly in the pull request but failed as soon as it was merged.
I will fix and re-open the pull request.