### PR TITLE
tbc: convert hash pointers to hashes as variable arguments

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -152,7 +152,7 @@ type Block struct {
 
 // BlockByHashRequest requests a [Block] by its hash.
 type BlockByHashRequest struct {
-	Hash *chainhash.Hash `json:"hash"`
+	Hash chainhash.Hash `json:"hash"`
 }
 
 // BlockByHashResponse is the response for [BlockByHashRequest].
@@ -163,7 +163,7 @@ type BlockByHashResponse struct {
 
 // BlockByHashRawRequest requests a raw block by its hash.
 type BlockByHashRawRequest struct {
-	Hash *chainhash.Hash `json:"hash"`
+	Hash chainhash.Hash `json:"hash"`
 }
 
 // BlockByHashRawResponse is the response for [BlockByHashRawRequest].
@@ -238,7 +238,7 @@ type UTXOsByAddressResponse struct {
 }
 
 type TxByIdRawRequest struct {
-	TxID *chainhash.Hash `json:"tx_id"`
+	TxID chainhash.Hash `json:"tx_id"`
 }
 
 type TxByIdRawResponse struct {
@@ -247,7 +247,7 @@ type TxByIdRawResponse struct {
 }
 
 type TxByIdRequest struct {
-	TxID *chainhash.Hash `json:"tx_id"`
+	TxID chainhash.Hash `json:"tx_id"`
 }
 
 type TxByIdResponse struct {
@@ -289,7 +289,7 @@ type BlockInsertRawRequest struct {
 }
 
 type BlockKeystoneByL2KeystoneAbrevHashRequest struct {
-	L2KeystoneAbrevHash *chainhash.Hash `json:"l2_keystones_abrev_hash"`
+	L2KeystoneAbrevHash chainhash.Hash `json:"l2_keystones_abrev_hash"`
 }
 
 type BlockKeystoneByL2KeystoneAbrevHashResponse struct {
@@ -306,8 +306,8 @@ type BlockInsertRawResponse struct {
 // BlockDownloadAsyncResponse returns a block if it exists or attempts to
 // download the block from p2p asynchronously.
 type BlockDownloadAsyncRequest struct {
-	Hash  *chainhash.Hash `json:"hash"`
-	Peers uint            `json:"peers"`
+	Hash  chainhash.Hash `json:"hash"`
+	Peers uint           `json:"peers"`
 }
 
 // BlockDownloadAsyncResponse replies with a block, an error or nothing. When
@@ -319,8 +319,8 @@ type BlockDownloadAsyncResponse struct {
 }
 
 type BlockDownloadAsyncRawRequest struct {
-	Hash  *chainhash.Hash `json:"hash"`
-	Peers uint            `json:"peers"`
+	Hash  chainhash.Hash `json:"hash"`
+	Peers uint           `json:"peers"`
 }
 
 type BlockDownloadAsyncRawResponse struct {

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -296,7 +296,7 @@ func tbcdb(pctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("chainhash: %w", err)
 		}
-		b, err := s.BlockByHash(ctx, ch)
+		b, err := s.BlockByHash(ctx, *ch)
 		if err != nil {
 			return fmt.Errorf("block by hash: %w", err)
 		}

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -401,7 +401,7 @@ func tbcdb(pctx context.Context) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		bh, err := s.BlockHashByTxId(ctx, chtxid)
+		bh, err := s.BlockHashByTxId(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("block by txid: %w", err)
 		}
@@ -417,7 +417,7 @@ func tbcdb(pctx context.Context) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		tx, err := s.TxById(ctx, chtxid)
+		tx, err := s.TxById(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("block by txid: %w", err)
 		}
@@ -433,7 +433,7 @@ func tbcdb(pctx context.Context) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		si, err := s.SpentOutputsByTxId(ctx, chtxid)
+		si, err := s.SpentOutputsByTxId(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("spend outputs by txid: %w", err)
 		}
@@ -452,7 +452,7 @@ func tbcdb(pctx context.Context) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		si, err := s.SpentOutputsByTxId(ctx, chtxid)
+		si, err := s.SpentOutputsByTxId(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("spend outputs by txid: %w", err)
 		}
@@ -469,7 +469,7 @@ func tbcdb(pctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("chainhash: %w", err)
 		}
-		ok, err := s.BlockInTxIndex(ctx, blkhash)
+		ok, err := s.BlockInTxIndex(ctx, *blkhash)
 		if err != nil {
 			return fmt.Errorf("block in transaction index: %w", err)
 		}

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -239,7 +239,7 @@ func tbcdb(pctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("chainhash: %w", err)
 		}
-		bh, height, err := s.BlockHeaderByHash(ctx, ch)
+		bh, height, err := s.BlockHeaderByHash(ctx, *ch)
 		if err != nil {
 			return fmt.Errorf("block header by hash: %w", err)
 		}
@@ -364,7 +364,7 @@ func tbcdb(pctx context.Context) error {
 			}
 			cfg.MaxCachedTxs = int(mc)
 		}
-		err = s.UtxoIndexer(ctx, eh)
+		err = s.UtxoIndexer(ctx, *eh)
 		if err != nil {
 			return fmt.Errorf("indexer: %w", err)
 		}
@@ -387,7 +387,7 @@ func tbcdb(pctx context.Context) error {
 			}
 			cfg.MaxCachedTxs = int(mc)
 		}
-		if err = s.TxIndexer(ctx, eh); err != nil {
+		if err = s.TxIndexer(ctx, *eh); err != nil {
 			return fmt.Errorf("indexer: %w", err)
 		}
 

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -95,7 +95,7 @@ type Database interface {
 
 	// Block header
 	BlockHeaderBest(ctx context.Context) (*BlockHeader, error) // return canonical
-	BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*BlockHeader, error)
+	BlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*BlockHeader, error)
 	BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader, height uint64, diff *big.Int) error
 	BlockHeaderCacheStats() CacheStats
 

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -96,7 +96,7 @@ type Database interface {
 	// Block header
 	BlockHeaderBest(ctx context.Context) (*BlockHeader, error) // return canonical
 	BlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*BlockHeader, error)
-	BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader, height uint64, diff *big.Int) error
+	BlockHeaderGenesisInsert(ctx context.Context, wbh wire.BlockHeader, height uint64, diff *big.Int) error
 	BlockHeaderCacheStats() CacheStats
 
 	// Block headers

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -106,7 +106,7 @@ type Database interface {
 
 	// Block
 	BlocksMissing(ctx context.Context, count int) ([]BlockIdentifier, error)
-	BlockMissingDelete(ctx context.Context, height int64, hash *chainhash.Hash) error
+	BlockMissingDelete(ctx context.Context, height int64, hash chainhash.Hash) error
 	BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error)
 	// BlocksInsert(ctx context.Context, bs []*btcutil.Block) (int64, error)
 	BlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error)
@@ -118,11 +118,11 @@ type Database interface {
 	BlockHeaderByTxIndex(ctx context.Context) (*BlockHeader, error)
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput, utxoIndexHash chainhash.Hash) error
 	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue, txIndexHash chainhash.Hash) error
-	BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error)
-	SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]SpentInfo, error)
+	BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainhash.Hash, error)
+	SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]SpentInfo, error)
 	// ScriptHash returns the sha256 of PkScript for the provided outpoint.
 	BalanceByScriptHash(ctx context.Context, sh ScriptHash) (uint64, error)
-	BlockInTxIndex(ctx context.Context, hash *chainhash.Hash) (bool, error)
+	BlockInTxIndex(ctx context.Context, hash chainhash.Hash) (bool, error)
 	ScriptHashByOutpoint(ctx context.Context, op Outpoint) (*ScriptHash, error)
 	ScriptHashesByOutpoint(ctx context.Context, ops []*Outpoint, result func(Outpoint, ScriptHash) error) error
 	UtxosByScriptHash(ctx context.Context, sh ScriptHash, start uint64, count uint64) ([]Utxo, error)

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -109,7 +109,8 @@ type Database interface {
 	BlockMissingDelete(ctx context.Context, height int64, hash *chainhash.Hash) error
 	BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error)
 	// BlocksInsert(ctx context.Context, bs []*btcutil.Block) (int64, error)
