### PR TITLE
Fix spelling errors

### DIFF
--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -161,7 +161,7 @@ func TestDatabasePostgres(t *testing.T) {
 		cleanup()
 	}()
 
-	// Version, no need to verify because it is explicitely tested on db open
+	// Version, no need to verify because it is explicitly tested on db open
 	version, err := db.Version(ctx)
 	if err != nil {
 		t.Fatalf("Failed to get Version: %v", err)
@@ -475,7 +475,7 @@ func TestDatabaseNotification(t *testing.T) {
 		Header: fillOutBytes("myHeAdEr", 80),
 		Height: 1,
 	}
-	// Register notfication
+	// Register notification
 	ctx, cancel := context.WithTimeout(pctx, 5*time.Second)
 	defer cancel()
 	b := &btcBlocksNtfn{

--- a/database/database.go
+++ b/database/database.go
@@ -146,7 +146,7 @@ func (ba ByteArray) Value() (driver.Value, error) {
 	return []byte(ba), nil
 }
 
-// // XXX figure out why this doens't work
+// // XXX figure out why this doesn't work
 // func (ba *ByteArray) Value() (driver.Value, error) {
 //	return *ba, nil
 // }

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -380,10 +380,10 @@ func logMemStats() {
 	runtime.ReadMemStats(&mem)
 
 	// Go memory statistics are hard to interpret but the following list is
-	// an aproximation:
+	// an approximation:
 	//	Alloc is currently allocated memory
 	// 	TotalAlloc is all memory allocated over time
-	// 	Sys is basicaly a peak memory use
+	// 	Sys is basically a peak memory use
 	log.Infof("Alloc = %v, TotalAlloc = %v, Sys = %v, NumGC = %v\n",
 		humanize.IBytes(mem.Alloc),
 		humanize.IBytes(mem.TotalAlloc),
@@ -1021,7 +1021,7 @@ func (s *Server) unindexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash
 			return 0, last, fmt.Errorf("process txs %v: %w", hh, err)
 		}
 
-		// This is probably not needed here since we alreayd dealt with
+		// This is probably not needed here since we already dealt with
 		// it via the utxo unindexer but since it will be mostly a
 		// no-op just go ahead.
 		//if s.cfg.MempoolEnabled {


### PR DESCRIPTION
- Fixed wording in `database_ext_test.go`:  
  - `"explicitely"` → `"explicitly"`  
  - `"notfication"` → `"notification"`  
  
- Improved clarity in `database.go`:  
  - `"doens't"` → `"doesn't"`  
  
- Adjusted comments in `crawler.go`:  
  - `"aproximation"` → `"approximation"`  
  - `"basicaly"` → `"basically"`  
  - `"alreayd"` → `"already"`  
