### PR TITLE
bfg: take into account l2 keystones that are more final than 100

### DIFF
--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -639,7 +639,7 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 							= pop_basis.l2_keystone_abrev_hash
 			
 					AND ll.l2_block_number >= l2_keystones_lowest_btc_block.l2_block_number
-					AND ll.l2_keystone_abrev_hash IS NOT NULL
+					WHERE ll.l2_keystone_abrev_hash IS NOT NULL
 					ORDER BY height ASC LIMIT 1
 				)), 0),
 			COALESCE((SELECT height FROM btc_blocks ORDER BY height DESC LIMIT 1),0)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -594,12 +594,7 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 	}
 
 	sql := `
-		WITH relevant_pop_basis AS (
-			SELECT l2_keystone_abrev_hash, btc_block_hash FROM pop_basis WHERE btc_block_hash = ANY(
-				SELECT hash FROM btc_blocks ORDER BY height DESC LIMIT 100
-			)
-		),
-		l2_keystones_lowest_btc_block AS (
+		WITH l2_keystones_lowest_btc_block AS (
 			SELECT 
 			l2_keystones.l2_keystone_abrev_hash,
 			l2_keystones.l1_block_number,
@@ -638,10 +633,10 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 				FROM 
 				(
 					SELECT height FROM btc_blocks
-						LEFT JOIN relevant_pop_basis ON relevant_pop_basis.btc_block_hash 
+						LEFT JOIN pop_basis ON pop_basis.btc_block_hash 
 							= btc_blocks.hash
 						LEFT JOIN l2_keystones ll ON ll.l2_keystone_abrev_hash 
-							= relevant_pop_basis.l2_keystone_abrev_hash
+							= pop_basis.l2_keystone_abrev_hash
 			
 					AND ll.l2_block_number >= l2_keystones_lowest_btc_block.l2_block_number
 					AND ll.l2_keystone_abrev_hash IS NOT NULL

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -644,7 +644,6 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 							= relevant_pop_basis.l2_keystone_abrev_hash
 			
 					AND ll.l2_block_number >= l2_keystones_lowest_btc_block.l2_block_number
-					WHERE height > (SELECT height FROM btc_blocks ORDER BY height DESC LIMIT 1) - 100
 					AND ll.l2_keystone_abrev_hash IS NOT NULL
 					ORDER BY height ASC LIMIT 1
 				)), 0),

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2946,6 +2946,107 @@ func TestGetFinalitiesByL2KeystoneBFG(t *testing.T) {
 	}
 }
 
+func TestGetFinalitiesByL2KeystoneBFGVeryOld(t *testing.T) {
+	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	defer func() {
+		db.Close()
+		sdb.Close()
+		cleanup()
+	}()
+
+	ctx, cancel := defaultTestContext()
+	defer cancel()
+
+	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1000)
+
+	height := 100
+	createBtcBlock(ctx, t, db, 1, height, []byte{}, 1)
+	// get the btc block's finality, this is the only one that
+	// we care about in this test
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l2Keystones := []hemi.L2Keystone{}
+	for _, r := range recentFinalities {
+		l, err := hemi.L2BTCFinalityFromBfgd(&r, 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		l2Keystones = append(l2Keystones, l.L2Keystone)
+	}
+
+	finalityRequest := bfgapi.BTCFinalityByKeystonesRequest{
+		L2Keystones: l2Keystones,
+	}
+
+	// create more than 100 blocks to achieve max finality threshold of 100
+	for height < 300 {
+		height++
+		createBtcBlock(ctx, t, db, 1, height, []byte{}, 1)
+	}
+
+	c, _, err := websocket.Dial(ctx, bfgWsurl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.CloseNow()
+
+	assertPing(ctx, t, c, bfgapi.CmdPingRequest)
+
+	bws := &bfgWs{
+		conn: protocol.NewWSConn(c),
+	}
+
+	time.Sleep(2 * time.Second)
+
+	err = bfgapi.Write(ctx, bws.conn, "someid", finalityRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var v protocol.Message
+
+	for {
+		err = wsjson.Read(ctx, c, &v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if v.Header.Command == bfgapi.CmdBTCFinalityByKeystonesResponse {
+			break
+		}
+	}
+
+	expectedResponse := []hemi.L2BTCFinality{}
+	for _, r := range recentFinalities {
+		f, err := hemi.L2BTCFinalityFromBfgd(&r, 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// expect finality of 100, this is the max
+		f.BTCFinality = 100
+		expectedResponse = append(expectedResponse, *f)
+	}
+
+	expectedApiResponse := bfgapi.BTCFinalityByRecentKeystonesResponse{
+		L2BTCFinalities: expectedResponse,
+	}
+
+	finalityResponse := bfgapi.BTCFinalityByRecentKeystonesResponse{}
+	err = json.Unmarshal(v.Payload, &finalityResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := deep.Equal(expectedApiResponse, finalityResponse)
+	if len(diff) > 0 {
+		t.Fatalf("unexpected diff %s", diff)
+	}
+}
+
 // TestNotifyOnNewBtcBlockBFGClients tests that upon getting a new btc block,
 // in this case from (mock) electrs, that a new btc block
 // notification will be sent to all clients connected to BFG


### PR DESCRIPTION
**Summary**
there is a bug in the postgres query that only takes into account the first 100 bitcoin blocks when determining effective height, so if a keystone was published older than the first 100 it wouldn't get counted in effective height.

remove this clause; I am not sure why it was introduced but it is likely fallout from when trying to optimize these queries

add a test that should have caught this

**Changes**
see summary
