### PR TITLE
all: use golicenser instead of go-header

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,7 @@ jobs:
           if ! (command -v 'golicenser' >/dev/null); then
             go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
           fi
-          echo "$LICENSE_FILE" > license_header.txt
+          echo "$LICENSE_HEADER" > license_header.txt
           golicenser -author="Hemi Labs, Inc." -year-mode=git-range ./...
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   GO_VERSION: "1.23.x"
+  GOLICENSER_VERSION: "0.1.0"
 
 permissions:
   contents: read
@@ -42,6 +43,23 @@ jobs:
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           version: "v1.62"
+
+      - name: "Cache golicenser"
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: "/bin/golicenser"
+          key: "${{ runner.os }}-golicenser-${{ env.GOLICENSER_VERSION }}"
+
+      - name: "golicenser"
+        env:
+          GOLICENSER_VERSION: "${{ env.GOLICENSER_VERSION }}"
+          LICENSE_HEADER: |
+            Copyright (c) {{.year}} {{.author}}
+            Use of this source code is governed by the MIT License,
+            which can be found in the LICENSE file.
+        run: |
+          GOBIN=/bin/ go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
+          /bin/golicenser -tmpl="$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range -fix ./...
 
   build:
     name: "Build"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 env:
-  GO_VERSION: "1.23.x"
+  GO_VERSION: "1.24.x"
   GOLICENSER_VERSION: "0.1.0"
 
 permissions:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,8 +57,11 @@ jobs:
             Use of this source code is governed by the MIT License,
             which can be found in the LICENSE file.
         run: |
-          go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
-          golicenser -tmpl="$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range ./...
+          if ! (command -v 'golicenser' >/dev/null); then
+            go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
+          fi
+          echo "$LICENSE_FILE" > license_header.txt
+          golicenser -author="Hemi Labs, Inc." -year-mode=git-range ./...
 
   build:
     name: "Build"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,19 +47,18 @@ jobs:
       - name: "Cache golicenser"
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: "/bin/golicenser"
+          path: "/home/runner/go/bin/golicenser"
           key: "${{ runner.os }}-golicenser-${{ env.GOLICENSER_VERSION }}"
 
       - name: "golicenser"
         env:
-          GOLICENSER_VERSION: "${{ env.GOLICENSER_VERSION }}"
           LICENSE_HEADER: |
             Copyright (c) {{.year}} {{.author}}
             Use of this source code is governed by the MIT License,
             which can be found in the LICENSE file.
         run: |
-          GOBIN=/bin/ go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
-          /bin/golicenser -tmpl="$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range -fix ./...
+          go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
+          golicenser -tmpl="$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range ./...
 
   build:
     name: "Build"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 env:
-  GO_VERSION: "1.23.x"
+  GO_VERSION: "1.24.x"
   PNPM_VERSION: "9.4.x"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.23.x"
+  GO_VERSION: "1.24.x"
   PNPM_VERSION: "9.4.x"
   GO_LDFLAGS: >-
     -X 'github.com/hemilabs/heminetwork/version.Brand=Hemi Labs'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,7 +31,6 @@ linters:
     - "gocheckcompilerdirectives" # Checks that go compiler directive comments (//go:) are valid.
     - "gochecksumtype" # Run exhaustiveness checks on Go "sum types".
     - "gofumpt" # Runs gofumpt.
-    - "goheader" # Enforces copyright header.
     # TODO enable gosec, when bored run 'golangci-lint run -Egosec' to fix these
     # - "gosec" # Checks for potential security issues
     - "gosimple" # Checks for ways to simplify code.
@@ -87,18 +86,6 @@ linters-settings:
   gomoddirectives:
     replace-allow-list:
       - "github.com/coder/websocket" # Currently uses our fork with a bug fix.
-
-  # Enforces copyright header
-  goheader: # TODO: Replace goheader, autofix is too buggy.
-    values:
-      const:
-        COMPANY: "Hemi Labs, Inc."
-      regexp:
-        YEAR_RANGE: "(\\d{4}-{{MOD-YEAR}})|({{MOD-YEAR}})"
-    template: |-
-      Copyright (c) {{ YEAR_RANGE }} {{ COMPANY }}
-      Use of this source code is governed by the MIT License,
-      which can be found in the LICENSE file.
 
   # Lints nolint directives.
   nolintlint:

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,20 @@ build:
 
 install: $(cmds)
 
+define LICENSE_HEADER
+Copyright (c) {{.year}} {{.author}}
+Use of this source code is governed by the MIT License,
+which can be found in the LICENSE file.
+endef
+export LICENSE_HEADER
+
 lint:
-	# TODO: re-enable autofix with --fix, after removing buggy goheader linter
-	$(shell go env GOPATH)/bin/golangci-lint run ./...
+	$(shell go env GOPATH)/bin/golangci-lint run --fix ./...
+	$(shell go env GOPATH)/bin/golicenser -tmpl="$$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range -fix ./...
 
 lint-deps:
 	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@v0.1.0
 
 tidy:
 	go mod tidy

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Copyright (c) 2024 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
 package level
 
 import (

--- a/database/tbcd/level/encodedecode_test.go
+++ b/database/tbcd/level/encodedecode_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
 package level
 
 import (

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
 package level
 
 import (

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/service/tbc/peer/rawpeer/rawpeer_test.go
+++ b/service/tbc/peer/rawpeer/rawpeer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 


### PR DESCRIPTION
**Summary**
Switch from using go-header (via golangci-lint) to [golicenser](https://github.com/joshuasing/golicenser).

`golicenser` has the following advantages:
 - Processes files in parallel (faster)
 - Correctly handles auto-fixes (does not place regex in the updated headers)
 - Uses Git to for copyright year ranges.
 - Maintained by me, so quick bug fixes if necessary :)

**Changes**
 - Remove use of `go-header` from golangci-lint config.
 - Add golicenser to `make lint-deps`
 - Add golicenser to `make lint`
 - Add golicenser to "Go / Lint" job
 - Use Go 1.24 for building in CI.

**Notes**
golicenser is not currently included in golangci-lint. Once it is, we can have it configured through the `.golangci.yml` file and the extra Make / GitHub Actions parts will no longer be necessary. Running as a part of golangci-lint will also make linting faster, as it prevents processing the AST and loading all files multiple times, and takes advantage of golangci-lint's caching.