-	BlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error)
+	BlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error)
+	BlockExistsByHash(ctx context.Context, hash chainhash.Hash) (bool, error)
 	BlockCacheStats() CacheStats
 
 	// Transactions

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -116,8 +116,8 @@ type Database interface {
 	// Transactions
 	BlockHeaderByUtxoIndex(ctx context.Context) (*BlockHeader, error)
 	BlockHeaderByTxIndex(ctx context.Context) (*BlockHeader, error)
-	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput, utxoIndexHash *chainhash.Hash) error
-	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue, txIndexHash *chainhash.Hash) error
+	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput, utxoIndexHash chainhash.Hash) error
+	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue, txIndexHash chainhash.Hash) error
 	BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error)
 	SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]SpentInfo, error)
 	// ScriptHash returns the sha256 of PkScript for the provided outpoint.
@@ -129,7 +129,7 @@ type Database interface {
 	UtxosByScriptHashCount(ctx context.Context, sh ScriptHash) (uint64, error)
 
 	// Hemi
-	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Keystone, keystoneIndexHash *chainhash.Hash) error
+	BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]Keystone, keystoneIndexHash chainhash.Hash) error
 	BlockKeystoneByL2KeystoneAbrevHash(ctx context.Context, abrevhash chainhash.Hash) (*Keystone, error)
 	BlockHeaderByKeystoneIndex(ctx context.Context) (*BlockHeader, error)
 }

--- a/database/tbcd/level/blockcache.go
+++ b/database/tbcd/level/blockcache.go
@@ -68,11 +68,11 @@ func (l *lowIQLRU) Put(hash chainhash.Hash, block []byte) {
 	l.c.Size = l.totalSize
 }
 
-func (l *lowIQLRU) Get(k *chainhash.Hash) ([]byte, bool) {
+func (l *lowIQLRU) Get(k chainhash.Hash) ([]byte, bool) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	be, ok := l.m[*k]
+	be, ok := l.m[k]
 	if !ok {
 		l.c.Misses++
 		return nil, false

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -49,7 +49,7 @@ func TestLRUCache(t *testing.T) {
 
 	// retrieve all blocks
 	for k := range blocks {
-		if _, ok := l.Get(&blocks[k]); !ok {
+		if _, ok := l.Get(blocks[k]); !ok {
 			t.Fatalf("block not found: %v", blocks[k])
 		}
 	}
@@ -80,7 +80,7 @@ func TestLRUCache(t *testing.T) {
 		if k >= maxCache {
 			break
 		}
-		if _, ok := l.Get(&blocks[k]); ok {
+		if _, ok := l.Get(blocks[k]); ok {
 			t.Fatalf("block found: %v", blocks[k])
 		}
 	}

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -117,7 +117,7 @@ func TestMapCache(t *testing.T) {
 		h, bh := newHeader(&prevHash, uint32(i))
 		t.Logf("%v: %v", i, h)
 		headers = append(headers, h)
-		l.Put(bh)
+		l.Put(*bh)
 		prevHash = h
 	}
 
@@ -129,7 +129,7 @@ func TestMapCache(t *testing.T) {
 
 	// retrieve all headers
 	for k := range headers {
-		if _, ok := l.Get(&headers[k]); !ok {
+		if _, ok := l.Get(headers[k]); !ok {
 			t.Fatalf("header not found: %v", headers[k])
 		}
 	}
@@ -145,7 +145,7 @@ func TestMapCache(t *testing.T) {
 		h, bh := newHeader(&prevHash, uint32(i))
 		t.Logf("%v: %v", i, h)
 		headers = append(headers, h)
-		l.Put(bh)
+		l.Put(*bh)
 		prevHash = h
 	}
 
@@ -157,7 +157,7 @@ func TestMapCache(t *testing.T) {
 
 	// Force a random miss
 	hm, _ := newHeader(&chainhash.Hash{}, 0xdeadbeef)
-	_, ok := l.Get(&hm)
+	_, ok := l.Get(hm)
 	if ok {
 		t.Fatal("non cached header found")
 	}
@@ -191,24 +191,20 @@ func TestHC(t *testing.T) {
 	}
 	hs := intHash(0)
 	for range 2 {
-		l.Put(&tbcd.BlockHeader{
-			Hash: hs,
-		})
+		l.Put(tbcd.BlockHeader{Hash: hs})
 	}
 	if len(l.m) > 1 {
 		t.Fatalf("duplicate headers not excluded by hash")
 	}
-	if _, ok := l.Get(&hs); !ok {
+	if _, ok := l.Get(hs); !ok {
 		t.Fatalf("failed to retrieve header present in map")
 	}
 	hs = intHash(1)
-	if _, ok := l.Get(&hs); ok {
+	if _, ok := l.Get(hs); ok {
 		t.Fatalf("invalid header retrieved from Map")
 	}
 	for k := range l.count + 5 {
-		l.Put(&tbcd.BlockHeader{
-			Hash: intHash(k),
-		})
+		l.Put(tbcd.BlockHeader{Hash: intHash(k)})
 	}
 	if len(l.m) > l.count {
 		t.Fatalf("map size exceeded bounds. expected %v, got %v", l.count, len(l.m))
@@ -227,7 +223,7 @@ func TestHC(t *testing.T) {
 	if len(l.m) != 1 {
 		t.Fatalf("expected %d elements to be purged, purged %d", len(storedHashes), l.count-len(l.m))
 	}
-	if _, ok := l.Get(lastHash); !ok {
+	if _, ok := l.Get(*lastHash); !ok {
 		t.Fatalf("incorrect element purged")
 	}
 }

--- a/database/tbcd/level/headercache.go
+++ b/database/tbcd/level/headercache.go
@@ -26,7 +26,7 @@ type lowIQMap struct {
 	c tbcd.CacheStats
 }
 
-func (l *lowIQMap) Put(v *tbcd.BlockHeader) {
+func (l *lowIQMap) Put(v tbcd.BlockHeader) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
@@ -43,14 +43,14 @@ func (l *lowIQMap) Put(v *tbcd.BlockHeader) {
 		}
 	}
 
-	l.m[v.Hash] = v
+	l.m[v.Hash] = &v
 }
 
-func (l *lowIQMap) Get(k *chainhash.Hash) (*tbcd.BlockHeader, bool) {
+func (l *lowIQMap) Get(k chainhash.Hash) (*tbcd.BlockHeader, bool) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	bh, ok := l.m[*k]
+	bh, ok := l.m[k]
 	if ok {
 		l.c.Hits++
 	} else {

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1503,7 +1503,7 @@ func (l *ldb) BlockExistsByHash(ctx context.Context, hash chainhash.Hash) (bool,
 		if errors.Is(err, leveldb.ErrNotFound) {
 			return false, nil
 		}
-		return false, fmt.Errorf("block exists: %w", err)
+		return false, fmt.Errorf("check block exists: %w", err)
 	}
 	return ok, nil
 }

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1435,7 +1435,7 @@ func (l *ldb) BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error) 
 	return int64(bh.Height), nil
 }
 
-func (l *ldb) BlockMissingDelete(ctx context.Context, height int64, hash *chainhash.Hash) error {
+func (l *ldb) BlockMissingDelete(ctx context.Context, height int64, hash chainhash.Hash) error {
 	log.Tracef("BlockMissingDelete")
 	defer log.Tracef("BlockMissingDelete exit")
 
@@ -1508,7 +1508,7 @@ func (l *ldb) BlockExistsByHash(ctx context.Context, hash chainhash.Hash) (bool,
 	return ok, nil
 }
 
-func (l *ldb) BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error) {
+func (l *ldb) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainhash.Hash, error) {
 	log.Tracef("BlockHashByTxId")
 	defer log.Tracef("BlockHashByTxId exit")
 
@@ -1540,7 +1540,7 @@ func (l *ldb) BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chain
 	}
 }
 
-func (l *ldb) SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]tbcd.SpentInfo, error) {
+func (l *ldb) SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]tbcd.SpentInfo, error) {
 	log.Tracef("SpentOutputByOutpoint")
 	defer log.Tracef("SpentOutputByOutpoint exit")
 
@@ -1580,7 +1580,7 @@ func (l *ldb) SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]t
 	return si, nil
 }
 
-func (l *ldb) BlockInTxIndex(ctx context.Context, hash *chainhash.Hash) (bool, error) {
+func (l *ldb) BlockInTxIndex(ctx context.Context, hash chainhash.Hash) (bool, error) {
 	log.Tracef("BlockInTxIndex")
 	defer log.Tracef("BlockInTxIndex exit")
 

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1728,7 +1728,7 @@ func (l *ldb) UtxosByScriptHashCount(ctx context.Context, sh tbcd.ScriptHash) (u
 	return x, nil
 }
 
-func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd.Outpoint]tbcd.CacheOutput, utxoIndexHash *chainhash.Hash) error {
+func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd.Outpoint]tbcd.CacheOutput, utxoIndexHash chainhash.Hash) error {
 	log.Tracef("BlockUtxoUpdate")
 	defer log.Tracef("BlockUtxoUpdate exit")
 
@@ -1785,7 +1785,7 @@ func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd
 	return nil
 }
 
-func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxKey]*tbcd.TxValue, txIndexHash *chainhash.Hash) error {
+func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxKey]*tbcd.TxValue, txIndexHash chainhash.Hash) error {
 	log.Tracef("BlockTxUpdate")
 	defer log.Tracef("BlockTxUpdate exit")
 
@@ -1891,7 +1891,7 @@ func decodeKeystone(eks []byte) (ks tbcd.Keystone) {
 	return ks
 }
 
-func (l *ldb) BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]tbcd.Keystone, keystoneIndexHash *chainhash.Hash) error {
+func (l *ldb) BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]tbcd.Keystone, keystoneIndexHash chainhash.Hash) error {
 	log.Tracef("BlockKeystoneUpdate")
 	defer log.Tracef("BlockKeystoneUpdate exit")
 

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -457,7 +457,7 @@ func (l *ldb) MetadataPut(ctx context.Context, key, value []byte) error {
 	return nil
 }
 
-func (l *ldb) BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*tbcd.BlockHeader, error) {
+func (l *ldb) BlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*tbcd.BlockHeader, error) {
 	log.Tracef("BlockHeaderByHash")
 	defer log.Tracef("BlockHeaderByHash exit")
 
@@ -484,7 +484,7 @@ func (l *ldb) BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*tbc
 
 	// Insert into cache, roughly 150 byte cost.
 	if l.cfg.blockheaderCacheSize > 0 {
-		l.headerCache.Put(bh)
+		l.headerCache.Put(*bh)
 	}
 
 	return bh, nil
@@ -509,7 +509,7 @@ func (l *ldb) BlockHeadersByHeight(ctx context.Context, height uint64) ([]tbcd.B
 			// all done
 			break
 		}
-		bh, err := l.BlockHeaderByHash(ctx, hash)
+		bh, err := l.BlockHeaderByHash(ctx, *hash)
 		if err != nil {
 			return nil, fmt.Errorf("headers by height: %w", err)
 		}
@@ -858,7 +858,7 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 		}
 
 		// Get full header that has height in it for the block to remove we are checking
