### PR TITLE
docker: add hemictl image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -284,6 +284,36 @@ dockers:
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
 
+  # hemictl amd64
+  - id: "hemictl-amd64"
+    goos: "linux"
+    goarch: "amd64"
+    dockerfile: "docker/hemictl/goreleaser.Dockerfile"
+    use: "buildx"
+    image_templates:
+      - "hemilabs/hemictl:{{ .Version }}-amd64"
+      - "ghcr.io/hemilabs/hemictl:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=VCS_REF={{ .FullCommit }}"
+      - "--build-arg=BUILD_DATE={{ .Date }}"
+
+  # hemictl arm64
+  - id: "hemictl-arm64"
+    goos: "linux"
+    goarch: "arm64"
+    dockerfile: "docker/hemictl/goreleaser.Dockerfile"
+    use: "buildx"
+    image_templates:
+      - "hemilabs/hemictl:{{ .Version }}-arm64"
+      - "ghcr.io/hemilabs/hemictl:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=VCS_REF={{ .FullCommit }}"
+      - "--build-arg=BUILD_DATE={{ .Date }}"
+
   # bssd amd64
   - id: "bssd-amd64"
     goos: "linux"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Hemi Labs, Inc.
+# Copyright (c) 2024-2025 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 

--- a/docker/hemictl/Dockerfile
+++ b/docker/hemictl/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Hemi Labs, Inc.
+# Copyright (c) 2025 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 

--- a/docker/hemictl/Dockerfile
+++ b/docker/hemictl/Dockerfile
@@ -1,0 +1,67 @@
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+# Build stage
+FROM golang:1.23-alpine3.20@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
+
+ARG GO_LDFLAGS
+
+# Add ca-certificates, timezone data, make and git
+RUN apk --no-cache add --update ca-certificates tzdata make git
+
+# Create non-root user
+RUN addgroup --gid 65532 hemictl && \
+    adduser --disabled-password --gecos "" \
+        --home "/etc/hemictl/" --shell "/sbin/nologin" \
+        -G hemictl --uid 65532 hemictl
+
+WORKDIR /build/
+
+COPY Makefile .
+COPY go.mod .
+COPY go.sum .
+RUN make deps
+
+COPY . .
+RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" hemictl
+
+# Run stage
+FROM scratch
+
+# Build metadata
+ARG VERSION
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Hemi Labs" \
+      org.opencontainers.image.url="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.source="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="Hemi Labs" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="Hemictl" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Hemictl" \
+      org.label-schema.url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vendor="Hemi Labs" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"
+
+# Copy files
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /build/bin/hemictl /usr/local/bin/hemictl
+
+# Environment variables
+ENV HEMICTL_BSS_URL=""
+ENV HEMICTL_LOG_LEVEL=""
+
+USER hemictl:hemictl
+WORKDIR /etc/hemictl/
+ENTRYPOINT ["/usr/local/bin/hemictl"]

--- a/docker/hemictl/goreleaser.Dockerfile
+++ b/docker/hemictl/goreleaser.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Hemi Labs, Inc.
+# Copyright (c) 2025 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 

--- a/docker/hemictl/goreleaser.Dockerfile
+++ b/docker/hemictl/goreleaser.Dockerfile
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+# Build stage
+FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5 AS builder
+
+# Add ca-certificates, timezone data
+RUN apk --no-cache add --update ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup --gid 65532 hemictl && \
+    adduser --disabled-password --gecos "" \
+        --home "/etc/hemictl/" --shell "/sbin/nologin" \
+        -G hemictl --uid 65532 hemictl
+
+# Run stage
+FROM scratch
+
+# Build metadata
+ARG VERSION
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Hemi Labs" \
+      org.opencontainers.image.url="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.source="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="Hemi Labs" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="Hemictl" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Hemictl" \
+      org.label-schema.url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vendor="Hemi Labs" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"
+
+# Copy files
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY hemictl /usr/local/bin/hemictl
+
+# Environment variables
+ENV HEMICTL_BSS_URL=""
+ENV HEMICTL_LOG_LEVEL=""
+
+USER hemictl:hemictl
+WORKDIR /etc/hemictl/
+ENTRYPOINT ["/usr/local/bin/hemictl"]


### PR DESCRIPTION
**Summary**
add hemictl image for hemictl via regular Docker and goreleaser

updated goreleaser workflow to include hemictl

**Changes**
see summary
