### PR TITLE
tbc: fix race condition in fork tests

### DIFF
--- a/service/tbc/peer/rawpeer/rawpeer.go
+++ b/service/tbc/peer/rawpeer/rawpeer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -110,8 +110,8 @@ func (r *RawPeer) Id() int {
 
 func (r *RawPeer) Write(timeout time.Duration, msg wire.Message) error {
 	r.mtx.Lock()
+	defer r.mtx.Unlock()
 	conn := r.conn
-	r.mtx.Unlock()
 	if conn == nil {
 		return fmt.Errorf("write: %w", ErrNoConn)
 	}

--- a/service/tbc/peer/rawpeer/rawpeer_test.go
+++ b/service/tbc/peer/rawpeer/rawpeer_test.go
@@ -89,8 +89,10 @@ func TestConcurrentReadWrite(t *testing.T) {
 		panic(err)
 	}
 
-	writerNum := 2
-	WriteCount := 100
+	const (
+		writeNum = 2
+		writeCount = 100	
+	)
 
 	fakeCh := chainhash.Hash{}
 	for k := range writerNum {

--- a/service/tbc/peer/rawpeer/rawpeer_test.go
+++ b/service/tbc/peer/rawpeer/rawpeer_test.go
@@ -90,14 +90,14 @@ func TestConcurrentReadWrite(t *testing.T) {
 	}
 
 	const (
-		writeNum = 2
-		writeCount = 100	
+		writerNum  = 2
+		writeCount = 100
 	)
 
-	fakeCh := chainhash.Hash{}
+	var fakeCh chainhash.Hash
 	for k := range writerNum {
 		go func() {
-			for range WriteCount {
+			for range writeCount {
 				bh := wire.NewBlockHeader(int32(k), &fakeCh, &fakeCh, uint32(k), uint32(k))
 				mva := wire.NewMsgHeaders()
 				mva.AddBlockHeader(bh)
@@ -110,7 +110,7 @@ func TestConcurrentReadWrite(t *testing.T) {
 
 	expectedCmds := map[string]int{
 		wire.CmdPing:    1,
-		wire.CmdHeaders: writerNum * WriteCount,
+		wire.CmdHeaders: writerNum * writeCount,
 	}
 
 	for {

--- a/service/tbc/peer/rawpeer/rawpeer_test.go
+++ b/service/tbc/peer/rawpeer/rawpeer_test.go
@@ -4,4 +4,132 @@
 
 package rawpeer
 
-// XXX add tests here
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/phayes/freeport"
+)
+
+func GetFreePort() string {
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		panic(err)
+	}
+	return strconv.Itoa(port)
+}
+
+func mockPeerServer(ctx context.Context, id int, listener net.Listener, msgCh chan string) error {
+	conn, err := listener.Accept()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	p, err := NewFromConn(conn, wire.TestNet3, wire.AddrV2Version, id)
+	if err != nil {
+		return err
+	}
+
+	var rmsg wire.Message
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			rmsg, _, err = p.Read(0)
+			if err != nil {
+				return err
+			}
+			msgCh <- rmsg.Command()
+		}
+	}
+}
+
+func TestRawpeerReadWrite(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	msgCh := make(chan string)
+
+	port := GetFreePort()
+
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		err := mockPeerServer(ctx, 2, listener, msgCh)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+			panic(err)
+		}
+	}()
+
+	conn, err := net.Dial("tcp", "localhost:"+port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	p1, err := NewFromConn(conn, wire.TestNet3, wire.AddrV2Version, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p1.Write(0, wire.NewMsgPing(1)); err != nil {
+		panic(err)
+	}
+
+	for k := range 2 {
+		go func() {
+			for range 100 {
+				fakeCh := chainhash.Hash{0xde, 0xad, 0xbe, 0xef}
+				bh := wire.NewBlockHeader(1, &fakeCh, &fakeCh, uint32(k), uint32(k))
+				mva := wire.NewMsgHeaders()
+				mva.AddBlockHeader(bh)
+				if err := p1.Write(0, mva); err != nil {
+					panic(err)
+				}
+			}
+		}()
+	}
+
+	receivedCmds := make(map[string]int)
+
+	expectedCmds := map[string]int{
+		wire.CmdPing:    1,
+		wire.CmdHeaders: 200,
+	}
+
+	for {
+		select {
+		case s := <-msgCh:
+			t.Logf("received response from server: %v", s)
+			receivedCmds[s]++
+		case <-ctx.Done():
+			if ctx.Err() != nil {
+				t.Fatal(ctx.Err())
+			}
+		}
+		remaining := false
+		for k, v := range expectedCmds {
+			if v != receivedCmds[k] {
+				t.Logf("%v %v commands left", v-receivedCmds[k], k)
+				remaining = true
+			}
+		}
+		if !remaining {
+			break
+		}
+	}
+
+}

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -978,8 +978,6 @@ func (b *btcNode) MineAndSend(ctx context.Context, name string, parent *chainhas
 		return nil, err
 	}
 
-	time.Sleep(100 * time.Millisecond)
-
 	return blk, nil
 }
 
@@ -1169,7 +1167,7 @@ func TestFork(t *testing.T) {
 		t.Fatal(err)
 	}
 	// t.Logf("%v", spew.Sdump(n.chain[n.Best()[0].String()]))
-	time.Sleep(500 * time.Millisecond) // XXX
+	time.Sleep(250 * time.Millisecond) // XXX
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1403,7 +1401,7 @@ func TestIndexNoFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1593,7 +1591,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -1839,7 +1837,7 @@ func TestIndexFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -2161,7 +2159,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 			panic(err)
 		}
 	}()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	// Connect tbc service
 	cfg := &Config{
@@ -2241,8 +2239,6 @@ func TestKeystoneIndexFork(t *testing.T) {
 	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
-
-	// time.Sleep(2000 * time.Millisecond)
 
 	// Verify linear indexing. Current TxIndex is sitting at genesis
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -978,6 +978,8 @@ func (b *btcNode) MineAndSend(ctx context.Context, name string, parent *chainhas
 		return nil, err
 	}
 
+	time.Sleep(100 * time.Millisecond)
+
 	return blk, nil
 }
 
@@ -2240,7 +2242,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(2000 * time.Millisecond)
+	// time.Sleep(2000 * time.Millisecond)
 
 	// Verify linear indexing. Current TxIndex is sitting at genesis
 


### PR DESCRIPTION
**Summary**
Fixes a [race condition ](https://github.com/hemilabs/heminetwork/actions/runs/13774032146/job/38519089244) that occurs due to multiple blockheader messages being sent to TBC before it has time to read them.

**Changes**
Fix slight error in locking mechanism for rawpeer conn writes, and added a test that should make it easier to identify hidden race conditions such as this one.