-		fullHeader, err := l.BlockHeaderByHash(ctx, &hash)
+		fullHeader, err := l.BlockHeaderByHash(ctx, hash)
 		if err != nil {
 			return 0, nil,
 				fmt.Errorf("block headers remove: cannot find header with hash %s in database, err: %w",
@@ -923,7 +923,7 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 
 	// Ensure that the tip which the caller claims should be canonical after the
 	// removal is a valid block in the database.
-	tipAfterRemovalFromDb, err := l.BlockHeaderByHash(ctx, &tipAfterRemovalHash)
+	tipAfterRemovalFromDb, err := l.BlockHeaderByHash(ctx, tipAfterRemovalHash)
 	if err != nil {
 		return tbcd.RTInvalid, nil,
 			fmt.Errorf("block headers remove: cannot find tip after removal header with hash %s "+
@@ -1005,7 +1005,7 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 
 	// Get parent block from database
 	// XXX verify l. here instead of using the bh transaction to get the hash
-	parentToRemovalSet, err := l.BlockHeaderByHash(ctx, &headersParsed[0].PrevBlock)
+	parentToRemovalSet, err := l.BlockHeaderByHash(ctx, headersParsed[0].PrevBlock)
 	if err != nil {
 		return tbcd.RTInvalid, nil,
 			fmt.Errorf("block headers remove: cannot find previous header (with hash %s) to lowest header"+
@@ -1150,7 +1150,7 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, batc
 
 	// Obtain current and previous blockheader.
 	wbh := bhs.Headers[0]
-	pbh, err := l.BlockHeaderByHash(ctx, &wbh.PrevBlock)
+	pbh, err := l.BlockHeaderByHash(ctx, wbh.PrevBlock)
 	if err != nil {
 		return tbcd.ITInvalid, nil, nil, 0,
 			fmt.Errorf("block headers insert: %w", err)
@@ -1398,7 +1398,7 @@ func (l *ldb) BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error) 
 	log.Tracef("BlockInsert")
 	defer log.Tracef("BlockInsert exit")
 
-	bh, err := l.BlockHeaderByHash(ctx, b.Hash())
+	bh, err := l.BlockHeaderByHash(ctx, *b.Hash())
 	if err != nil {
 		return -1, fmt.Errorf("block header by hash: %w", err)
 	}
@@ -1968,7 +1968,7 @@ func (l *ldb) BlockHeaderByKeystoneIndex(ctx context.Context) (*tbcd.BlockHeader
 	if err != nil {
 		return nil, fmt.Errorf("new hash: %w", err)
 	}
-	return l.BlockHeaderByHash(ctx, ch)
+	return l.BlockHeaderByHash(ctx, *ch)
 }
 
 func (l *ldb) BlockHeaderByUtxoIndex(ctx context.Context) (*tbcd.BlockHeader, error) {
@@ -1990,7 +1990,7 @@ func (l *ldb) BlockHeaderByUtxoIndex(ctx context.Context) (*tbcd.BlockHeader, er
 	if err != nil {
 		return nil, fmt.Errorf("new hash: %w", err)
 	}
-	return l.BlockHeaderByHash(ctx, ch)
+	return l.BlockHeaderByHash(ctx, *ch)
 }
 
 func (l *ldb) BlockHeaderByTxIndex(ctx context.Context) (*tbcd.BlockHeader, error) {
@@ -2012,7 +2012,7 @@ func (l *ldb) BlockHeaderByTxIndex(ctx context.Context) (*tbcd.BlockHeader, erro
 	if err != nil {
 		return nil, fmt.Errorf("new hash: %w", err)
 	}
-	return l.BlockHeaderByHash(ctx, ch)
+	return l.BlockHeaderByHash(ctx, *ch)
 }
 
 func (l *ldb) BlockHeaderCacheStats() tbcd.CacheStats {

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -586,7 +586,7 @@ func decodeBlockHeader(ebh []byte) *tbcd.BlockHeader {
 	return bh
 }
 
-func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeader, height uint64, diff *big.Int) error {
+func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh wire.BlockHeader, height uint64, diff *big.Int) error {
 	log.Tracef("BlockHeaderGenesisInsert")
 	defer log.Tracef("BlockHeaderGenesisInsert exit")
 
@@ -648,7 +648,7 @@ func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh *wire.BlockHeade
 	if diff != nil && diff.Cmp(big.NewInt(0)) > 0 {
 		cdiff = diff
 	}
-	ebh := encodeBlockHeader(height, h2b(wbh), cdiff)
+	ebh := encodeBlockHeader(height, h2b(&wbh), cdiff)
 	bhBatch.Put(bhash[:], ebh[:])
 
 	bhBatch.Put([]byte(bhsCanonicalTipKey), ebh[:])

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1103,7 +1103,7 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, batc
 	log.Tracef("BlockHeadersInsert")
 	defer log.Tracef("BlockHeadersInsert exit")
 
-	if len(bhs.Headers) == 0 {
+	if bhs == nil || len(bhs.Headers) == 0 {
 		return tbcd.ITInvalid, nil, nil, 0,
 			errors.New("block headers insert: invalid")
 	}

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -323,7 +323,7 @@ func TestKeystoneUpdate(t *testing.T) {
 		},
 	}
 
-	blockhash := &chainhash.Hash{1, 3, 3, 7}
+	blockhash := chainhash.Hash{1, 3, 3, 7}
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
 			home := t.TempDir()
@@ -411,7 +411,7 @@ func TestKeystoneDBWindUnwind(t *testing.T) {
 		}
 	}()
 
-	blockhash := &chainhash.Hash{0xde, 0xad, 0xbe, 0xef}
+	blockhash := chainhash.Hash{0xde, 0xad, 0xbe, 0xef}
 	blk1Hash := chainhash.Hash{1}
 	k1hash, k1 := newKeystone(&blk1Hash, 1, 2)
 	blk2Hash := chainhash.Hash{1}
@@ -482,7 +482,7 @@ func TestKeystoneDBCache(t *testing.T) {
 		cycles = 1
 	)
 
-	blockhash := &chainhash.Hash{0xba, 0xdc, 0x0f, 0xfe}
+	blockhash := chainhash.Hash{0xba, 0xdc, 0x0f, 0xfe}
 	for i := range cycles {
 		ksm := make(map[chainhash.Hash]tbcd.Keystone, kssNum)
 		for j := range kssNum {

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -788,7 +788,7 @@ func (s *Server) UtxoIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Blo
 
 		// Flush to disk
 		start = time.Now()
-		if err = s.db.BlockUtxoUpdate(ctx, -1, utxos, &last.Hash); err != nil {
+		if err = s.db.BlockUtxoUpdate(ctx, -1, utxos, last.Hash); err != nil {
 			return fmt.Errorf("block utxo update: %w", err)
 		}
 		// leveldb does all kinds of allocations, force GC to lower
@@ -842,7 +842,7 @@ func (s *Server) UtxoIndexerWind(ctx context.Context, startBH, endBH *tbcd.Block
 
 		// Flush to disk
 		start = time.Now()
-		if err = s.db.BlockUtxoUpdate(ctx, 1, utxos, &last.Hash); err != nil {
+		if err = s.db.BlockUtxoUpdate(ctx, 1, utxos, last.Hash); err != nil {
 			return fmt.Errorf("block tx update: %w", err)
 		}
 
@@ -1133,7 +1133,7 @@ func (s *Server) TxIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Block
 
 		// Flush to disk
 		start = time.Now()
-		if err = s.db.BlockTxUpdate(ctx, -1, txs, &last.Hash); err != nil {
+		if err = s.db.BlockTxUpdate(ctx, -1, txs, last.Hash); err != nil {
 			return fmt.Errorf("block tx update: %w", err)
 		}
 		// leveldb does all kinds of allocations, force GC to lower
@@ -1187,7 +1187,7 @@ func (s *Server) TxIndexerWind(ctx context.Context, startBH, endBH *tbcd.BlockHe
 
 		// Flush to disk
 		start = time.Now()
-		if err = s.db.BlockTxUpdate(ctx, 1, txs, &last.Hash); err != nil {
+		if err = s.db.BlockTxUpdate(ctx, 1, txs, last.Hash); err != nil {
 			return fmt.Errorf("block tx update: %w", err)
 		}
 		// leveldb does all kinds of allocations, force GC to lower
@@ -1483,7 +1483,7 @@ func (s *Server) KeystoneIndexerUnwind(ctx context.Context, startBH, endBH *tbcd
 
 		// Flush to disk
 		start = time.Now()
-		if err = s.db.BlockKeystoneUpdate(ctx, -1, kss, &last.Hash); err != nil {
+		if err = s.db.BlockKeystoneUpdate(ctx, -1, kss, last.Hash); err != nil {
 			return fmt.Errorf("block keystone update: %w", err)
 		}
 		// leveldb does all kinds of allocations, force GC to lower
@@ -1537,7 +1537,7 @@ func (s *Server) KeystoneIndexerWind(ctx context.Context, startBH, endBH *tbcd.B
 
 		// Flush to disk
 		start = time.Now()
-		if err = s.db.BlockKeystoneUpdate(ctx, 1, kss, &last.Hash); err != nil {
+		if err = s.db.BlockKeystoneUpdate(ctx, 1, kss, last.Hash); err != nil {
 			return fmt.Errorf("block hemi update: %w", err)
 		}
 		// leveldb does all kinds of allocations, force GC to lower

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -420,7 +420,7 @@ func (s *Server) txOutFromOutPoint(ctx context.Context, op tbcd.Outpoint) (*wire
 	txIndex := op.TxIndex()
 
 	// Find block hashes
-	blockHash, err := s.db.BlockHashByTxId(ctx, txId)
+	blockHash, err := s.db.BlockHashByTxId(ctx, *txId)
 	if err != nil {
 		return nil, fmt.Errorf("block by txid: %w", err)
 	}

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -364,7 +364,7 @@ func (s *Server) headerAndBlock(ctx context.Context, hash *chainhash.Hash) (*tbc
 	if err != nil {
 		return nil, nil, fmt.Errorf("block header %v: %w", hash, err)
 	}
-	b, err := s.db.BlockByHash(ctx, &bh.Hash)
+	b, err := s.db.BlockByHash(ctx, bh.Hash)
 	if err != nil {
 		return nil, nil, fmt.Errorf("block by hash %v: %w", bh, err)
 	}
@@ -424,7 +424,7 @@ func (s *Server) txOutFromOutPoint(ctx context.Context, op tbcd.Outpoint) (*wire
 	if err != nil {
 		return nil, fmt.Errorf("block by txid: %w", err)
 	}
-	b, err := s.db.BlockByHash(ctx, blockHash)
+	b, err := s.db.BlockByHash(ctx, *blockHash)
 	if err != nil {
 		return nil, fmt.Errorf("block by hash: %w", err)
 	}
@@ -703,7 +703,7 @@ func (s *Server) unindexUtxosInBlocks(ctx context.Context, endHash *chainhash.Ha
 		}
 
 		// Index block
-		b, err := s.db.BlockByHash(ctx, &bh.Hash)
+		b, err := s.db.BlockByHash(ctx, bh.Hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block by hash %v: %w", bh, err)
 		}
@@ -1049,7 +1049,7 @@ func (s *Server) unindexTxsInBlocks(ctx context.Context, endHash *chainhash.Hash
 		}
 
 		// Index block
-		b, err := s.db.BlockByHash(ctx, &bh.Hash)
+		b, err := s.db.BlockByHash(ctx, bh.Hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block by hash %v: %w", bh, err)
 		}
@@ -1411,7 +1411,7 @@ func (s *Server) unindexKeystonesInBlocks(ctx context.Context, endHash *chainhas
 		}
 
 		// Index block
-		b, err := s.db.BlockByHash(ctx, &bh.Hash)
+		b, err := s.db.BlockByHash(ctx, bh.Hash)
 		if err != nil {
 			return 0, last, fmt.Errorf("block by hash %v: %w", bh, err)
 		}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -272,7 +272,7 @@ func (s *Server) handleBlockByHashRequest(ctx context.Context, req *tbcapi.Block
 	log.Tracef("handleBlockByHashRequest")
 	defer log.Tracef("handleBlockByHashRequest exit")
 
-	block, err := s.BlockByHash(ctx, *req.Hash)
+	block, err := s.BlockByHash(ctx, req.Hash)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return &tbcapi.BlockByHashResponse{
@@ -295,7 +295,7 @@ func (s *Server) handleBlockByHashRawRequest(ctx context.Context, req *tbcapi.Bl
 	log.Tracef("handleBlockByHashRawRequest")
 	defer log.Tracef("handleBlockByHashRawRequest exit")
 
-	block, err := s.BlockByHash(ctx, *req.Hash)
+	block, err := s.BlockByHash(ctx, req.Hash)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return &tbcapi.BlockByHashRawResponse{
@@ -493,7 +493,7 @@ func (s *Server) handleTxByIdRawRequest(ctx context.Context, req *tbcapi.TxByIdR
 	log.Tracef("handleTxByIdRawRequest")
 	defer log.Tracef("handleTxByIdRawRequest exit")
 
-	tx, err := s.TxById(ctx, *req.TxID)
+	tx, err := s.TxById(ctx, req.TxID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			responseErr := protocol.RequestErrorf("tx not found: %s", req.TxID)
@@ -525,7 +525,7 @@ func (s *Server) handleTxByIdRequest(ctx context.Context, req *tbcapi.TxByIdRequ
 	log.Tracef("handleTxByIdRequest")
 	defer log.Tracef("handleTxByIdRequest exit")
 
-	tx, err := s.TxById(ctx, *req.TxID)
+	tx, err := s.TxById(ctx, req.TxID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			responseErr := protocol.RequestErrorf("tx not found: %s", req.TxID)
@@ -644,12 +644,7 @@ func (s *Server) handleBlockKeystoneByL2KeystoneAbrevHashRequest(ctx context.Con
 	log.Tracef("handleBlockKeystoneByL2KeystoneAbrevHashRequest")
 	defer log.Tracef("handleBlockKeystoneByL2KeystoneAbrevHashRequest exit")
 
-	if req.L2KeystoneAbrevHash == nil {
-		return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{
-			Error: protocol.RequestErrorf("invalid nil abrev hash"),
-		}, nil
-	}
-	ks, err := s.db.BlockKeystoneByL2KeystoneAbrevHash(ctx, *req.L2KeystoneAbrevHash)
+	ks, err := s.db.BlockKeystoneByL2KeystoneAbrevHash(ctx, req.L2KeystoneAbrevHash)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return &tbcapi.BlockKeystoneByL2KeystoneAbrevHashResponse{
@@ -672,18 +667,13 @@ func (s *Server) handleBlockDownloadAsyncRequest(ctx context.Context, req *tbcap
 	log.Tracef("handleBlockAsyncDownloadRequest")
 	defer log.Tracef("handleBlockAsyncDownloadRequest exit")
 
-	if req.Hash == nil {
-		return &tbcapi.BlockDownloadAsyncResponse{
-			Error: protocol.RequestErrorf("hash must be provided"),
-		}, nil
-	}
 	if req.Peers <= 0 || req.Peers > 5 {
 		return &tbcapi.BlockDownloadAsyncResponse{
 			Error: protocol.RequestErrorf("invalid peers"),
 		}, nil
 	}
 
-	blk, err := s.DownloadBlockFromRandomPeers(ctx, *req.Hash, req.Peers)
+	blk, err := s.DownloadBlockFromRandomPeers(ctx, req.Hash, req.Peers)
 	if err != nil {
 		e := protocol.NewInternalError(err)
 		return &tbcapi.BlockDownloadAsyncRawResponse{Error: e.ProtocolError()}, e
@@ -700,18 +690,13 @@ func (s *Server) handleBlockDownloadAsyncRawRequest(ctx context.Context, req *tb
 	log.Tracef("handleBlockDownloadAsyncRawRequest")
 	defer log.Tracef("handleBlockDownloadAsyncRawRequest exit")
 
-	if req.Hash == nil {
-		return &tbcapi.BlockDownloadAsyncRawResponse{
-			Error: protocol.RequestErrorf("hash must be provided"),
-		}, nil
-	}
 	if req.Peers <= 0 || req.Peers > 5 {
 		return &tbcapi.BlockDownloadAsyncRawResponse{
 			Error: protocol.RequestErrorf("too many peers"),
 		}, nil
 	}
 
-	blk, err := s.DownloadBlockFromRandomPeers(ctx, *req.Hash, req.Peers)
+	blk, err := s.DownloadBlockFromRandomPeers(ctx, req.Hash, req.Peers)
 	if err != nil {
 		e := protocol.NewInternalError(err)
 		return &tbcapi.BlockDownloadAsyncRawResponse{Error: e.ProtocolError()}, e

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -493,7 +493,7 @@ func (s *Server) handleTxByIdRawRequest(ctx context.Context, req *tbcapi.TxByIdR
 	log.Tracef("handleTxByIdRawRequest")
 	defer log.Tracef("handleTxByIdRawRequest exit")
 
-	tx, err := s.TxById(ctx, req.TxID)
+	tx, err := s.TxById(ctx, *req.TxID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			responseErr := protocol.RequestErrorf("tx not found: %s", req.TxID)
@@ -525,7 +525,7 @@ func (s *Server) handleTxByIdRequest(ctx context.Context, req *tbcapi.TxByIdRequ
 	log.Tracef("handleTxByIdRequest")
 	defer log.Tracef("handleTxByIdRequest exit")
 
-	tx, err := s.TxById(ctx, req.TxID)
+	tx, err := s.TxById(ctx, *req.TxID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			responseErr := protocol.RequestErrorf("tx not found: %s", req.TxID)

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -272,7 +272,7 @@ func (s *Server) handleBlockByHashRequest(ctx context.Context, req *tbcapi.Block
 	log.Tracef("handleBlockByHashRequest")
 	defer log.Tracef("handleBlockByHashRequest exit")
 
-	block, err := s.BlockByHash(ctx, req.Hash)
+	block, err := s.BlockByHash(ctx, *req.Hash)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return &tbcapi.BlockByHashResponse{
@@ -295,7 +295,7 @@ func (s *Server) handleBlockByHashRawRequest(ctx context.Context, req *tbcapi.Bl
 	log.Tracef("handleBlockByHashRawRequest")
 	defer log.Tracef("handleBlockByHashRawRequest exit")
 
-	block, err := s.BlockByHash(ctx, req.Hash)
+	block, err := s.BlockByHash(ctx, *req.Hash)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return &tbcapi.BlockByHashRawResponse{
@@ -683,7 +683,7 @@ func (s *Server) handleBlockDownloadAsyncRequest(ctx context.Context, req *tbcap
 		}, nil
 	}
 
-	blk, err := s.DownloadBlockFromRandomPeers(ctx, req.Hash, req.Peers)
+	blk, err := s.DownloadBlockFromRandomPeers(ctx, *req.Hash, req.Peers)
 	if err != nil {
 		e := protocol.NewInternalError(err)
 		return &tbcapi.BlockDownloadAsyncRawResponse{Error: e.ProtocolError()}, e
@@ -711,7 +711,7 @@ func (s *Server) handleBlockDownloadAsyncRawRequest(ctx context.Context, req *tb
 		}, nil
 	}
 
-	blk, err := s.DownloadBlockFromRandomPeers(ctx, req.Hash, req.Peers)
+	blk, err := s.DownloadBlockFromRandomPeers(ctx, *req.Hash, req.Peers)
 	if err != nil {
 		e := protocol.NewInternalError(err)
 		return &tbcapi.BlockDownloadAsyncRawResponse{Error: e.ProtocolError()}, e

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1323,7 +1323,7 @@ func TestTxById(t *testing.T) {
 		t.Fatal(response.Error.Message)
 	}
 
-	tx, err := tbcServer.TxById(ctx, txId)
+	tx, err := tbcServer.TxById(ctx, *txId)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1597,7 +1597,7 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 				AbbreviatedKeystone: abrvKss,
 			}
 
-			if err := s.db.BlockKeystoneUpdate(ctx, 1, kssCache, &btcBlockHash); err != nil {
+			if err := s.db.BlockKeystoneUpdate(ctx, 1, kssCache, btcBlockHash); err != nil {
 				t.Fatal(err)
 			}
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1054,7 +1054,7 @@ func TestTxByIdRaw(t *testing.T) {
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxID: txId,
+		TxID: *txId,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1137,7 +1137,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 	txId[0]++
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxID: txId,
+		TxID: *txId,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1226,7 +1226,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	txId[len(txId)-1] = 8
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxID: txId,
+		TxID: *txId,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1301,7 +1301,7 @@ func TestTxById(t *testing.T) {
 
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxID: txId,
+		TxID: *txId,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1380,7 +1380,7 @@ func TestTxByIdInvalid(t *testing.T) {
 	txId[0]++
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxID: txId,
+		TxID: *txId,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1470,7 +1470,7 @@ func TestTxByIdNotFound(t *testing.T) {
 	txId[len(txId)-1] = 8
 
 	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxID: txId,
+		TxID: *txId,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1535,10 +1535,6 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 
 	testTable := []testTableItem{
 		{
-			name:          "nilL2KeystoneAbrevHash",
-			expectedError: protocol.RequestErrorf("invalid nil abrev hash"),
-		},
-		{
 			name:                "invalidL2KeystoneAbrevHash",
 			l2KeystoneAbrevHash: &invalidL2KeystoneAbrevHash,
 			expectedError:       protocol.RequestErrorf("could not find l2 keystone"),
@@ -1602,7 +1598,7 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 			}
 
 			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockKeystoneByL2KeystoneAbrevHashRequest{
-				L2KeystoneAbrevHash: tti.l2KeystoneAbrevHash,
+				L2KeystoneAbrevHash: *tti.l2KeystoneAbrevHash,
 			}); err != nil {
 				t.Fatal(err)
 			}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1659,7 +1659,7 @@ func indexAll(ctx context.Context, t *testing.T, tbcServer *Server) {
 
 	hash := bh.BlockHash()
 
-	if err := tbcServer.SyncIndexersToHash(ctx, &hash); err != nil {
+	if err := tbcServer.SyncIndexersToHash(ctx, hash); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1683,7 +1683,7 @@ func (s *Server) insertGenesis(ctx context.Context, height uint64, diff *big.Int
 	// We really should be inserting the block first but block insert
 	// verifies that a block header exists.
 	log.Infof("Inserting genesis block and header: %v", s.chainParams.GenesisHash)
-	err := s.db.BlockHeaderGenesisInsert(ctx, &s.chainParams.GenesisBlock.Header, height, diff)
+	err := s.db.BlockHeaderGenesisInsert(ctx, s.chainParams.GenesisBlock.Header, height, diff)
 	if err != nil {
 		return fmt.Errorf("genesis block header insert: %w", err)
 	}
@@ -2699,7 +2699,7 @@ func (s *Server) ExternalHeaderSetup(ctx context.Context, upstreamStateId []byte
 
 		// Getting best header returned ErrNotFound so assume initial
 		// startup
-		err = s.db.BlockHeaderGenesisInsert(ctx, genesis, genesisHeight,
+		err = s.db.BlockHeaderGenesisInsert(ctx, *genesis, genesisHeight,
 			genesisDiff)
 		if err != nil {
 			return fmt.Errorf("genesis block header insert: %w", err)

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -993,7 +993,7 @@ func (s *Server) handleBlockExpired(ctx context.Context, key any, value any) err
 	if !canonical {
 		log.Infof("Deleting from blocks missing database: %v %v %v",
 			p, bhX.Height, bhX)
-		err := s.db.BlockMissingDelete(ctx, int64(bhX.Height), &bhX.Hash)
+		err := s.db.BlockMissingDelete(ctx, int64(bhX.Height), bhX.Hash)
 		if err != nil {
 			return fmt.Errorf("block expired delete missing: %w", err)
 		}
@@ -1932,7 +1932,7 @@ func (s *Server) ScriptHashAvailableToSpend(ctx context.Context, txId *chainhash
 	return false, nil
 }
 
-func (s *Server) SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) ([]tbcd.SpentInfo, error) {
+func (s *Server) SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]tbcd.SpentInfo, error) {
 	log.Tracef("SpentOutputsByTxId")
 	defer log.Tracef("SpentOutputsByTxId exit")
 
@@ -1949,7 +1949,7 @@ func (s *Server) SpentOutputsByTxId(ctx context.Context, txId *chainhash.Hash) (
 	return si, nil
 }
 
-func (s *Server) BlockInTxIndex(ctx context.Context, blkid *chainhash.Hash) (bool, error) {
+func (s *Server) BlockInTxIndex(ctx context.Context, blkid chainhash.Hash) (bool, error) {
 	log.Tracef("BlockInTxIndex")
 	defer log.Tracef("BlockInTxIndex exit")
 
@@ -1961,7 +1961,7 @@ func (s *Server) BlockInTxIndex(ctx context.Context, blkid *chainhash.Hash) (boo
 	return s.db.BlockInTxIndex(ctx, blkid)
 }
 
-func (s *Server) BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*chainhash.Hash, error) {
+func (s *Server) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainhash.Hash, error) {
 	log.Tracef("BlockHashByTxId")
 	defer log.Tracef("BlockHashByTxId exit")
 
@@ -1972,7 +1972,7 @@ func (s *Server) BlockHashByTxId(ctx context.Context, txId *chainhash.Hash) (*ch
 	return s.db.BlockHashByTxId(ctx, txId)
 }
 
-func (s *Server) TxById(ctx context.Context, txId *chainhash.Hash) (*wire.MsgTx, error) {
+func (s *Server) TxById(ctx context.Context, txId chainhash.Hash) (*wire.MsgTx, error) {
 	log.Tracef("TxById")
 	defer log.Tracef("TxById exit")
 
@@ -1989,7 +1989,7 @@ func (s *Server) TxById(ctx context.Context, txId *chainhash.Hash) (*wire.MsgTx,
 		return nil, err
 	}
 	for _, tx := range block.Transactions() {
-		if tx.Hash().IsEqual(txId) {
+		if tx.Hash().IsEqual(&txId) {
 			return tx.MsgTx(), nil
 		}
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -982,7 +982,7 @@ func (s *Server) handleBlockExpired(ctx context.Context, key any, value any) err
 	if err != nil {
 		return fmt.Errorf("new hash: %w", err)
 	}
-	bhX, err := s.db.BlockHeaderByHash(ctx, hash)
+	bhX, err := s.db.BlockHeaderByHash(ctx, *hash)
 	if err != nil {
 		return fmt.Errorf("block header by hash: %w", err)
 	}
@@ -1133,7 +1133,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 				// Fixup ib array to not ask for block headers
 				// we already have.
 				ib = slices.DeleteFunc(ib, func(h *chainhash.Hash) bool {
-					_, _, err := s.BlockHeaderByHash(ctx, h)
+					_, _, err := s.BlockHeaderByHash(ctx, *h)
 					return err == nil
 				})
 
@@ -1599,7 +1599,7 @@ func (s *Server) handleInv(ctx context.Context, p *rawpeer.RawPeer, msg *wire.Ms
 			// txsFound = true
 		case wire.InvTypeBlock:
 			// Make sure we haven't seen block header yet.
-			_, _, err := s.BlockHeaderByHash(ctx, &v.Hash)
+			_, _, err := s.BlockHeaderByHash(ctx, v.Hash)
 			if err == nil {
 				return nil
 			}
@@ -1711,7 +1711,7 @@ func (s *Server) BlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil
 
 // XXX should we return a form of tbcd.BlockHeader which contains all info? and
 // note that the return parameters here are reversed from BlockHeaderBest call.
-func (s *Server) BlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*wire.BlockHeader, uint64, error) {
+func (s *Server) BlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*wire.BlockHeader, uint64, error) {
 	log.Tracef("BlockHeaderByHash")
 	defer log.Tracef("BlockHeaderByHash exit")
 
@@ -1786,7 +1786,7 @@ func (s *Server) RawBlockHeaderBest(ctx context.Context) (uint64, api.ByteSlice,
 	return bhb.Height, bhb.Header[:], nil
 }
 
-func (s *Server) DifficultyAtHash(ctx context.Context, hash *chainhash.Hash) (*big.Int, error) {
+func (s *Server) DifficultyAtHash(ctx context.Context, hash chainhash.Hash) (*big.Int, error) {
 	log.Tracef("DifficultyAtHash")
 	defer log.Tracef("DifficultyAtHash exit")
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -2074,7 +2074,7 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 		}
 
 		_, _, hash, err := getHeaderHashIndex(i-1, simpleChainHeaders[:], simpleChainHashes[:])
-		header, height, err := tbc.BlockHeaderByHash(ctx, hash)
+		header, height, err := tbc.BlockHeaderByHash(ctx, *hash)
 		if err == nil {
 			t.Errorf("getting header by hash %x should have returned an error but did not", hash[:])
 		}

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -2029,7 +2029,7 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 	}
 
 	updateStateWithoutModificationsId := [32]byte{0x4C, 0xA1, 0x62, 0xB6}
-	err = tbc.SetUpstreamStateId(ctx, &updateStateWithoutModificationsId)
+	err = tbc.SetUpstreamStateId(ctx, updateStateWithoutModificationsId)
 	if err != nil {
 		t.Errorf("unable to set upstream state id, err: %v", err)
 	}

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1056,7 +1056,7 @@ func mustHave(ctx context.Context, t *testing.T, s *Server, blocks ...*block) er
 				if err != nil {
 					return fmt.Errorf("invalid tx hash: %w", err)
 				}
-				sis, err := s.SpentOutputsByTxId(ctx, tx)
+				sis, err := s.SpentOutputsByTxId(ctx, *tx)
 				if err != nil {
 					return fmt.Errorf("invalid spend infos: %w", err)
 				}
@@ -1081,7 +1081,7 @@ func mustHave(ctx context.Context, t *testing.T, s *Server, blocks ...*block) er
 				if err != nil {
 					return fmt.Errorf("invalid tx key: %w", err)
 				}
-				_, err = s.TxById(ctx, txId)
+				_, err = s.TxById(ctx, *txId)
 				if err != nil {
 					return fmt.Errorf("tx by id: %w", err)
 				}
@@ -1490,32 +1490,32 @@ func TestIndexNoFork(t *testing.T) {
 	}
 
 	// make sure genesis tx is in db
-	_, err = s.TxById(ctx, n.gtx.Hash())
+	_, err = s.TxById(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatalf("genesis not found: %v", err)
 	}
 	// make sure gensis was not spent
-	_, err = s.SpentOutputsByTxId(ctx, n.gtx.Hash())
+	_, err = s.SpentOutputsByTxId(ctx, *n.gtx.Hash())
 	if err == nil {
 		t.Fatal("genesis coinbase tx should not be spent")
 	}
 
 	// Spot check tx 1 from b2
 	tx := b2.b.Transactions()[1]
-	txb2, err := s.TxById(ctx, tx.Hash())
+	txb2, err := s.TxById(ctx, *tx.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !btcutil.NewTx(txb2).Hash().IsEqual(tx.Hash()) {
 		t.Fatal("hash not equal")
 	}
-	si, err := s.SpentOutputsByTxId(ctx, b1.b.Transactions()[0].Hash())
+	si, err := s.SpentOutputsByTxId(ctx, *b1.b.Transactions()[0].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = si
 	// t.Logf("%v: %v", b1.b.Transactions()[0].Hash(), spew.Sdump(si))
-	si, err = s.SpentOutputsByTxId(ctx, b2.b.Transactions()[1].Hash())
+	si, err = s.SpentOutputsByTxId(ctx, *b2.b.Transactions()[1].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1536,7 +1536,7 @@ func TestIndexNoFork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.TxById(ctx, n.gtx.Hash())
+	_, err = s.TxById(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatal("expected genesis")
 	}
@@ -1720,33 +1720,33 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	}
 
 	// make sure genesis tx is in db
-	_, err = s.TxById(ctx, n.gtx.Hash())
+	_, err = s.TxById(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatalf("genesis not found: %v", err)
 	}
 
 	// make sure gensis was not spent
-	_, err = s.SpentOutputsByTxId(ctx, n.gtx.Hash())
+	_, err = s.SpentOutputsByTxId(ctx, *n.gtx.Hash())
 	if err == nil {
 		t.Fatal("genesis coinbase tx should not be spent")
 	}
 
 	// Spot check tx 1 from b2
 	tx := b2.b.Transactions()[1]
-	txb2, err := s.TxById(ctx, tx.Hash())
+	txb2, err := s.TxById(ctx, *tx.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !btcutil.NewTx(txb2).Hash().IsEqual(tx.Hash()) {
 		t.Fatal("hash not equal")
 	}
-	si, err := s.SpentOutputsByTxId(ctx, b1.b.Transactions()[0].Hash())
+	si, err := s.SpentOutputsByTxId(ctx, *b1.b.Transactions()[0].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = si
 	// t.Logf("%v: %v", b1.b.Transactions()[0].Hash(), spew.Sdump(si))
-	si, err = s.SpentOutputsByTxId(ctx, b2.b.Transactions()[1].Hash())
+	si, err = s.SpentOutputsByTxId(ctx, *b2.b.Transactions()[1].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1778,7 +1778,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.TxById(ctx, n.gtx.Hash())
+	_, err = s.TxById(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatal("expected genesis")
 	}

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1038,7 +1038,7 @@ func newPKAddress(params *chaincfg.Params) (*btcec.PrivateKey, *btcec.PublicKey,
 
 func mustHave(ctx context.Context, t *testing.T, s *Server, blocks ...*block) error {
 	for _, b := range blocks {
-		_, height, err := s.BlockHeaderByHash(ctx, b.Hash())
+		_, height, err := s.BlockHeaderByHash(ctx, *b.Hash())
 		if err != nil {
 			return err
 		}
@@ -1229,7 +1229,7 @@ func TestFork(t *testing.T) {
 	}
 
 	// Check cumulative difficulty
-	difficulty, err := s.DifficultyAtHash(ctx, n.Best()[0])
+	difficulty, err := s.DifficultyAtHash(ctx, *n.Best()[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1457,7 +1457,7 @@ func TestIndexNoFork(t *testing.T) {
 	}
 
 	// genesis -> b3 should work with negative direction (cdiff is less than target)
-	direction, err := s.TxIndexIsLinear(ctx, b3.Hash())
+	direction, err := s.TxIndexIsLinear(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatalf("expected success g -> b3, got %v", err)
 	}
@@ -1466,7 +1466,7 @@ func TestIndexNoFork(t *testing.T) {
 	}
 
 	// Index to b3
-	err = s.SyncIndexersToHash(ctx, b3.Hash())
+	err = s.SyncIndexersToHash(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1523,7 +1523,7 @@ func TestIndexNoFork(t *testing.T) {
 	_ = si
 
 	// unwind back to b3 (removes b3 and b2)
-	err = s.SyncIndexersToHash(ctx, b2.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2.Hash())
 	if err != nil {
 		t.Fatalf("unwinding to genesis should have returned nil, got %v", err)
 	}
@@ -1532,7 +1532,7 @@ func TestIndexNoFork(t *testing.T) {
 		t.Fatalf("expected an error from mustHave: %v", err)
 	}
 
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1650,7 +1650,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	}
 
 	// genesis -> b3 should work with negative direction (cdiff is less than target)
-	direction, err := s.TxIndexIsLinear(ctx, b3.Hash())
+	direction, err := s.TxIndexIsLinear(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatalf("expected success g -> b3, got %v", err)
 	}
@@ -1659,7 +1659,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	}
 
 	// Index to b2
-	err = s.SyncIndexersToHash(ctx, b2.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1676,7 +1676,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	}
 
 	// Index to b3
-	err = s.SyncIndexersToHash(ctx, b3.Hash())
+	err = s.SyncIndexersToHash(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1754,7 +1754,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	_ = si
 
 	// unwind back to b3 (removes b3 and b2)
-	err = s.SyncIndexersToHash(ctx, b2.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2.Hash())
 	if err != nil {
 		t.Fatalf("unwinding to genesis should have returned nil, got %v", err)
 	}
@@ -1774,7 +1774,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 		t.Fatalf("wrong blockhash for stored keystone: %v", kss1Hash)
 	}
 
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1919,7 +1919,7 @@ func TestIndexFork(t *testing.T) {
 	// Verify linear indexing. Current TxIndex is sitting at genesis
 
 	// genesis -> b3 should work with negative direction (cdiff is less than target)
-	direction, err := s.TxIndexIsLinear(ctx, b3.Hash())
+	direction, err := s.TxIndexIsLinear(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatalf("expected success g -> b3, got %v", err)
 	}
@@ -1928,7 +1928,7 @@ func TestIndexFork(t *testing.T) {
 	}
 
 	// Index to b3
-	err = s.SyncIndexersToHash(ctx, b3.Hash())
+	err = s.SyncIndexersToHash(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1956,7 +1956,7 @@ func TestIndexFork(t *testing.T) {
 	t.Logf("b3: %v", b3)
 
 	// b3 -> genesis should work with postive direction (cdiff is greater than target)
-	direction, err = s.TxIndexIsLinear(ctx, s.chainParams.GenesisHash)
+	direction, err = s.TxIndexIsLinear(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("expected success b3 -> genesis, got %v", err)
 	}
@@ -1965,7 +1965,7 @@ func TestIndexFork(t *testing.T) {
 	}
 
 	// b3 -> b1 should work with positive direction
-	direction, err = s.TxIndexIsLinear(ctx, b1.Hash())
+	direction, err = s.TxIndexIsLinear(ctx, *b1.Hash())
 	if err != nil {
 		t.Fatalf("expected success b3 -> b1, got %v", err)
 	}
@@ -1974,25 +1974,25 @@ func TestIndexFork(t *testing.T) {
 	}
 
 	// b3 -> b2a should fail
-	_, err = s.TxIndexIsLinear(ctx, b2a.Hash())
+	_, err = s.TxIndexIsLinear(ctx, *b2a.Hash())
 	if !errors.Is(err, ErrNotLinear) {
 		t.Fatalf("b2a is not linear to b3: %v", err)
 	}
 
 	// b3 -> b2b should fail
-	_, err = s.TxIndexIsLinear(ctx, b2b.Hash())
+	_, err = s.TxIndexIsLinear(ctx, *b2b.Hash())
 	if !errors.Is(err, ErrNotLinear) {
 		t.Fatalf("b2b is not linear to b3: %v", err)
 	}
 
 	// make sure syncing to iself is non linear
-	err = s.SyncIndexersToHash(ctx, b3.Hash())
+	err = s.SyncIndexersToHash(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatalf("at b3, should have returned nil, got %v", err)
 	}
 
 	// unwind back to genesis
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("unwinding to genesis should have returned nil, got %v", err)
 	}
@@ -2027,7 +2027,7 @@ func TestIndexFork(t *testing.T) {
 	}
 
 	// see if we can move to b2a
-	direction, err = s.TxIndexIsLinear(ctx, b2a.Hash())
+	direction, err = s.TxIndexIsLinear(ctx, *b2a.Hash())
 	if err != nil {
 		t.Fatalf("expected success genesis -> b2a, got %v", err)
 	}
@@ -2035,7 +2035,7 @@ func TestIndexFork(t *testing.T) {
 		t.Fatalf("expected 1 going from genesis to b2a, got %v", direction)
 	}
 
-	err = s.SyncIndexersToHash(ctx, b2a.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2a.Hash())
 	if err != nil {
 		t.Fatalf("wind to b2a: %v", err)
 	}
@@ -2054,7 +2054,7 @@ func TestIndexFork(t *testing.T) {
 	}
 
 	// unwind back to genesis
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("unwinding to genesis should have returned nil, got %v", err)
 	}
@@ -2086,7 +2086,7 @@ func TestIndexFork(t *testing.T) {
 	}
 
 	t.Logf("---------------------------------------- going to b2b")
-	err = s.SyncIndexersToHash(ctx, b2b.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2b.Hash())
 	if err != nil {
 		t.Fatalf("wind to b2b: %v", err)
 	}
@@ -2106,7 +2106,7 @@ func TestIndexFork(t *testing.T) {
 
 	// t.Logf("---------------------------------------- going to b3")
 	// unwind back to genesis
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("xxxx %v", err)
 	}
@@ -2245,7 +2245,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	// Verify linear indexing. Current TxIndex is sitting at genesis
 
 	// genesis -> b3 should work with negative direction (cdiff is less than target)
-	direction, err := s.TxIndexIsLinear(ctx, b3.Hash())
+	direction, err := s.TxIndexIsLinear(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatalf("expected success g -> b3, got %v", err)
 	}
@@ -2254,7 +2254,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	}
 
 	// Index to b2
-	err = s.SyncIndexersToHash(ctx, b2.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2271,7 +2271,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	}
 
 	// Index to b3
-	err = s.SyncIndexersToHash(ctx, b3.Hash())
+	err = s.SyncIndexersToHash(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2319,7 +2319,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	t.Logf("b3: %v", b3)
 
 	// b3 -> genesis should work with postive direction (cdiff is greater than target)
-	direction, err = s.TxIndexIsLinear(ctx, s.chainParams.GenesisHash)
+	direction, err = s.TxIndexIsLinear(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("expected success b3 -> genesis, got %v", err)
 	}
@@ -2328,7 +2328,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	}
 
 	// b3 -> b1 should work with positive direction
-	direction, err = s.TxIndexIsLinear(ctx, b1.Hash())
+	direction, err = s.TxIndexIsLinear(ctx, *b1.Hash())
 	if err != nil {
 		t.Fatalf("expected success b3 -> b1, got %v", err)
 	}
@@ -2337,25 +2337,25 @@ func TestKeystoneIndexFork(t *testing.T) {
 	}
 
 	// b3 -> b2a should fail
-	_, err = s.TxIndexIsLinear(ctx, b2a.Hash())
+	_, err = s.TxIndexIsLinear(ctx, *b2a.Hash())
 	if !errors.Is(err, ErrNotLinear) {
 		t.Fatalf("b2a is not linear to b3: %v", err)
 	}
 
 	// b3 -> b2b should fail
-	_, err = s.TxIndexIsLinear(ctx, b2b.Hash())
+	_, err = s.TxIndexIsLinear(ctx, *b2b.Hash())
 	if !errors.Is(err, ErrNotLinear) {
 		t.Fatalf("b2b is not linear to b3: %v", err)
 	}
 
 	// make sure syncing to iself is non linear
-	err = s.SyncIndexersToHash(ctx, b3.Hash())
+	err = s.SyncIndexersToHash(ctx, *b3.Hash())
 	if err != nil {
 		t.Fatalf("at b3, should have returned nil, got %v", err)
 	}
 
 	// unwind back to genesis
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("unwinding to genesis should have returned nil, got %v", err)
 	}
@@ -2390,7 +2390,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	}
 
 	// see if we can move to b2a
-	direction, err = s.TxIndexIsLinear(ctx, b2a.Hash())
+	direction, err = s.TxIndexIsLinear(ctx, *b2a.Hash())
 	if err != nil {
 		t.Fatalf("expected success genesis -> b2a, got %v", err)
 	}
@@ -2398,7 +2398,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 		t.Fatalf("expected 1 going from genesis to b2a, got %v", direction)
 	}
 
-	err = s.SyncIndexersToHash(ctx, b2a.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2a.Hash())
 	if err != nil {
 		t.Fatalf("wind to b2a: %v", err)
 	}
@@ -2427,7 +2427,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	}
 
 	// unwind back to genesis
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("unwinding to genesis should have returned nil, got %v", err)
 	}
@@ -2459,7 +2459,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	}
 
 	t.Logf("---------------------------------------- going to b2b")
-	err = s.SyncIndexersToHash(ctx, b2b.Hash())
+	err = s.SyncIndexersToHash(ctx, *b2b.Hash())
 	if err != nil {
 		t.Fatalf("wind to b2b: %v", err)
 	}
@@ -2489,7 +2489,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 
 	// t.Logf("---------------------------------------- going to b3")
 	// unwind back to genesis
-	err = s.SyncIndexersToHash(ctx, s.chainParams.GenesisHash)
+	err = s.SyncIndexersToHash(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("xxxx %v", err)
 	}


### PR DESCRIPTION
**Summary**
Turns out some callers send in nil and play with the underlying data so we cannot reliably use pointers to hashes. Convert them to stack variables. There is no real impact on performance at the cost of some stack space but this does harden the call stack considerably.

**Changes**
<!-- A list of changes made by this pull request. -->
