### PR TITLE
ttl: fix typos in comments

### DIFF
--- a/ttl/ttl.go
+++ b/ttl/ttl.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 


### PR DESCRIPTION
- "callback functions" → "callback function" (singular)
- "key value pair" → "key-value pair" (hyphenated)
- "Len return" → "Len returns" (grammar fix)

