### PR TITLE
database/tbcd/level: fix printf-style function used with no args

### DIFF
--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -91,7 +91,7 @@ func TestLRUCache(t *testing.T) {
 		t.Fatal(spew.Sdump(s))
 	}
 
-	t.Logf(spew.Sdump(s))
+	t.Log(spew.Sdump(s))
 }
 
 func newHeader(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *tbcd.BlockHeader) {
@@ -168,7 +168,7 @@ func TestMapCache(t *testing.T) {
 		t.Fatal(spew.Sdump(s))
 	}
 
-	t.Logf(spew.Sdump(s))
+	t.Log(spew.Sdump(s))
 }
 
 func intHash(b int) chainhash.Hash {


### PR DESCRIPTION
**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->


printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)go-staticcheck

**Changes**
<!-- A list of changes made by this pull request. -->
