### PR TITLE
Clayton/localnode mainnet

### DIFF
--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /git
 ARG OP_GETH_CACHE_BREAK=12F2
 RUN git clone https://github.com/hemilabs/op-geth
 WORKDIR /git/op-geth
-RUN git checkout b531783
+RUN git checkout a5a12ae
 
 WORKDIR /git/op-geth
 
@@ -42,7 +42,7 @@ COPY --from=build_1 /git/op-geth /git/op-geth
 WORKDIR /git
 RUN git clone https://github.com/hemilabs/optimism
 WORKDIR /git/optimism
-RUN git checkout 4ab38c7
+RUN git checkout 3a56733
 RUN git submodule update --init --recursive
 RUN pnpm install
 RUN pnpm install:abigen

--- a/localnode/.gitignore
+++ b/localnode/.gitignore
@@ -1,2 +1,0 @@
-mainnet-genesis.json
-mainnet-rollup.json

--- a/localnode/docker-compose_mainnet.yml
+++ b/localnode/docker-compose_mainnet.yml
@@ -151,7 +151,7 @@ services:
 
   # Hemi L2 node
   op-geth-l2:
-    image: "ghcr.io/hemilabs/op-geth@sha256:43860fcb691c85e344bd17a660a19e254924953b2ccebe03f2d87d425eeaecbb" # 337407d
+    image: "ghcr.io/hemilabs/op-geth:a5a12ae@sha256:6e21d631b073a363ff859f4e82bbbcbde339801b5f5e5b9e42a5eb34081e054e"
     depends_on:
       geth-l1:
         condition: "service_started"
@@ -210,7 +210,7 @@ services:
 
   # Hemi op-node
   op-node:
-    image: "ghcr.io/hemilabs/op-node@sha256:8a190294b5ee6acc200e9cdfbef95143e604be2ba37b60e42e419118edc1f376" # 6b46f50
+    image: "ghcr.io/hemilabs/op-node:3a56733@sha256:99f692bd734f8fac8f6f2a531641cfdab11220c2aefa31a25525d916c96668c1"
     depends_on:
       geth-l1:
         condition: "service_started"

--- a/localnode/mainnet-entrypointl2.sh
+++ b/localnode/mainnet-entrypointl2.sh
@@ -5,9 +5,16 @@
 
 set -xe
 
-geth init --datadir /tmp/datadir/geth /tmp/genesis.json
+if [ -d "/tmp/datadir/geth" ]; then
+  echo "geth data dir exists, skipping genesis."
+else
+	geth init --datadir /tmp/datadir/geth /tmp/genesis.json
+fi
+
+
 
 geth \
+	--verbosity=5 \
 	--config=/tmp/l2-config.toml \
 	--http \
 	--http.corsdomain=* \
@@ -34,6 +41,10 @@ geth \
 	--override.ecotone=1725868497 \
 	--override.canyon=1725868497 \
 	--override.cancun=1725868497 \
-	--tbc.initheight=0 \
-	--tbc.leveldbhome=/tbcdata \
+	--tbc.leveldbhome=/tbcdata/data \
+    --hvm.headerdatadir=/tbcdata/headers \
+	--override.hvm0=1739286001 \
+    --tbc.network=mainnet \
+    --hvm.genesisheader=0000003efaaa2ba65de684c512bb67ef115298d1d16bcb49b16c02000000000000000000ed31a56788c4488afc4ee69e0791ad6aeeb9ea05f069e0fdde6159068765ad3f4128a96726770217e7f41c86 \
+    --hvm.genesisheight=883092 \
 	--bootnodes=enode://f591af0f0c25b794f008254262da082df23282f946c397128f4ca13f53842a09867cff8d8b68a39fddcfee885abc5b60ba21b98f88dcf7983a834c3ebc5b0254@34.13.162.152:30303,enode://e7970a29d89f8b158371a8d4aca909ee8c1c759e711547b797a6a6f01513c1e7c85121dd2600397ca20cebf3cea21025001be7c0f577b496caf32ea0433a1cfd@34.90.21.246:30303,enode://8eedf09af5bd8bb14479dfeabf522e6d80ac624d272d5ea87779121960c3f8fe4f16e6f1d344e92369a7e855e9e96bc003c8a31f82b73305b74684edc72ac90e@34.13.171.139:30303,enode://ebb5c1de8e66c27e57ddafbf9ef8d9da81e25dc68a5ff9d901a45e970671dd93f46d7b19b33624c23813281c924d27b4f8865d2c2daec858561a69706b04be7e@34.91.216.121:30303,enode://0a9d3aaadbc403d9034fc587836969ae14ca096a86bef7330f9c4da7a68113f07e70b9bc543b966ff545f0a4c5408d498b6105d0f37fd1f173599d6ac2baefd8@34.141.148.19:30303

--- a/localnode/mainnet-rollup.json
+++ b/localnode/mainnet-rollup.json
@@ -1,0 +1,34 @@
+{
+    "genesis": {
+      "l1": {
+        "hash": "0x29886abeccf2ce71915bf51a6895f49712eb604888472f048e4a87d25063cfa0",
+        "number": 20711548
+      },
+      "l2": {
+        "hash": "0x6b070d8b8f3bf81c9314ff863748e3db2662ecc0a8dbd4c394a8b646ae0c8b8b",
+        "number": 0
+      },
+      "l2_time": 1725866711,
+      "system_config": {
+        "batcherAddr": "0x65115c6d23274e0a29a63b69130efe901aa52e7a",
+        "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
+        "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
+        "gasLimit": 30000000
+      }
+    },
+    "block_time": 12,
+    "max_sequencer_drift": 600,
+    "seq_window_size": 3600,
+    "channel_timeout": 300,
+    "l1_chain_id": 1,
+    "l2_chain_id": 43111,
+    "regolith_time": 0,
+    "batch_inbox_address": "0xff00000000000000000000000000000000043111",
+    "deposit_contract_address": "0x39a0005415256b9863afe2d55edcf75ecc3a4d7e",
+    "l1_system_config_address": "0x5ae68684d9179a8053883f1df599ea7fb35303c3",
+    "protocol_versions_address": "0x0000000000000000000000000000000000000000",
+    "da_challenge_address": "0x0000000000000000000000000000000000000000",
+    "da_challenge_window": 0,
+    "da_resolve_window": 0,
+    "use_plasma": false
+  }


### PR DESCRIPTION
**Summary**
update mainnet localnode compose + localnet to the latest op-geth and op-node

added needed flags, files, etc. for hvm phase 0

NOTE: this breaks localnet at op-geth+tbc startup on blank directory

**Changes**
see summary
