### PR TITLE
tbc: use chainhash.Hash without pointers in the lowIQLRU cache

### DIFF
--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -53,9 +53,9 @@ func (l *lowIQLRU) Put(hash *chainhash.Hash, block []byte) {
 		if re == nil {
 			if true {
 				panic(fmt.Sprintf("SHOW THIS TO ME: total %v block "+
-					"%v size %v - map %v list %v",
+					"%v size %v - map %v list %v - hash %v",
 					l.totalSize, len(block), l.size, len(l.m),
-					l.l.Len()))
+					l.l.Len(), hash))
 			}
 			break
 		}

--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -61,9 +61,23 @@ func (l *lowIQLRU) Put(hash *chainhash.Hash, block []byte) {
 		}
 		rha := l.l.Remove(re)
 		rh := *rha.(*chainhash.Hash)
+		if b, ok := l.m[rh]; !ok {
+			panic(fmt.Sprintf("WTF: total %v block "+
+				"%v size %v - map %v list %v - hash %v",
+				l.totalSize, len(block), l.size, len(l.m),
+				l.l.Len(), hash))
+			_ = b
+		}
 		l.totalSize -= len(l.m[rh].block)
 		delete(l.m, rh)
 		l.c.Purges++
+
+		if len(l.m) != l.l.Len() {
+			panic(fmt.Sprintf("whut whut: total %v block "+
+				"%v size %v - map %v list %v - hash %v",
+				l.totalSize, len(block), l.size, len(l.m),
+				l.l.Len(), hash))
+		}
 	}
 
 	// block lookup and lru append

--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -50,10 +50,19 @@ func (l *lowIQLRU) Put(hash *chainhash.Hash, block []byte) {
 	for l.totalSize+len(block) > l.size {
 		// LET THEM EAT PANIC
 		re := l.l.Front()
+		if re == nil {
+			if true {
+				panic(fmt.Sprintf("SHOW THIS TO ME: total %v block "+
+					"%v size %v - map %v list %v",
+					l.totalSize, len(block), l.size, len(l.m),
+					l.l.Len()))
+			}
+			break
+		}
 		rha := l.l.Remove(re)
-		rh := rha.(*chainhash.Hash)
-		l.totalSize -= len(l.m[*rh].block)
-		delete(l.m, *rh)
+		rh := *rha.(*chainhash.Hash)
+		l.totalSize -= len(l.m[rh].block)
+		delete(l.m, rh)
 		l.c.Purges++
 	}
 

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -37,7 +37,7 @@ func TestLRUCache(t *testing.T) {
 		h, _, r := newBlock(&prevHash, uint32(i))
 		t.Logf("%v: %v", i, h)
 		blocks = append(blocks, h)
-		l.Put(&h, r)
+		l.Put(h, r)
 		prevHash = h
 	}
 
@@ -65,7 +65,7 @@ func TestLRUCache(t *testing.T) {
 		h, _, r := newBlock(&prevHash, uint32(i))
 		t.Logf("%v: %v", i, h)
 		blocks = append(blocks, h)
-		l.Put(&h, r)
+		l.Put(h, r)
 		prevHash = h
 	}
 

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1418,7 +1418,7 @@ func (l *ldb) BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error) 
 			return -1, fmt.Errorf("blocks insert put: %w", err)
 		}
 		if l.cfg.blockCacheSize > 0 {
-			l.blockCache.Put(b.Hash(), raw)
+			l.blockCache.Put(*b.Hash(), raw)
 		}
 	}
 
@@ -1475,7 +1475,7 @@ func (l *ldb) BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.B
 			return nil, fmt.Errorf("block get: %w", err)
 		}
 		if l.cfg.blockCacheSize > 0 {
-			l.blockCache.Put(hash, eb)
+			l.blockCache.Put(*hash, eb)
 		}
 	}
 	// if we get here eb MUST exist

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1474,15 +1474,14 @@ func (l *ldb) BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.B
 			}
 			return nil, fmt.Errorf("block get: %w", err)
 		}
+		if l.cfg.blockCacheSize > 0 {
+			l.blockCache.Put(hash, eb)
+		}
 	}
-
 	// if we get here eb MUST exist
 	b, err := btcutil.NewBlockFromBytes(eb)
 	if err != nil {
 		panic(fmt.Errorf("block decode data corruption: %v %w", hash, err))
-	}
-	if l.cfg.blockCacheSize > 0 {
-		l.blockCache.Put(hash, eb)
 	}
 	return b, nil
 }


### PR DESCRIPTION
**Summary**
Add a diagnostic to root cause a bug.

**Changes**
<!-- A list of changes made by this pull request. -->
