### PR TITLE
docker, ci: use make go-deps to avoid installing lint deps

### DIFF
--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -33,7 +33,7 @@ jobs:
           check-latest: true
 
       - name: "Download and verify dependencies"
-        run: make deps
+        run: make go-deps
 
       - name: "build localnet"
         run: docker compose -f ./e2e/docker-compose.yml build

--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /build/
 COPY Makefile .
 COPY go.mod .
 COPY go.sum .
-RUN make deps
+RUN make go-deps
 
 COPY . .
 RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" bfgd

--- a/docker/bssd/Dockerfile
+++ b/docker/bssd/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /build/
 COPY Makefile .
 COPY go.mod .
 COPY go.sum .
-RUN make deps
+RUN make go-deps
 
 COPY . .
 RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" bssd

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /build/
 COPY Makefile .
 COPY go.mod .
 COPY go.sum .
-RUN make deps
+RUN make go-deps
 
 COPY . .
 RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" popmd


### PR DESCRIPTION
**Summary**
Use `make go-deps` instead of `make deps` to avoid installing linting/vulncheck dependencies when not necessary.

**Changes**
<!-- A list of changes made by this pull request. -->
