### PR TITLE
popm: fix test expecting testnet3

### DIFF
--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -90,6 +90,7 @@ func TestBTCPrivateKeyFromHex(t *testing.T) {
 
 func TestNewMiner(t *testing.T) {
 	cfg := NewDefaultConfig()
+	cfg.BTCChainName = "testnet3"
 	cfg.BTCPrivateKey = "ebaaedce6af48a03bbfd25e8cd0364140ebaaedce6af48a03bbfd25e8cd03641"
 
 	m, err := NewMiner(cfg)


### PR DESCRIPTION
**Summary**
Fix popm test expecting testnet3 but default was changed to mainnet

**Changes**
<!-- A list of changes made by this pull request. -->
