### PR TITLE
Updated Discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Please **do not** use this template for questions.
-        Have a question or need help? Join our [Discord server](https://discord.gg/8z9antYtus)!
+        Have a question or need help? Join our [Discord server](https://discord.com/invite/hemixyz)!
 
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: "Discord"
-    url: "https://discord.gg/8z9antYtus"
+    url: "https://discord.com/invite/hemixyz"
     about: "Have a question or need help? Join our Discord server!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Please **do not** use this template for questions.
-        Have a question or need help? Join our [Discord server](https://discord.gg/8z9antYtus)!
+        Have a question or need help? Join our [Discord server](https://discord.com/invite/hemixyz)!
 
   - type: checkboxes
     attributes:


### PR DESCRIPTION
### **Summary**

Updated Discord links in issue templates, replacing the old URL (`discord.gg/8z9antYtus`) with the new one (`discord.com/invite/hemixyz`).

### **Changes**

- Updated the Discord link in **bug_report.yml**.
- Updated the Discord link in **config.yml**.
- Updated the Discord link in **feature_request.yml**.

These changes ensure that users are redirected to the correct and updated Discord server.

