### PR TITLE
bfg, bss, popm, tbc: fix various typos

### DIFF
--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -43,7 +43,7 @@ import (
 )
 
 // XXX this code needs to be a bit smarter when syncing bitcoin. We should
-// return a "not ready" error whe that is the case.
+// return a "not ready" error when that is the case.
 
 type notificationId string
 

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -279,7 +279,7 @@ func NewServer(cfg *Config) (*Server, error) {
 
 	// XXX this is not right. NewServer should always return. The call to
 	// electrs.NewClient should be in Run. Or, electrs should be a service
-	// so that we can mirror the New/Run paradig, the New/Run paradigm,
+	// so that we can mirror the New/Run paradigm, the New/Run paradigm,
 	s.btcClient, err = electrs.NewClient(cfg.EXBTCAddress, &electrs.ClientOptions{
 		InitialConnections:  cfg.EXBTCInitialConns,
 		MaxConnections:      cfg.EXBTCMaxConns,
@@ -1516,7 +1516,7 @@ func (s *Server) handleStateUpdates(ctx context.Context, table string, action st
 	heightBefore := s.canonicalChainHeight
 	s.mtx.RUnlock()
 
-	// get the current canoncial chain height from the db
+	// get the current canonical chain height from the db
 	heightAfter, err := s.BtcBlockCanonicalHeight(ctx)
 	if err != nil {
 		log.Errorf("error occurred getting canonical height: %s", err)

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -328,7 +328,7 @@ func (s *Server) handleWebsocketRead(ctx context.Context, bws *bssWs) {
 		// base context in the callback thus if we shadow it we
 		// overwrite the correct context that has a reasonable timeout.
 		//
-		// Make dead sure all contexts folloing in this code are not
+		// Make dead sure all contexts following in this code are not
 		// shadowed.
 		switch cmd {
 		case bssapi.CmdPingRequest:
@@ -505,7 +505,7 @@ func (s *Server) handleBFGWebsocketReadUnauth(ctx context.Context, conn *protoco
 
 	log.Tracef("handleBFGWebsocketReadUnauth")
 	defer log.Tracef("handleBFGWebsocketReadUnauth exit")
-	s.setBFGConnected(conn.IsOnline()) // this is a bit inaccurate because on reconeect the code does not get past the ReadConn call. Moving the call into the for would be bouncing so let's assume bfg chatters soon so that the connection is marked online.
+	s.setBFGConnected(conn.IsOnline()) // this is a bit inaccurate because on reconnect the code does not get past the ReadConn call. Moving the call into the for would be bouncing so let's assume bfg chatters soon so that the connection is marked online.
 	for {
 		log.Infof("handleBFGWebsocketReadUnauth %v", "ReadConn")
 		cmd, rid, payload, err := bfgapi.ReadConn(ctx, conn)

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -670,7 +670,7 @@ func (m *Miner) checkForKeystones(ctx context.Context) error {
 	log.Tracef("Checking for new keystone headers...")
 
 	ghkr := &bfgapi.L2KeystonesRequest{
-		NumL2Keystones: 3, // XXX this needs to be a bit smarter, do this based on some sort of time calculation. Do keep it simple, we don't need keystones that are older than let's say, 30 minbutes.
+		NumL2Keystones: 3, // XXX this needs to be a bit smarter, do this based on some sort of time calculation. Do keep it simple, we don't need keystones that are older than let's say, 30 minutes.
 	}
 
 	res, err := m.callBFG(ctx, m.requestTimeout, ghkr)

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -345,10 +345,10 @@ func logMemStats() {
 	runtime.ReadMemStats(&mem)
 
 	// Go memory statistics are hard to interpret but the following list is
-	// an aproximation:
+	// an approximation:
 	//	Alloc is currently allocated memory
 	// 	TotalAlloc is all memory allocated over time
-	// 	Sys is basicaly a peak memory use
+	// 	Sys is basically a peak memory use
 	log.Infof("Alloc = %v, TotalAlloc = %v, Sys = %v, NumGC = %v\n",
 		humanize.IBytes(mem.Alloc),
 		humanize.IBytes(mem.TotalAlloc),
@@ -507,7 +507,7 @@ func (s *Server) fixupCache(ctx context.Context, b *btcutil.Block, utxos map[tbc
 
 // indexUtxosInBlocks indexes utxos from the last processed block until the
 // provided end hash, inclusive. It returns the number of blocks processed and
-// the last hash it has processedd.
+// the last hash it has processed.
 func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash, utxos map[tbcd.Outpoint]tbcd.CacheOutput) (int, *HashHeight, error) {
 	log.Tracef("indexUtxoBlocks")
 	defer log.Tracef("indexUtxoBlocks exit")
@@ -600,7 +600,7 @@ func (s *Server) indexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash
 
 // unindexUtxosInBlocks unindexes utxos from the last processed block until the
 // provided end hash, inclusive. It returns the number of blocks processed and
-// the last hash it has processedd.
+// the last hash it has processed.
 func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Hash, utxos map[tbcd.Outpoint]tbcd.CacheOutput) (int, *HashHeight, error) {
 	log.Tracef("unindexUtxoBlocks")
 	defer log.Tracef("unindexUtxoBlocks exit")
@@ -684,7 +684,7 @@ func (s *Server) UtxoIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Blo
 	log.Tracef("UtxoIndexerUnwind")
 	defer log.Tracef("UtxoIndexerUnwind exit")
 
-	// XXX dedup with TxIndexedWind; it's basically the same code but with the direction, start anf endhas flipped
+	// XXX dedup with TxIndexedWind; it's basically the same code but with the direction, start and endhas flipped
 	s.mtx.Lock()
 	if !s.indexing {
 		// XXX this prob should be an error but pusnish bad callers for now
@@ -879,7 +879,7 @@ func processTxs(blockHash *chainhash.Hash, txs []*btcutil.Tx, txsCache map[tbcd.
 
 // indexTxsInBlocks indexes txs from the last processed block until the
 // provided end hash, inclusive. It returns the number of blocks processed and
-// the last hash it has processedd.
+// the last hash it has processed.
 func (s *Server) indexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, txs map[tbcd.TxKey]*tbcd.TxValue) (int, *HashHeight, error) {
 	log.Tracef("indexTxsInBlocks")
 	defer log.Tracef("indexTxsInBlocks exit")
@@ -964,7 +964,7 @@ func (s *Server) indexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, 
 
 // unindexTxsInBlocks indexes txs from the last processed block until the
 // provided end hash, inclusive. It returns the number of blocks processed and
-// the last hash it has processedd.
+// the last hash it has processed.
 func (s *Server) unindexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash, txs map[tbcd.TxKey]*tbcd.TxValue) (int, *HashHeight, error) {
 	log.Tracef("unindexTxsInBlocks")
 	defer log.Tracef("unindexTxsInBlocks exit")

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -936,7 +936,7 @@ func (s *Server) handleBlockExpired(ctx context.Context, key any, value any) err
 	defer log.Tracef("handleBlockExpired exit")
 
 	// handleBlockExpired is called numerous times after SIGTERM. This call
-	//will fail with database closed error and is very loud.
+	// will fail with database closed error and is very loud.
 	select {
 	case <-ctx.Done():
 		return nil

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -936,7 +936,7 @@ func (s *Server) handleBlockExpired(ctx context.Context, key any, value any) err
 	defer log.Tracef("handleBlockExpired exit")
 
 	// handleBlockExpired is called numerous times after SIGTERM. This call
-	// wil fail with database closed error and is very loud.
+	//will fail with database closed error and is very loud.
 	select {
 	case <-ctx.Done():
 		return nil

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -275,7 +275,7 @@ func (b *btcNode) newSignedTxFromTx(name string, inTx *btcutil.Tx, amount btcuti
 
 		// only support one address for now
 		if len(as) != 1 {
-			return nil, fmt.Errorf("only 1 address suported in pkSctipt got %v", len(as))
+			return nil, fmt.Errorf("only 1 address supported in pkSctipt got %v", len(as))
 		}
 
 		// b.t.Logf("left %v value %v", left, value)


### PR DESCRIPTION
### Summary
Fixed grammatical and spelling errors in multiple service files.

### Changes
service/bfg/bfg.go

Fixed typo in comment: "whe" → "when".
Corrected "canoncial" → "canonical".
service/bss/bss.go

Fixed typo "folloing" → "following".
Corrected "reconeect" → "reconnect".
service/popm/popm.go

Fixed typo "minbutes" → "minutes".
service/tbc/crawler.go

Fixed spelling errors: "aproximation" → "approximation", "basicaly" → "basically".
Fixed repeated typo "processedd" → "processed".
Fixed typo "anf" → "and".
service/tbc/tbc.go

Fixed typo "wil" → "will".
service/tbc/tbcfork_test.go

Fixed typo "suported" → "supported".

###Notes
These corrections improve code readability and clarity without affecting functionality.