### PR TITLE
all: update golangci-lint to v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,9 +40,9 @@ jobs:
           cache: true
 
       - name: "golangci-lint"
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: "v1.62"
+          version: "v2.0"
 
       - name: "Cache golicenser"
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -85,7 +85,7 @@ jobs:
         run: make GOCACHE="$(go env GOCACHE)" build
 
   test:
-    name: "Test"
+    name: "Test (${{ env.GO_VERSION }})"
     runs-on: "ubuntu-latest"
     services:
       postgres:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Setup Go ${{ matrix.go-version }}"
+      - name: "Setup Go ${{ env.GO_VERSION }}"
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ env.GO_VERSION }}"
@@ -70,7 +70,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: "Setup Go ${{ matrix.go-version }}"
+      - name: "Setup Go ${{ env.GO_VERSION }}"
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ env.GO_VERSION }}"
@@ -85,7 +85,7 @@ jobs:
         run: make GOCACHE="$(go env GOCACHE)" build
 
   test:
-    name: "Test (${{ env.GO_VERSION }})"
+    name: "Test"
     runs-on: "ubuntu-latest"
     services:
       postgres:
@@ -103,7 +103,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: "Setup Go ${{ matrix.go-version }}"
+      - name: "Setup Go ${{ env.GO_VERSION }}"
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ env.GO_VERSION }}"
@@ -127,7 +127,7 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: "Setup Go ${{ matrix.go-version }}"
+      - name: "Setup Go ${{ env.GO_VERSION }}"
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: "${{ env.GO_VERSION }}"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,23 +1,11 @@
+version: "2"
 run:
   tests: false
+  go: "1.23"
 
 issues:
-  # Show all errors
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  # Exclude sources following the Go generated file convention.
-  exclude-generated: "strict"
-
-  # Add exclusions here.
-  exclude-rules:
-    # Licensed under ISC License, with different copyright owners.
-    - path: version/version\.go
-      linters: [ "goheader" ]
-
-    # Licensed under ISC License, 2016-2022 The Decred developers
-    - path: service/tbc/util\.go
-      linters: [ "goheader" ]
 
 linters:
   enable:
@@ -27,19 +15,16 @@ linters:
     - "errcheck" # Checks for unchecked errors.
     - "errorlint" # Verifies errors are properly wrapped.
     - "errname" # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
-    - "gci" # Enforces package import order, making it deterministic.
     - "gocheckcompilerdirectives" # Checks that go compiler directive comments (//go:) are valid.
     - "gochecksumtype" # Run exhaustiveness checks on Go "sum types".
-    - "gofumpt" # Runs gofumpt.
     # TODO enable gosec, when bored run 'golangci-lint run -Egosec' to fix these
     # - "gosec" # Checks for potential security issues
-    - "gosimple" # Checks for ways to simplify code.
     - "gomoddirectives" # Manages 'replace', 'retract' and 'excludes' directives in go.mod.
     - "gosmopolitan" # Report certain i18n/l10n anti-patterns in your Go codebase.
     - "govet" # Runs go vet.
     - "ineffassign" # Detects when assignments to variables are not used.
     # TODO enable revive, when bored run 'golangci-lint run -Erevive' to fix these
-    # - "revive" # Checks for potential security issues
+    # - "revive" # Miscellaneous linter
     - "nilerr" # Finds the code that returns nil even if it checks that the error is not nil.
     - "nolintlint" # Reports ill-formed or insufficient nolint directives.
     - "prealloc" # Finds slice declarations that could potentially be pre-allocated.
@@ -50,46 +35,59 @@ linters:
     - "rowserrcheck" # Checks whether Rows.Err of rows is checked successfully.
     - "unconvert" # Checks for unnecessary type conversions.
     - "unused" # Checks for unused constants, variables, functions and types.
+  settings:
+    errcheck:
+      exclude-functions:
+        - "loggo.ConfigureLoggers(string)"
+    gocritic:
+      disabled-checks:
+        - "elseif"
+        - "exitAfterDefer"
+        - "ifElseChain"
+        - "singleCaseSwitch"
+    godox: # Finds todo comments; Use: golangci-lint run --enable-only godox
+      keywords:
+        - "XXX"
+        - "TODO"
+        - "FIXME"
+    gomoddirectives:
+      replace-allow-list:
+        - "github.com/coder/websocket" # Currently uses our fork with a bug fix.
+    nolintlint:
+      # Require an explanation after each nolint directive.
+      # Explanation format example: '//nolint:ineffassign // Explanation goes here.'
+      # If this becomes too annoying, disable it.
+      require-explanation: true
+  exclusions:
+    generated: "strict"
+    presets:
+      - "comments"
+      - "common-false-positives"
+      - "legacy"
+      - "std-error-handling"
+    rules:
+      - linters: [ "staticcheck" ]
+        text: "QF1001:" # "could apply De Morgan's law"
+    paths:
+      - "third_party$"
+      - "builtin$"
+      - "examples$"
 
