### PR TITLE
all: build with go1.24.1

### DIFF
--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        go-version: [ "1.23.x" ]
+        go-version: [ "1.24.x" ]
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 run:
   tests: false
+  go: "1.23"
 
 issues:
   # Show all errors

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Pre-built binaries are available on the [Releases Page](https://github.com/hemil
 
 - `git`
 - `make`
-- [Go v1.23+](https://go.dev/dl/)
+- [Go v1.24+](https://go.dev/dl/)
 
 ### Building with Makefile
 

--- a/cmd/tbcd/README.md
+++ b/cmd/tbcd/README.md
@@ -25,7 +25,7 @@ endpoint.**
 
 ### 🏁 Prerequisites
 
-Ensure Go v1.23 or newer is installed on your system.
+Ensure Go v1.24 or newer is installed on your system.
 
 ### Using Makefile
 

--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.23-alpine3.20@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/bfgd/goreleaser.Dockerfile
+++ b/docker/bfgd/goreleaser.Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5 AS builder
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS builder
 
 # Add ca-certificates, timezone data
 RUN apk --no-cache add --update ca-certificates tzdata

--- a/docker/bssd/Dockerfile
+++ b/docker/bssd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.23-alpine3.20@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/bssd/goreleaser.Dockerfile
+++ b/docker/bssd/goreleaser.Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5 AS builder
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS builder
 
 # Add ca-certificates, timezone data
 RUN apk --no-cache add --update ca-certificates tzdata

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.23-alpine3.20@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/popmd/goreleaser.Dockerfile
+++ b/docker/popmd/goreleaser.Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5 AS builder
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS builder
 
 # Add ca-certificates, timezone data
 RUN apk --no-cache add --update ca-certificates tzdata

--- a/e2e/monitor/README.md
+++ b/e2e/monitor/README.md
@@ -5,7 +5,7 @@ that we want to test against.
 
 ## Prerequisites
 
-* Go 1.23+
+* Go 1.24+
 * `docker` available in your cli
 
 ## Running

--- a/e2e/monitor/go.mod
+++ b/e2e/monitor/go.mod
@@ -2,7 +2,7 @@ module github.com/hemilabs/heminetwork/e2e/monitor
 
 go 1.23
 
-toolchain go1.23.0
+toolchain go1.24.1
 
 replace github.com/hemilabs/heminetwork => ../../
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hemilabs/heminetwork
 
 go 1.23
 
-toolchain go1.23.3
+toolchain go1.24.1
 
 // Temporary replace until we upstream our ws_js patch.
 replace github.com/coder/websocket v1.8.12 => github.com/hemilabs/websocket v0.0.0-20240813101919-bf33653e9aa5

--- a/localnode/docker-compose.yml
+++ b/localnode/docker-compose.yml
@@ -210,7 +210,7 @@ services:
   # Init container for Hemi L2 node
   op-geth-l2-init:
     # yamllint disable-line rule:line-length
-    image: "alpine@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d"
+    image: "alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"  # 3.21.3
     profiles: ["hemi", "full"]
     volumes:
       - op-geth_data:/tmp/datadir
@@ -223,7 +223,7 @@ services:
   # Init TBC container for Hemi L2 node
   op-geth-l2-init-tbc:
     # yamllint disable-line rule:line-length
-    image: "alpine@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d"
+    image: "alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"  # 3.21.3
     profiles: ["hemi", "full"]
     volumes:
       - tbc_data:/tbcdata

--- a/localnode/docker-compose_mainnet.yml
+++ b/localnode/docker-compose_mainnet.yml
@@ -209,7 +209,7 @@ services:
   # Init container for Hemi L2 node
   op-geth-l2-init:
     # yamllint disable-line rule:line-length
-    image: "alpine@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d"
+    image: "alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"  # 3.21.3
     profiles: ["hemi", "full"]
     volumes:
       - op-geth_data:/tmp/datadir
@@ -222,7 +222,7 @@ services:
   # Init TBC container for Hemi L2 node
   op-geth-l2-init-tbc:
     # yamllint disable-line rule:line-length
-    image: "alpine@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d"
+    image: "alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"  # 3.21.3
     profiles: ["hemi", "full"]
     volumes:
       - tbc_data:/tbcdata


### PR DESCRIPTION
**Summary**
Update builds to use Go 1.24.1. This does not change the Go version for the `github.com/hemilabs/heminetwork` module, meaning this is not affect dependants.

**Changes**
- Update Go toolchain to `go1.24.1`
- Update remaining Go versions in GitHub Actions to `1.24.x`
- Update documentation to say "Go 1.24" instead of "Go 1.23"
- Update golang base images to `golang:1.24.1-alpine3.21`
- Update alpine images to `alpine:3.21.3`
