### PR TITLE
fragile test fixes

### DIFF
--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -41,9 +41,6 @@ jobs:
       - name: "run localnet"
         run: HVM_PHASE0_TIMESTAMP=$(date --date='+120 seconds' +%s) docker compose -f ./e2e/docker-compose.yml up -d
 
-      - name: "kill an op-node after 15 seconds, then wait 3 minutes (the healthcheck interval + time for another sequencer to take over)"
-        run: sleep 15 && docker compose -f ./e2e/docker-compose.yml down op-node && sleep 180
-
       - name: "get localnet stats"
         working-directory: ./e2e/monitor
         # XXX should this be a make command?

--- a/e2e/deploy-config.json
+++ b/e2e/deploy-config.json
@@ -1,7 +1,7 @@
 {
     "l1ChainID": 1337,
     "l2ChainID": 901,
-    "l2BlockTime": 2,
+    "l2BlockTime": 1,
     "maxSequencerDrift": 300,
     "sequencerWindowSize": 200,
     "channelTimeout": 120,

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -3222,6 +3222,8 @@ func TestNotifyOnL2KeystonesBFGClientsViaOtherBFG(t *testing.T) {
 }
 
 func TestOtherBFGSavesL2KeystonesOnNotifications(t *testing.T) {
+	t.Parallel()
+
 	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
 	defer func() {
 		db.Close()
@@ -3309,6 +3311,14 @@ func TestOtherBFGSavesL2KeystonesOnNotifications(t *testing.T) {
 	}()
 
 	wg.Wait()
+
+	// give a few seconds for the notification to be processed in the other
+	// bfg (saving keystones etc.)
+	select {
+	case <-time.After(5 * time.Second):
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
 
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
**Summary**
a few fragile test fixes

**Changes**
as of now, op-conductor is not hvm-aware so we do not use it in higher environments.  there is a problematic step in localnet testing that is meant to test some op-conductor functionality.  this slows down the tests, is incorrect, and is inconsistent.  remove until we update op-conductor, at which time we will add an appropriate sequencer failover test

decrease l2 block time to speed up testing

a test that tests two bfgs doesn't wait for the insertion of l2 keystones, add that wait and add t.Parallel() so it doesn't block other parallel tests.
