### PR TITLE
popm: fix fragile test

### DIFF
--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -1339,6 +1339,7 @@ func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string, keyst
 		}
 
 		for {
+			time.Sleep(50 * time.Millisecond)
 			command, id, _, err := bfgapi.Read(ctx, conn)
 			if err != nil {
 				if !errors.Is(ctx.Err(), context.Canceled) {


### PR DESCRIPTION
**Summary**
The test `TestConnectToBFGAndPerformMineALot` will at times fail with a race condition. After investigating, it _appears_ that since the BFG used in that test is a Mock BFG (which responds to requests much faster than a normal BFG), it will at times respond to a request before the pop miner is ready to receive it, after which the pop miner will get stuck in the mining process for that particular keystone until a timeout occurs. 

This does mean other tests using the Mock BFG might have also had this issue, but since it is rare, the one failing was usually this specific test, as it mines the most keystones.

The easiest way to fix this issue is to simply add a slight delay before each response. However, it may be worthwhile to investigate this problem further since it appears the pop miner will remain stuck even if the Mock BFG retries to send the response multiple times.

**Changes**
Added a slight timeout before each response in the Mock BFG code.
