### PR TITLE
all: fix various typos in variable names

### DIFF
--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -161,11 +161,11 @@ func NewServer(cfg *Config) (*Server, error) {
 }
 
 // handleRequest is called as a go routine to handle a long lived command.
-func (s *Server) handleRequest(parrentCtx context.Context, bws *bssWs, wsid string, requestType string, handler func(ctx context.Context) (any, error)) {
+func (s *Server) handleRequest(parentCtx context.Context, bws *bssWs, wsid string, requestType string, handler func(ctx context.Context) (any, error)) {
 	log.Tracef("handleRequest: %v", bws.addr)
 	defer log.Tracef("handleRequest exit: %v", bws.addr)
 
-	ctx, cancel := context.WithTimeout(parrentCtx, s.requestTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, s.requestTimeout)
 	defer cancel()
 
 	select {
@@ -544,11 +544,11 @@ func (s *Server) handleBFGWebsocketReadUnauth(ctx context.Context, conn *protoco
 	}
 }
 
-func (s *Server) handleBFGCallCompletion(parrentCtx context.Context, conn *protocol.Conn, bc bfgCmd) {
+func (s *Server) handleBFGCallCompletion(parentCtx context.Context, conn *protocol.Conn, bc bfgCmd) {
 	log.Tracef("handleBFGCallCompletion")
 	defer log.Tracef("handleBFGCallCompletion exit")
 
-	ctx, cancel := context.WithTimeout(parrentCtx, s.bfgCallTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, s.bfgCallTimeout)
 	defer cancel()
 
 	log.Tracef("handleBFGCallCompletion: %v", spew.Sdump(bc.msg))
@@ -583,7 +583,7 @@ func (s *Server) handleBFGWebsocketCallUnauth(ctx context.Context, conn *protoco
 	}
 }
 
-func (s *Server) callBFG(parrentCtx context.Context, msg any) (any, error) {
+func (s *Server) callBFG(parentCtx context.Context, msg any) (any, error) {
 	log.Tracef("callBFG %T", msg)
 	defer log.Tracef("callBFG exit %T", msg)
 
@@ -592,7 +592,7 @@ func (s *Server) callBFG(parrentCtx context.Context, msg any) (any, error) {
 		ch:  make(chan any),
 	}
 
-	ctx, cancel := context.WithTimeout(parrentCtx, s.bfgCallTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, s.bfgCallTimeout)
 	defer cancel()
 
 	// attempt to send
@@ -709,7 +709,7 @@ func (s *Server) isBFGConnected() float64 {
 	return 0
 }
 
-func (s *Server) Run(parrentCtx context.Context) error {
+func (s *Server) Run(parentCtx context.Context) error {
 	log.Tracef("Run")
 	defer log.Tracef("Run exit")
 
@@ -718,7 +718,7 @@ func (s *Server) Run(parrentCtx context.Context) error {
 	}
 	defer s.testAndSetRunning(false)
 
-	ctx, cancel := context.WithCancel(parrentCtx)
+	ctx, cancel := context.WithCancel(parentCtx)
 	defer cancel() // just in case
 
 	mux := http.NewServeMux()

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -438,8 +438,8 @@ func TestCreateTxTxOutPopTx(t *testing.T) {
 		t.Fatalf("failed to encode PoP transaction: %v", err)
 	}
 
-	expectexTxOut := btcwire.NewTxOut(0, popTxOpReturn)
-	diff := deep.Equal(expectexTxOut, btx.TxOut[1])
+	expectedTxOut := btcwire.NewTxOut(0, popTxOpReturn)
+	diff := deep.Equal(expectedTxOut, btx.TxOut[1])
 	if len(diff) != 0 {
 		t.Fatalf("got unexpected diff %s", diff)
 	}
@@ -871,7 +871,7 @@ func TestProcessReceivedInAscOrderOverride(t *testing.T) {
 	}
 }
 
-func TestProcesAllKeystonesIfAble(t *testing.T) {
+func TestProcessAllKeystonesIfAble(t *testing.T) {
 	miner, err := NewMiner(&Config{
 		BTCPrivateKey: "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641",
 		BTCChainName:  "testnet3",

--- a/service/tbc/peermanager.go
+++ b/service/tbc/peermanager.go
@@ -324,7 +324,7 @@ func (pm *PeerManager) randomPeer(ctx context.Context, slot int) (*rawpeer.RawPe
 	pm.mtx.Lock()
 	defer pm.mtx.Unlock()
 
-	// Reset caluse
+	// Reset clause
 	// log.Infof("good %v bad %v seeds %v", len(pm.good), len(pm.bad), len(pm.seeds))
 	if len(pm.good) < len(pm.seeds) && len(pm.bad) >= len(pm.seeds) {
 		// Return an error to make the caller aware that we have reset

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -204,7 +204,7 @@ func TestDbUpgrade(t *testing.T) {
 		t.Fatal("expected failure retrieving keystone index hash")
 	}
 
-	// Make sure we get the ecxpected indexkeys from db
+	// Make sure we get the expected indexkeys from db
 	hash := s2h("0000000050ff3053ada24e6ad581fa0295297f20a2747d034997ffc899aa931e")
 	utxobh, err := s.db.BlockHeaderByUtxoIndex(ctx)
 	if err != nil {

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -206,7 +206,7 @@ func TestTTLDelete(t *testing.T) {
 		if expired, err := tm.Delete(key); err != nil {
 			t.Fatal(err)
 		} else if expired {
-			t.Fatalf("%v: expired got %v wamted %v", key, expired, false)
+			t.Fatalf("%v: expired got %v wanted %v", key, expired, false)
 		}
 	}
 


### PR DESCRIPTION
## Summary  
This PR corrects several spelling mistakes and improves consistency in variable names and comments across multiple files. It fixes issues such as typos in function parameters, expected output variables, and inline documentation, ensuring better readability and maintainability.

## Changes  
- Fixed the misspelling of `parrentCtx` to `parentCtx` across multiple functions in `service/bss/bss.go`.  
- Corrected `expectexTxOut` to `expectedTxOut` in `service/popm/popm_test.go`.  
- Fixed the function name typo `TestProcesAllKeystonesIfAble` to `TestProcessAllKeystonesIfAble` in `service/popm/popm_test.go`.  
- Corrected comment typo `caluse` to `clause` in `service/tbc/peermanager.go`.  
- Fixed `ecxpected` to `expected` in `service/tbc/tbc_test.go`.  
- Resolved `wamted` to `wanted` in `ttl/ttl_test.go`.  