-linters-settings:
-  # Checks for unchecked errors.
-  errcheck:
-    exclude-functions:
-      - "loggo.ConfigureLoggers(string)"
-
-  # Enforces import order in Go source files
-  gci:
-    sections:
-      - "standard"
-      - "default"
-      - "blank"
-      - "dot"
-      - "localmodule"
-    custom-order: true
-
-  gocritic:
-    disabled-checks:
-      - "elseif"
-      - "exitAfterDefer"
-      - "ifElseChain"
-      - "singleCaseSwitch"
-
-  # Detects XXX/TODO/FIXME comments. Useful for finding old todo items.
-  #  Use: golangci-lint run --enable-only godox
-  godox:
-    keywords:
-      - "XXX"
-      - "TODO"
-      - "FIXME"
-
-  # Manages 'replace', 'retract' and 'excludes' directives in go.mod.
-  gomoddirectives:
-    replace-allow-list:
-      - "github.com/coder/websocket" # Currently uses our fork with a bug fix.
-
-  # Lints nolint directives.
-  nolintlint:
-    # Require an explanation after each nolint directive.
-    # Explanation format example: '//nolint:ineffassign // Explanation goes here.'
-    # If this becomes too annoying, disable it.
-    require-explanation: true
+formatters:
+  enable:
+    - "gci" # Enforces package import order, making it deterministic.
+    - "gofumpt" # An extended version of go fmt.
+  settings:
+    gci:
+      sections:
+        - "standard"
+        - "default"
+        - "blank"
+        - "dot"
+        - "localmodule"
+      custom-order: true
+  exclusions:
+    paths:
+      - "third_party$"
+      - "builtin$"
+      - "examples$"

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ lint:
 	$(shell go env GOPATH)/bin/golicenser -tmpl="$$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range -fix ./...
 
 lint-deps:
-	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0
 	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@v0.1.0
 
 tidy:

--- a/database/database.go
+++ b/database/database.go
@@ -282,7 +282,7 @@ func (ts Timestamp) Value() (driver.Value, error) {
 	if ts.IsZero() {
 		return nil, nil
 	}
-	return ts.Time.Format(time.RFC3339Nano), nil
+	return ts.Format(time.RFC3339Nano), nil
 }
 
 var _ driver.Valuer = (*Timestamp)(nil)

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -565,7 +565,7 @@ func (s *Server) handleBitcoinUTXOs(ctx context.Context, bur *bfgapi.BitcoinUTXO
 	return buResp, nil
 }
 
-var ErrAlreadyProcessed = errors.New("already processed BTC block")
+var ErrAlreadyProcessed = errors.New("already processed bitcoin block")
 
 func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 	log.Tracef("Processing Bitcoin block at height %d...", height)

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -565,7 +565,7 @@ func (s *Server) handleBitcoinUTXOs(ctx context.Context, bur *bfgapi.BitcoinUTXO
 	return buResp, nil
 }
 
-var ErrAlreadyProcessed error = fmt.Errorf("Already Processed BTC Block")
+var ErrAlreadyProcessed = errors.New("already processed BTC block")
 
 func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 	log.Tracef("Processing Bitcoin block at height %d...", height)

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2285,8 +2285,8 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 
 	// Find out how many blocks are missing.
 	var (
-		blksMissing bool = true
-		maxMissing  int  = 64
+		blksMissing = true
+		maxMissing  = 64
 	)
 	// expensive check
 	bm, err := s.db.BlocksMissing(ctx, maxMissing)


### PR DESCRIPTION
**Summary**
Update golangci-lint to v2. This changes the configuration schema, introduces some new rules, and removes deprecated linters. Additionally, the linter `gosimple` has been merged into `staticcheck`.

**Changes**
- Update `golangci-lint` to `v2.0` in `make lint-deps`
- Update `golangci/golangci-lint-action` to `v7.0.0` in CI.
- Update `golangci-lint` to `v2.0` in CI
- Update `golangci.yml` configuration file to new schema
- Disable `QF1001: could apply De Morgan's law` staticcheck rule, as it formats Marco's code and makes it somewhat harder to read.
- Fix new linting issues.
