### PR TITLE
api/auth, e2e, popm: fix minor spelling mistakes

### DIFF
--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -55,7 +55,7 @@ func MustNewAuthenticateMessage(message string) *AuthenticateMessage {
 
 func NewAuthenticateFromBytes(b []byte) (*AuthenticateMessage, error) {
 	if len(b) < nonceLength {
-		return nil, errors.New("authenicate message too short")
+		return nil, errors.New("authenticate message too short")
 	}
 	am := &AuthenticateMessage{}
 	copy(am.Nonce[0:], b[:nonceLength])

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2075,7 +2075,7 @@ loop:
 
 // TestPopPayouts ensures that when querying for pop payouts by L2Keystone,
 // we can filter out pop payouts not in that keystone and we can reduce
-// mulitiple pop txs by the same miner to a single pop payout
+// multiple pop txs by the same miner to a single pop payout
 // 1 create all of the pop txs via the pop_basis table, there will be (4) total,
 // of those (1) will be filtered out, (2) will be for one pop miner, the remaining
 // (1) will be for the other

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -340,7 +340,7 @@ func createTx(l2Keystone *hemi.L2Keystone, btcHeight uint64, utxo *bfgapi.Bitcoi
 
 // XXX this function is not right. Clean it up and ensure we make this in at
 // least 2 functions. This needs to create and sign a tx, and then broadcast
-// seperately. Also utxo picker needs to be fixed. Don't return a fake utxo
+// separately. Also utxo picker needs to be fixed. Don't return a fake utxo
 // etc. Fix fee estimation.
 func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 	log.Infof("Mining an L2 keystone at height %d...", ks.L2BlockNumber)


### PR DESCRIPTION
"authenicate message too short" to "authenticate message too short".
"mulitiple" to "multiple".
"seperately" to "separately".