### PR TITLE
all: change default network to mainnet

### DIFF
--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -23,7 +23,7 @@ import (
 const (
 	daemonName      = "tbcd"
 	defaultLogLevel = daemonName + "=INFO;tbc=INFO;level=INFO"
-	defaultNetwork  = "testnet3" // XXX make this mainnet
+	defaultNetwork  = "mainnet"
 	defaultHome     = "~/." + daemonName
 	bDefaultSize    = "512mb" // ~320 blocks on mainnet
 	bhsDefaultSize  = "2mb"

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -95,7 +95,7 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		BFGWSURL:          "http://localhost:8383/v1/ws/public",
 		BFGRequestTimeout: DefaultBFGRequestTimeout,
-		BTCChainName:      "testnet3",
+		BTCChainName:      "mainnet",
 	}
 }
 


### PR DESCRIPTION
**Summary**
Change the default PoP Miner and tbcd networks to Bitcoin mainnet.

**Changes**
- Change PoP Miner default network to Bitcoin mainnet.
- Change TBC default network to Bitcoin mainnet.
