### PR TITLE
bfg: add config option to disable public ws conns

### DIFF
--- a/cmd/bfgd/bfgd.go
+++ b/cmd/bfgd/bfgd.go
@@ -129,6 +129,12 @@ var (
 			Help:         "a btc private key, this is only needed when connecting to another BFG",
 			Print:        config.PrintSecret,
 		},
+		"BFG_DISABLE_PUBLIC_CONNS": config.Config{
+			Value:        &cfg.DisablePublicConns,
+			DefaultValue: false,
+			Help:         "disable public connections",
+			Print:        config.PrintAll,
+		},
 	}
 )
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -738,6 +738,9 @@ func TestBFGPublicDisabled(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
+	if !errors.Is(err, protocol.ErrPublicKeyAuth) {
+		t.Fatal("expected ErrPublicKeyAuth")
+	}
 	if !strings.Contains(err.Error(), "status = StatusCode(4100)") {
 		t.Fatal(err)
 	}

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -120,6 +120,7 @@ type Config struct {
 	TrustedProxies          []string
 	BFGURL                  string
 	BTCPrivateKey           string
+	DisablePublicConns      bool
 }
 
 type Server struct {
@@ -1103,6 +1104,11 @@ func (s *Server) handleWebsocketPublic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	if s.cfg.DisablePublicConns {
+		_ = conn.Close(protocol.ErrPublicKeyAuth.Code, protocol.ErrPublicKeyAuth.Reason)
+		return
+	}
 
 	bws := &bfgWs{
 		addr:           remoteAddr,


### PR DESCRIPTION
**Summary**
Add a configuration option `BFG_DISABLE_PUBLIC_CONNS` to disable public WebSocket connections on BFG.
When a PoP Miner connects and this option is enabled, the PoP Miner will be disconnected with an authentication error, which will result in the PoP Miner not retrying the connection.

**Changes**
- Add `BFG_DISABLE_PUBLIC_CONNS` environment variable to BFG.
- Add handling to close public WebSocket connections with a `protocol.ErrPublicKeyAuth` error when `DisablePublicConns` is `true`.
