### PR TITLE
localnode: remove bfgd as a dependency of bssd

### DIFF
--- a/localnode/docker-compose_mainnet.yml
+++ b/localnode/docker-compose_mainnet.yml
@@ -83,8 +83,6 @@ services:
       dockerfile: "./docker/bssd/Dockerfile"
       context: "./.."
     profiles: ["hemi", "full"]
-    depends_on:
-      - "bfgd"
     environment:
       BSS_BFG_URL: "ws://bfgd:8080/v1/ws/private"
       BSS_LOG_LEVEL: "INFO"


### PR DESCRIPTION
**Summary**
bssd can TECHNICALLY run without bfgd, so don't declare it as a dependency.  this makes it easier to run HEMI-only nodes

**Changes**
see summary
