### PR TITLE
all: re-enable gosec linter

### DIFF
--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -6,11 +6,12 @@ package main // XXX wrap in structure
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
-	"math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"
@@ -141,7 +142,13 @@ func (p *peer) handshake(ctx context.Context) error {
 
 	us := &wire.NetAddress{Timestamp: time.Now()}
 	them := &wire.NetAddress{Timestamp: time.Now()}
-	msg := wire.NewMsgVersion(us, them, rand.Uint64(), 0)
+
+	var nonce uint64
+	if err := binary.Read(rand.Reader, binary.BigEndian, &nonce); err != nil {
+		return fmt.Errorf("could not generate rand: %w", err)
+	}
+
+	msg := wire.NewMsgVersion(us, them, nonce, 0)
 	err := p.write(msg)
 	if err != nil {
 		return fmt.Errorf("could not write version message: %w", err)

--- a/cmd/extool/extool.go
+++ b/cmd/extool/extool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -76,6 +76,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("Invalid height %q: %v", flag.Arg(2), err)
 		}
+		if height < 0 {
+			log.Fatalf("invalid negative height %v", height)
+		}
+
 		rbh, err := c.RawBlockHeader(ctx, uint64(height))
 		if err != nil {
 			log.Fatalf("Failed to get raw block header: %v", err)
@@ -109,9 +113,15 @@ func main() {
 		if err != nil {
 			log.Fatalf("Invalid height %q: %v", flag.Arg(2), err)
 		}
+		if height < 0 {
+			log.Fatalf("invalid negative height %v", height)
+		}
 		index, err := strconv.Atoi(flag.Arg(3))
 		if err != nil {
 			log.Fatalf("Invalid index %q: %v", flag.Arg(3), err)
+		}
+		if index < 0 {
+			log.Fatalf("invalid negative index %v", height)
 		}
 		txh, merkleHashes, err := c.TransactionAtPosition(ctx, uint64(height), uint64(index))
 		if err != nil {

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1432,6 +1432,10 @@ func (l *ldb) BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error) 
 		}
 	}
 
+	if bh.Height > math.MaxInt64 {
+		return -1, fmt.Errorf("invalid height conversion to int %v", bh.Height)
+	}
+
 	return int64(bh.Height), nil
 }
 

--- a/hemi/electrs/electrs.go
+++ b/hemi/electrs/electrs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"strings"
 	"syscall"
