### PR TITLE
Update popm.go

### DIFF
--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -383,7 +383,7 @@ func (m *Miner) mineKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
 	}
 
 	// Build transaction.
-	btx, err := createTx(ks, btcHeight, utxo, payToScript, feeAmount, 10000)
+	btx, err := createTx(ks, btcHeight, utxo, payToScript, feeAmount, 1000)
 	if err != nil {
 		return fmt.Errorf("create Bitcoin transaction: %w", err)
 	}


### PR DESCRIPTION
The minrelayfee has been set to high causing outputs being marked as dust too soon.

**Summary**
Change the minrelayfee to calculate dust from 10,000 to 1,000.

"Fixes #481 "
