### PR TITLE
popm: don't instantly noop if bfg response channel is busy

### DIFF
--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -742,7 +742,7 @@ func (m *Miner) handleBFGCallCompletion(parrentCtx context.Context, conn *protoc
 	select {
 	case bc.ch <- payload:
 		log.Tracef("handleBFGCallCompletion returned: %v", spew.Sdump(payload))
-	case <-time.After(DefaultBFGRequestTimeout):
+	case <-time.After(m.requestTimeout):
 		log.Errorf("handleBFGCallCompletion: response time out %v", cmd)
 	}
 }

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -729,7 +729,7 @@ func (m *Miner) handleBFGCallCompletion(parrentCtx context.Context, conn *protoc
 
 	log.Tracef("handleBFGCallCompletion: %v", spew.Sdump(bc.msg))
 
-	_, _, payload, err := bfgapi.Call(ctx, conn, bc.msg)
+	cmd, _, payload, err := bfgapi.Call(ctx, conn, bc.msg)
 	if err != nil {
 		log.Debugf("handleBFGCallCompletion %T: %v", bc.msg, err)
 		select {
@@ -742,7 +742,8 @@ func (m *Miner) handleBFGCallCompletion(parrentCtx context.Context, conn *protoc
 	select {
 	case bc.ch <- payload:
 		log.Tracef("handleBFGCallCompletion returned: %v", spew.Sdump(payload))
-	default:
+	case <-time.After(DefaultBFGRequestTimeout):
+		log.Errorf("handleBFGCallCompletion: response time out %v", cmd)
 	}
 }
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -744,6 +744,7 @@ func (m *Miner) handleBFGCallCompletion(parrentCtx context.Context, conn *protoc
 		log.Tracef("handleBFGCallCompletion returned: %v", spew.Sdump(payload))
 	case <-time.After(m.requestTimeout):
 		log.Errorf("handleBFGCallCompletion: response time out %v", cmd)
+	case <-ctx.Done():
 	}
 }
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -1340,7 +1340,6 @@ func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string, keyst
 		}
 
 		for {
-			time.Sleep(50 * time.Millisecond)
 			command, id, _, err := bfgapi.Read(ctx, conn)
 			if err != nil {
 				if !errors.Is(ctx.Err(), context.Canceled) {


### PR DESCRIPTION
**Summary**
Fix #422 

**Changes**
Prior, whenever the channel that would receive bfg responses in pop miner was busy, we would no-op. this happened often because the channel was not buffered. this would happen silently as well. add a timeout to sending messages to the non-buffered channel and log and error if we time out