@@ -438,6 +439,14 @@ func (c *Client) UTXOs(ctx context.Context, scriptHash []byte) ([]*UTXO, error) 
 		hash, err := btcchainhash.NewHashFromStr(eutxo.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("decode UTXO hash: %w", err)
+		}
+		if eutxo.Index > math.MaxUint32 {
+			log.Errorf("index exceeds max uint32 %v, skipping...", eutxo.Index)
+			continue
+		}
+		if eutxo.Value > math.MaxInt64 {
+			log.Errorf("value exceeds max int64 %v, skipping...", eutxo.Value)
+			continue
 		}
 		utxos = append(utxos, &UTXO{
 			Hash:   hash[:],

--- a/hemi/hemi.go
+++ b/hemi/hemi.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 
@@ -57,6 +58,14 @@ func L2BTCFinalityFromBfgd(l2BtcFinality *bfgd.L2BTCFinality, currentBTCHeight u
 	// set a reasonable upper bound so we can safely convert to int32
 	if fin > 100 {
 		fin = 100
+	}
+
+	if l2BtcFinality.L2Keystone.Version > math.MaxUint8 {
+		return nil, fmt.Errorf("invalid keystone version %v", l2BtcFinality.L2Keystone.Version)
+	}
+
+	if fin > math.MaxInt32 {
+		return nil, fmt.Errorf("finality value exceeds int32 size %v", fin)
 	}
 
 	return &L2BTCFinality{

--- a/rawdb/rawdb.go
+++ b/rawdb/rawdb.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -165,6 +166,14 @@ func (r *RawDB) Insert(key, value []byte) error {
 		} else {
 			// Encoded coordinates.
 			c := make([]byte, 4+4+4)
+
+			if fi.Size() > math.MaxUint32 {
+				return fmt.Errorf("file info exceeds max uint32 %v", fi.Size())
+			}
+			if len(value) > math.MaxUint32 {
+				return fmt.Errorf("size of value exceeds max uint32 %v", len(value))
+			}
+
 			binary.BigEndian.PutUint32(c[0:4], last)
 			binary.BigEndian.PutUint32(c[4:8], uint32(fi.Size()))
 			binary.BigEndian.PutUint32(c[8:12], uint32(len(value)))

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"strings"
@@ -632,6 +633,9 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 			height, index)
 		log.Tracef("validating bitcoin tx")
 
+		if index > math.MaxUint32 {
+			return fmt.Errorf("index exceeds uint32 max size during conversion: %v", index)
+		}
 		err = bitcoin.ValidateMerkleRoot(txHashEncoded, merkleHashes,
 			uint32(index), merkleRootEncoded)
 		if err != nil {
@@ -1327,6 +1331,10 @@ func (s *Server) refreshL2KeystoneCache(ctx context.Context) {
 
 	l2Keystones := make([]hemi.L2Keystone, 0, len(results))
 	for _, v := range results {
+		if v.Version > math.MaxUint8 {
+			log.Errorf("invalid keystone version %v, skipping...", v.Version)
+			continue
+		}
 		l2Keystones = append(l2Keystones, hemi.L2Keystone{
 			Version:            uint8(v.Version),
 			L1BlockNumber:      v.L1BlockNumber,
@@ -1888,16 +1896,18 @@ func (s *Server) Run(pctx context.Context) error {
 	}
 
 	publicHttpServer := &http.Server{
-		Addr:        s.cfg.PublicListenAddress,
-		Handler:     publicMux,
-		BaseContext: func(net.Listener) context.Context { return ctx },
+		Addr:              s.cfg.PublicListenAddress,
+		Handler:           publicMux,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	publicHttpErrCh := make(chan error)
 
 	privateHttpServer := &http.Server{
-		Addr:        s.cfg.PrivateListenAddress,
-		Handler:     privateMux,
-		BaseContext: func(net.Listener) context.Context { return ctx },
+		Addr:              s.cfg.PrivateListenAddress,
+		Handler:           privateMux,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	privateHttpErrCh := make(chan error)
 

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -725,9 +725,10 @@ func (s *Server) Run(parentCtx context.Context) error {
 	handle("bss", mux, bssapi.RouteWebsocket, s.handleWebsocket)
 
 	httpServer := &http.Server{
-		Addr:        s.cfg.ListenAddress,
-		Handler:     mux,
-		BaseContext: func(net.Listener) context.Context { return ctx },
+		Addr:              s.cfg.ListenAddress,
+		Handler:           mux,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	httpErrCh := make(chan error)
 	go func() {

--- a/service/deucalion/deucalion.go
+++ b/service/deucalion/deucalion.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -33,6 +33,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/juju/loggo"
 	"github.com/prometheus/client_golang/prometheus"
@@ -171,9 +172,10 @@ func (d *Deucalion) Run(ctx context.Context, cs []prometheus.Collector) error {
 	handle("prometheus", prometheusMux, "/metrics", promhttp.HandlerFor(reg,
 		promhttp.HandlerOpts{Registry: reg}).ServeHTTP)
 	httpPrometheusServer := &http.Server{
-		Addr:        d.cfg.ListenAddress,
-		Handler:     prometheusMux,
-		BaseContext: func(net.Listener) context.Context { return ctx },
+		Addr:              d.cfg.ListenAddress,
+		Handler:           prometheusMux,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	httpPrometheusErrCh := make(chan error)
 	go func() {

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net/http"
 	"slices"
@@ -299,6 +300,10 @@ func pickUTXO(utxos []*bfgapi.BitcoinUTXO, amount int64) (*bfgapi.BitcoinUTXO, e
 }
 
 func createTx(l2Keystone *hemi.L2Keystone, btcHeight uint64, utxo *bfgapi.BitcoinUTXO, payToScript []byte, feeAmount int64, minRelayTxFee int64) (*btcwire.MsgTx, error) {
+	if btcHeight > math.MaxUint32 {
+		return nil, fmt.Errorf("invalid btcHeight uint32 %v", btcHeight)
+	}
+
 	btx := btcwire.MsgTx{
 		Version:  2,
 		LockTime: uint32(btcHeight),

--- a/service/pprof/pprof.go
+++ b/service/pprof/pprof.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"sync/atomic"
+	"time"
 
 	"github.com/juju/loggo"
 )
@@ -48,9 +49,10 @@ func (s *Server) Run(ctx context.Context) error {
 	pprofMux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 
 	pprofHttpServer := &http.Server{
-		Addr:        s.cfg.ListenAddress,
-		Handler:     pprofMux,
-		BaseContext: func(net.Listener) context.Context { return ctx },
+		Addr:              s.cfg.ListenAddress,
+		Handler:           pprofMux,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	httpErrCh := make(chan error)

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"runtime"
 	"sort"
 	"sync"
@@ -406,6 +407,12 @@ func processUtxos(txs []*btcutil.Tx, utxos map[tbcd.Outpoint]tbcd.CacheOutput) e
 			if txscript.IsUnspendable(txOut.PkScript) {
 				continue
 			}
+
+			if outIndex > math.MaxUint32 {
+				log.Errorf("outindex conversion to uint32 %v, skipping...", outIndex)
+				continue
+			}
+
 			utxos[tbcd.NewOutpoint(*tx.Hash(), uint32(outIndex))] = tbcd.NewCacheOutput(
 				tbcd.NewScriptHashFromScript(txOut.PkScript),
 				uint64(txOut.Value),
@@ -474,6 +481,11 @@ func (s *Server) unprocessUtxos(ctx context.Context, txs []*btcutil.Tx, utxos ma
 		// cache.
 		for outIndex, txOut := range tx.MsgTx().TxOut {
 			if txscript.IsUnspendable(txOut.PkScript) {
+				continue
+			}
+
+			if outIndex > math.MaxUint32 {
+				log.Errorf("outindex conversion to uint32 %v, skipping...", outIndex)
 				continue
 			}
 
@@ -926,6 +938,11 @@ func processTxs(blockHash *chainhash.Hash, txs []*btcutil.Tx, txsCache map[tbcd.
 		}
 
 		for txInIdx, txIn := range tx.MsgTx().TxIn {
+			if txInIdx > math.MaxUint32 {
+				log.Errorf("txInIdx conversion to uint32 %v, skipping...", txInIdx)
+				continue
+			}
+
 			txk, txv := tbcd.NewTxSpent(
 				blockHash,
 				tx.Hash(),

--- a/service/tbc/peermanager.go
+++ b/service/tbc/peermanager.go
@@ -6,9 +6,10 @@ package tbc
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand/v2"
+	"math/big"
 	"net"
 	"sync"
 	"time"
@@ -404,7 +405,14 @@ func (pm *PeerManager) Run(ctx context.Context) error {
 				break
 			}
 
-			holdOff := time.Duration(minW+rand.IntN(maxW-minW)) * time.Second
+			bint := big.NewInt(int64(maxW) - int64(minW))
+			brint, err := rand.Int(rand.Reader, bint)
+			if err != nil {
+				return fmt.Errorf("error generating rand: %w", err)
+			}
+			rint := int64(minW) + brint.Int64()
+
+			holdOff := time.Duration(rint) * time.Second
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net"
 	"net/http"
@@ -993,6 +994,9 @@ func (s *Server) handleBlockExpired(ctx context.Context, key any, value any) err
 	if !canonical {
 		log.Infof("Deleting from blocks missing database: %v %v %v",
 			p, bhX.Height, bhX)
+		if bhX.Height > math.MaxInt64 {
+			return fmt.Errorf("block height exceeds int size")
+		}
 		err := s.db.BlockMissingDelete(ctx, int64(bhX.Height), &bhX.Hash)
 		if err != nil {
 			return fmt.Errorf("block expired delete missing: %w", err)
@@ -2522,9 +2526,10 @@ func (s *Server) Run(pctx context.Context) error {
 		mux.HandleFunc(tbcapi.RouteWebsocket, s.handleWebsocket)
 
 		httpServer := &http.Server{
-			Addr:        s.cfg.ListenAddress,
-			Handler:     mux,
-			BaseContext: func(_ net.Listener) context.Context { return ctx },
+			Addr:              s.cfg.ListenAddress,
+			Handler:           mux,
+			BaseContext:       func(_ net.Listener) context.Context { return ctx },
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 		go func() {
 			log.Infof("Listening: %s", s.cfg.ListenAddress)

--- a/web/integrationtest/integrationtest.go
+++ b/web/integrationtest/integrationtest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -16,6 +16,7 @@ type Response struct {
 	CurrentTime string
 }
 
+//nolint:gosec // test function
 func main() {
 	port := ":43111"
 	listen := "localhost" + port


### PR DESCRIPTION
**Summary**
The gosec linter was disabled due to the sheer amount of noise it produced. This pr fixes the flagged vulnerabilities in order to re-enable the linter.

**Changes**
Fixed most the vulnerabilities flagged by gosec,  with the exception of [G115](https://github.com/securego/gosec/blob/9452efe4ad770f703df825fb32cd693b421fc916/README.md?plain=1#L143) which produces too many false positives, and was thus kept disabled.

