### PR TITLE
all: fix int64 and uint64 casting to int

### DIFF
--- a/cmd/btctool/blockstream/blockstream.go
+++ b/cmd/btctool/blockstream/blockstream.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -40,7 +40,7 @@ func Tip(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("request: %w", err)
 	}
-	height, err := strconv.ParseInt(string(b), 10, 64)
+	height, err := strconv.ParseInt(string(b), 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("parse uint: %w", err)
 	}

--- a/cmd/btctool/blockstream/blockstream.go
+++ b/cmd/btctool/blockstream/blockstream.go
@@ -40,9 +40,12 @@ func Tip(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("request: %w", err)
 	}
-	height, err := strconv.ParseInt(string(b), 10, 32)
+	height, err := strconv.ParseInt(string(b), 10, 0)
 	if err != nil {
 		return 0, fmt.Errorf("parse uint: %w", err)
+	}
+	if height < 0 {
+		return 0, fmt.Errorf("parse uint: unexpected negative value")
 	}
 
 	return int(height), nil

--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -642,7 +642,7 @@ func _main() error {
 		blockCount := int(1024)
 		count := args["count"]
 		if count != "" {
-			bc, err := strconv.ParseInt(count, 10, 64)
+			bc, err := strconv.ParseInt(count, 10, 32)
 			if err != nil {
 				return fmt.Errorf("count: %w", err)
 			}
@@ -661,7 +661,7 @@ func _main() error {
 				return fmt.Errorf("tip: %w", err)
 			}
 		} else {
-			e, err := strconv.ParseInt(end, 10, 64)
+			e, err := strconv.ParseInt(end, 10, 32)
 			if err != nil {
 				return fmt.Errorf("end: %w", err)
 			}

--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -642,7 +642,7 @@ func _main() error {
 		blockCount := int(1024)
 		count := args["count"]
 		if count != "" {
-			bc, err := strconv.ParseInt(count, 10, 32)
+			bc, err := strconv.ParseInt(count, 10, 0)
 			if err != nil {
 				return fmt.Errorf("count: %w", err)
 			}
@@ -661,7 +661,7 @@ func _main() error {
 				return fmt.Errorf("tip: %w", err)
 			}
 		} else {
-			e, err := strconv.ParseInt(end, 10, 32)
+			e, err := strconv.ParseInt(end, 10, 0)
 			if err != nil {
 				return fmt.Errorf("end: %w", err)
 			}

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -415,8 +416,11 @@ func tbcdb() error {
 		maxCache := args["maxcache"]
 		var mc uint64
 		if maxCache != "" {
-			if mc, err = strconv.ParseUint(maxCache, 10, 32); err != nil {
+			if mc, err = strconv.ParseUint(maxCache, 10, 64); err != nil {
 				return fmt.Errorf("maxCache: %w", err)
+			}
+			if mc > math.MaxInt32 {
+				return fmt.Errorf("maxcache exceeds max int value")
 			}
 			cfg.MaxCachedTxs = int(mc)
 		}
@@ -438,8 +442,11 @@ func tbcdb() error {
 		maxCache := args["maxcache"]
 		var mc uint64
 		if maxCache != "" {
-			if mc, err = strconv.ParseUint(maxCache, 10, 32); err != nil {
+			if mc, err = strconv.ParseUint(maxCache, 10, 64); err != nil {
 				return fmt.Errorf("maxCache: %w", err)
+			}
+			if mc > math.MaxInt32 {
+				return fmt.Errorf("maxcache exceeds max int value")
 			}
 			cfg.MaxCachedTxs = int(mc)
 		}

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -13,7 +13,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -414,13 +413,10 @@ func tbcdb() error {
 		}
 
 		maxCache := args["maxcache"]
-		var mc uint64
 		if maxCache != "" {
-			if mc, err = strconv.ParseUint(maxCache, 10, 64); err != nil {
+			mc, err := strconv.ParseInt(maxCache, 10, 0)
+			if err != nil {
 				return fmt.Errorf("maxCache: %w", err)
-			}
-			if mc > math.MaxInt32 {
-				return fmt.Errorf("maxcache exceeds max int value")
 			}
 			cfg.MaxCachedTxs = int(mc)
 		}
@@ -440,13 +436,10 @@ func tbcdb() error {
 		}
 
 		maxCache := args["maxcache"]
-		var mc uint64
 		if maxCache != "" {
-			if mc, err = strconv.ParseUint(maxCache, 10, 64); err != nil {
+			mc, err := strconv.ParseInt(maxCache, 10, 0)
+			if err != nil {
 				return fmt.Errorf("maxCache: %w", err)
-			}
-			if mc > math.MaxInt32 {
-				return fmt.Errorf("maxcache exceeds max int value")
 			}
 			cfg.MaxCachedTxs = int(mc)
 		}

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -415,7 +415,7 @@ func tbcdb() error {
 		maxCache := args["maxcache"]
 		var mc uint64
 		if maxCache != "" {
-			if mc, err = strconv.ParseUint(maxCache, 10, 64); err != nil {
+			if mc, err = strconv.ParseUint(maxCache, 10, 32); err != nil {
 				return fmt.Errorf("maxCache: %w", err)
 			}
 			cfg.MaxCachedTxs = int(mc)
@@ -438,7 +438,7 @@ func tbcdb() error {
 		maxCache := args["maxcache"]
 		var mc uint64
 		if maxCache != "" {
-			if mc, err = strconv.ParseUint(maxCache, 10, 64); err != nil {
+			if mc, err = strconv.ParseUint(maxCache, 10, 32); err != nil {
 				return fmt.Errorf("maxCache: %w", err)
 			}
 			cfg.MaxCachedTxs = int(mc)

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1560,7 +1560,7 @@ func (l *ldb) UtxosByScriptHash(ctx context.Context, sh tbcd.ScriptHash, start u
 		copy(txId[:], it.Key()[33:65])
 		utxos = append(utxos, tbcd.NewUtxo(txId, value, index))
 
-		if len(utxos) >= int(count) {
+		if uint64(len(utxos)) >= count {
 			break
 		}
 	}


### PR DESCRIPTION
**Summary**
Github detected various CodeQL vulnerabilites related to a few instances in the code where strings were getting parsed to int64 and uint64, which were later getting cast to int without checking the upper bounds.

**Changes**
Changed to parse these with 32 bits explicitly, so at the very least an error will return if the parsed string exceeds the int32 bounds, rather than a potential undetected overflow in 32-bit architectures.