### PR TITLE
ci: split go build job to improve runtime

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,6 +46,27 @@ jobs:
   build:
     name: "Build"
     runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: "Setup Go ${{ matrix.go-version }}"
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
+          check-latest: true
+
+      - name: "Download and verify dependencies"
+        id: deps
+        run: make GOCACHE="$(go env GOCACHE)" go-deps
+
+      - name: "make build"
+        run: make GOCACHE="$(go env GOCACHE)" build
+
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
     services:
       postgres:
         image: postgres:16.3-alpine3.20
@@ -73,15 +94,29 @@ jobs:
         id: deps
         run: make GOCACHE="$(go env GOCACHE)" go-deps
 
-      - name: "make race"
-        run: make GOCACHE="$(go env GOCACHE)" race
-
-      - name: "make"
-        if: (success() || failure()) && steps.deps.outcome == 'success'
+      - name: "make test (with E2E tests)"
         env:
           PGTESTURI: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
           HEMI_DOCKER_TESTS: "1"
-        run: make GOCACHE="$(go env GOCACHE)" test build
+        run: make GOCACHE="$(go env GOCACHE)" test
 
-      - name: "Check changes"
-        run: git diff --exit-code
+  test-race:
+    name: "Test (race)"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: "Setup Go ${{ matrix.go-version }}"
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
+          check-latest: true
+
+      - name: "Download and verify dependencies"
+        id: deps
+        run: make GOCACHE="$(go env GOCACHE)" go-deps
+
+      - name: "make race"
+        run: make GOCACHE="$(go env GOCACHE)" race


### PR DESCRIPTION
**Summary**
Split the Go workflow's "Build" job into 3 separate jobs. This allows make build, make test and make race to be run in parallel.

On average this speeds up CI by about 1 minute and 30 seconds, which I believe is a welcome change.
Ideally, requiring `Go / Build`, `Go / Lint` and `Go / Test` to pass prior to merging a pull request (in repository rule-sets) would prevent broken pull requests from being merged (@jcvernaleo).

**Changes**
<!-- A list of changes made by this pull request. -->
