### PR TITLE
tbc: reduce threads used by fixup, misc improvements

### DIFF
--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -123,6 +123,7 @@ type Database interface {
 	BalanceByScriptHash(ctx context.Context, sh ScriptHash) (uint64, error)
 	BlockInTxIndex(ctx context.Context, hash *chainhash.Hash) (bool, error)
 	ScriptHashByOutpoint(ctx context.Context, op Outpoint) (*ScriptHash, error)
+	ScriptHashesByOutpoint(ctx context.Context, ops []*Outpoint, result func(Outpoint, ScriptHash) error) error
 	UtxosByScriptHash(ctx context.Context, sh ScriptHash, start uint64, count uint64) ([]Utxo, error)
 	UtxosByScriptHashCount(ctx context.Context, sh ScriptHash) (uint64, error)
 
@@ -365,7 +366,7 @@ func NewScriptHashFromScript(script []byte) (scriptHash ScriptHash) {
 }
 
 func NewScriptHashFromBytes(hash []byte) (scriptHash ScriptHash, err error) {
-	if len(hash) != 32 {
+	if len(hash) != sha256.Size {
 		err = errors.New("invalid script hash length")
 		return
 	}

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1607,8 +1607,7 @@ func (l *ldb) ScriptHashesByOutpoint(ctx context.Context, ops []*tbcd.Outpoint, 
 		if err != nil {
 			return fmt.Errorf("script hash %x: %w", ops[k], err)
 		}
-		err = result(*ops[k], sh)
-		if err != nil {
+		if err = result(*ops[k], sh); err != nil {
 			return fmt.Errorf("script hashes callback %x: %w", ops[k], err)
 		}
 	}

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1591,6 +1591,31 @@ func (l *ldb) BlockInTxIndex(ctx context.Context, hash *chainhash.Hash) (bool, e
 	}
 }
 
+func (l *ldb) ScriptHashesByOutpoint(ctx context.Context, ops []*tbcd.Outpoint, result func(tbcd.Outpoint, tbcd.ScriptHash) error) error {
+	log.Tracef("ScriptHashesByOutpoint")
+	defer log.Tracef("ScriptHashesByOutpoint exit")
+
+	uDB := l.pool[level.OutputsDB]
+
+	for k := range ops {
+		scriptHash, err := uDB.Get(ops[k][:], nil)
+		if err != nil {
+			// not found, skip
+			continue
+		}
+		sh, err := tbcd.NewScriptHashFromBytes(scriptHash)
+		if err != nil {
+			return fmt.Errorf("script hash %x: %w", ops[k], err)
+		}
+		err = result(*ops[k], sh)
+		if err != nil {
+			return fmt.Errorf("script hashes callback %x: %w", ops[k], err)
+		}
+	}
+
+	return nil
+}
+
 func (l *ldb) ScriptHashByOutpoint(ctx context.Context, op tbcd.Outpoint) (*tbcd.ScriptHash, error) {
 	log.Tracef("ScriptHashByOutpoint")
 	defer log.Tracef("ScriptHashByOutpoint exit")

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -360,17 +360,12 @@ func (s *Server) nextCanonicalBlockheader(ctx context.Context, endHash *chainhas
 // blockheader is part of the block we do this double database retrieval to
 // ensure both exist.
 func (s *Server) headerAndBlock(ctx context.Context, hash *chainhash.Hash) (*tbcd.BlockHeader, *btcutil.Block, error) {
-	// XXX move this into the database.
 	bh, err := s.db.BlockHeaderByHash(ctx, hash)
 	if err != nil {
 		return nil, nil, fmt.Errorf("block header %v: %w", hash, err)
 	}
 	b, err := s.db.BlockByHash(ctx, &bh.Hash)
 	if err != nil {
-		// XXX this should not happen antonio; block was mined and should thus exist
-		if true {
-			panic(err)
-		}
 		return nil, nil, fmt.Errorf("block by hash %v: %w", bh, err)
 	}
 

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -572,6 +572,7 @@ func (s *Server) fixupCacheSerial(ctx context.Context, b *btcutil.Block, utxos m
 
 func (s *Server) fixupCacheBatched(ctx context.Context, b *btcutil.Block, utxos map[tbcd.Outpoint]tbcd.CacheOutput) error {
 	ops := make([]*tbcd.Outpoint, 0, 8192)
+	defer clear(ops)
 	for _, tx := range b.Transactions() {
 		for _, txIn := range tx.MsgTx().TxIn {
 			if blockchain.IsCoinBase(tx) {

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -494,7 +494,7 @@ func (s *Server) unprocessUtxos(ctx context.Context, txs []*btcutil.Tx, utxos ma
 func (s *Server) fetchOPParallel(ctx context.Context, w *sync.WaitGroup, op tbcd.Outpoint, utxos map[tbcd.Outpoint]tbcd.CacheOutput) {
 	defer w.Done()
 
-	pkScript, err := s.db.ScriptHashByOutpoint(ctx, op)
+	sh, err := s.db.ScriptHashByOutpoint(ctx, op)
 	if err != nil {
 		// This happens when a transaction is created and spent in the
 		// same block.
@@ -504,7 +504,7 @@ func (s *Server) fetchOPParallel(ctx context.Context, w *sync.WaitGroup, op tbcd
 		return
 	}
 	s.mtx.Lock()
-	utxos[op] = tbcd.NewDeleteCacheOutput(*pkScript, op.TxIndex())
+	utxos[op] = tbcd.NewDeleteCacheOutput(*sh, op.TxIndex())
 	s.mtx.Unlock()
 }
 
@@ -551,14 +551,14 @@ func (s *Server) fixupCacheSerial(ctx context.Context, b *btcutil.Block, utxos m
 				continue
 			}
 
-			pkScript, err := s.db.ScriptHashByOutpoint(ctx, op)
+			sh, err := s.db.ScriptHashByOutpoint(ctx, op)
 			if err != nil {
 				// This happens when a transaction is created
 				// and spent in the same block.
 				continue
 			}
 			// utxo not found, retrieve pkscript from database.
-			utxos[op] = tbcd.NewDeleteCacheOutput(*pkScript, op.TxIndex())
+			utxos[op] = tbcd.NewDeleteCacheOutput(*sh, op.TxIndex())
 		}
 	}
 

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -565,7 +565,7 @@ func (s *Server) fixupCacheSerial(ctx context.Context, b *btcutil.Block, utxos m
 }
 
 func (s *Server) fixupCacheBatched(ctx context.Context, b *btcutil.Block, utxos map[tbcd.Outpoint]tbcd.CacheOutput) error {
-	ops := make([]*tbcd.Outpoint, 0, 8192)
+	ops := make([]*tbcd.Outpoint, 0, 16384)
 	defer clear(ops)
 	for _, tx := range b.Transactions() {
 		for _, txIn := range tx.MsgTx().TxIn {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -89,6 +89,8 @@ var (
 		Hash:   *chaincfg.RegressionNetParams.GenesisHash,
 		Height: 0,
 	}
+
+	fixupStrategy = 1 // Do not touch unless your name is marco
 )
 
 func init() {
@@ -145,6 +147,9 @@ type Server struct {
 	wg  sync.WaitGroup
 
 	cfg *Config
+
+	// fixup cache strategy
+	fixupCache func(ctx context.Context, b *btcutil.Block, utxos map[tbcd.Outpoint]tbcd.CacheOutput) error
 
 	// stats
 	printTime      time.Time
@@ -287,6 +292,15 @@ func NewServer(cfg *Config) (*Server, error) {
 			return nil, err
 		}
 		s.pm = pm
+	}
+
+	switch fixupStrategy {
+	case 0:
+		s.fixupCache = s.fixupCacheParallel
+	case 1:
+		s.fixupCache = s.fixupCacheSerial
+	case 2:
+		s.fixupCache = s.fixupCacheBatched
 	}
 
 	return s, nil

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -90,7 +90,7 @@ var (
 		Height: 0,
 	}
 
-	fixupStrategy = 1 // Do not touch unless your name is marco
+	fixupStrategy = 2 // Do not touch unless your name is marco
 )
 
 func init() {

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1167,7 +1167,7 @@ func TestFork(t *testing.T) {
 		t.Fatal(err)
 	}
 	// t.Logf("%v", spew.Sdump(n.chain[n.Best()[0].String()]))
-	time.Sleep(250 * time.Millisecond) // XXX
+	time.Sleep(500 * time.Millisecond) // XXX
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1401,7 +1401,7 @@ func TestIndexNoFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1591,7 +1591,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1837,7 +1837,7 @@ func TestIndexFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -2159,7 +2159,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -2239,6 +2239,8 @@ func TestKeystoneIndexFork(t *testing.T) {
 	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
+
+	time.Sleep(2000 * time.Millisecond)
 
 	// Verify linear indexing. Current TxIndex is sitting at genesis
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1167,7 +1167,7 @@ func TestFork(t *testing.T) {
 		t.Fatal(err)
 	}
 	// t.Logf("%v", spew.Sdump(n.chain[n.Best()[0].String()]))
-	time.Sleep(2 * time.Second) // XXX
+	time.Sleep(250 * time.Millisecond) // XXX
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1401,7 +1401,7 @@ func TestIndexNoFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(time.Second * 2)
+	time.Sleep(250 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1430,7 +1430,7 @@ func TestIndexNoFork(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(250 * time.Millisecond)
 
 	// creat a linear chain with some tx's
 	// g ->  b1 ->  b2 -> b3
@@ -1448,6 +1448,11 @@ func TestIndexNoFork(t *testing.T) {
 	}
 	b3, err := n.MineAndSend(ctx, "b3", b2.Hash(), address, false)
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure tbc dowloads blocks
+	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1586,7 +1591,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(time.Second * 2)
+	time.Sleep(250 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1618,7 +1623,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(250 * time.Millisecond)
 
 	// creat a linear chain with some tx's
 	// g ->  b1 ->  b2 -> b3
@@ -1636,6 +1641,11 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	}
 	b3, err := n.MineAndSend(ctx, "b3", b2.Hash(), address, true)
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure tbc dowloads blocks
+	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2149,7 +2159,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(time.Second * 2)
+	time.Sleep(250 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -2179,7 +2189,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(2 * time.Second)
+	time.Sleep(250 * time.Millisecond)
 
 	// Create a bunch of weird geometries to catch all corner cases in the indexer.
 
@@ -2225,7 +2235,10 @@ func TestKeystoneIndexFork(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(3 * time.Second)
+	// make sure tbc dowloads blocks
+	if err := n.MineAndSendEmpty(ctx); err != nil {
+		t.Fatal(err)
+	}
 
 	// Verify linear indexing. Current TxIndex is sitting at genesis
 


### PR DESCRIPTION
**Summary**
fixupCache is massively parallel and it kills kooboornootees.

**Changes**
Make fixupCache serial.
