### PR TITLE
tbc: fix typo

### DIFF
--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -662,7 +662,7 @@ func (s *Server) handleBlockKeystoneByL2KeystoneAbrevHashRequest(ctx context.Con
 		}, e
 	}
 	return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{
-		L2KeystoneAbrev: hemi.L2KeystoneAbrevDeserialize(hemi.RawAbreviatedL2Keystone(ks.AbbreviatedKeystone)),
+		L2KeystoneAbrev: hemi.L2KeystoneAbrevDeserialize(hemi.RawAbbreviatedL2Keystone(ks.AbbreviatedKeystone)),
 		BtcBlockHash:    &ks.BlockHash,
 	}, nil
 }


### PR DESCRIPTION
Not sure how this snuck into main.

**Summary**
Typo that broke the tree. Sorry about that.

**Changes**
<!-- A list of changes made by this pull request. -->
