### PR TITLE
ci: remove dependance on npm for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
   release:
     name: "Release"
     runs-on: "ubuntu-latest"
-    needs: [ "test-go", "npm" ]
+    needs: [ "test-go" ]
     permissions:
       # Required to create GitHub releases.
       contents: write


### PR DESCRIPTION
**Summary**
Remove dependance on NPM package being published to create release.

**Changes**
<!-- A list of changes made by this pull request. -->
