### PR TITLE
all: enable linting test sources

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  tests: false
+  tests: true
   go: "1.23"
 
 issues:
@@ -73,10 +73,24 @@ linters:
       - "legacy"
       - "std-error-handling"
     rules:
+      # Avoid applying De Morgan's law automatically.
       - linters: [ "staticcheck" ]
         text: "QF1001:" # "could apply De Morgan's law"
+
+      # Avoid automatically merging conditional assignments into var declarations.
       - linters: [ "staticcheck" ]
         text: "QF1007:" # "could merge conditional assignment into var declaration"
+
+      # Ignore "response body must be closed" when calling websocket.Dial.
+      # Response body closure is handled by the websocket library.
+      - linters: [ "bodyclose" ]
+        text: "response body must be closed"
+        source: "websocket\\.Dial"
+
+      # Ignore not checking return value of c.CloseNow (websocket) in tests.
+      - path: "(.+)_test\\.go"
+        linters: [ "errcheck" ]
+        text: "Error return value of `c.CloseNow` is not checked"
     paths:
       - "third_party$"
       - "builtin$"

--- a/api/auth/secp256k1_test.go
+++ b/api/auth/secp256k1_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -169,6 +169,9 @@ func TestProtocolHandshake(t *testing.T) {
 	err = bssapi.Write(ctx, conn, "ping-id", bssapi.PingRequest{
 		Timestamp: time.Now().Unix(),
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	_, _, payload, err := bssapi.Read(ctx, conn)
 	if err != nil {
 		t.Fatal(err)

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -376,7 +376,6 @@ func (ac *Conn) Connect(ctx context.Context) error {
 	// package.
 	// Note that we cannot have DialOptions on a WASM websocket
 	log.Tracef("Connect: dialing %v", ac.serverURL)
-	//nolint:bodyclose // Response body closure is handled by websocket library.
 	conn, _, err := websocket.Dial(connectCtx, ac.serverURL, newDialOptions(ac.opts))
 	if err != nil {
 		return fmt.Errorf("dial server: %w", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
 package config
 
 import (
-	"os"
 	"testing"
 )
 
@@ -62,14 +61,10 @@ func TestConfigTypesRequired(t *testing.T) {
 	for k, v := range cmr {
 		switch v.DefaultValue.(type) {
 		case string:
-			if err := os.Setenv(k, "ENVSTRING"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv(k, "ENVSTRING")
 
 		case int32, uint64:
-			if err := os.Setenv(k, "31337"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv(k, "31337")
 		}
 		v.Required = true
 		cmr[k] = v

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -2149,9 +2149,6 @@ func createBtcBlock(ctx context.Context, t *testing.T, db bfgd.Database, count i
 				header[k] = lastHash[k-4]
 			}
 		}
-
-		//nolint: ineffassign // unknown reason as to why this is set.
-		lastHash = hash
 	}
 
 	t.Logf(

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1734,6 +1734,7 @@ func TestBtcTransactionBroadcastRequestInsert(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer rows.Close()
 
 	result := BtcTransactionBroadcastRequest{}
 	count := 0
@@ -1744,6 +1745,9 @@ func TestBtcTransactionBroadcastRequestInsert(t *testing.T) {
 			t.Fatal(err)
 		}
 		count++
+	}
+	if rows.Err() != nil {
+		t.Fatalf("rows: %v", err)
 	}
 
 	if count != 1 {
@@ -2146,6 +2150,7 @@ func createBtcBlock(ctx context.Context, t *testing.T, db bfgd.Database, count i
 			}
 		}
 
+		//nolint: ineffassign // unknown reason as to why this is set.
 		lastHash = hash
 	}
 

--- a/database/tbcd/level/cache_test.go
+++ b/database/tbcd/level/cache_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func newBlock(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *btcutil.Block, []byte) {
-	bh := wire.NewBlockHeader(0, prevHash, &chainhash.Hash{}, 0, uint32(nonce))
+	bh := wire.NewBlockHeader(0, prevHash, &chainhash.Hash{}, 0, nonce)
 	b := wire.NewMsgBlock(bh)
 	ub := btcutil.NewBlock(b)
 	r, err := ub.Bytes()
@@ -99,7 +99,7 @@ func TestLRUCache(t *testing.T) {
 }
 
 func newHeader(prevHash *chainhash.Hash, nonce uint32) (chainhash.Hash, *tbcd.BlockHeader) {
-	bh := wire.NewBlockHeader(0, prevHash, &chainhash.Hash{}, 0, uint32(nonce))
+	bh := wire.NewBlockHeader(0, prevHash, &chainhash.Hash{}, 0, nonce)
 	return bh.BlockHash(), &tbcd.BlockHeader{
 		Hash:       bh.BlockHash(),
 		Height:     uint64(nonce),

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -58,10 +58,9 @@ func TestMD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	qr := make([][]byte, x+1)
+	qr := make([][]byte, 0, x+1)
 	for i := 0; i <= x; i++ {
-		y := byte(i)
-		qr[i] = []byte{y}
+		qr = append(qr, []byte{byte(i)})
 	}
 	rrows, err := db.MetadataBatchGet(ctx, true, qr)
 	if err != nil {

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -3605,7 +3605,6 @@ func TestOtherBFGSavesL2KeystonesOnNotifications(t *testing.T) {
 
 				return
 			}
-
 		}
 	}()
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -35,11 +35,9 @@ import (
 	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
 	btctxscript "github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	btcwire "github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	dcrsecp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	dcrecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -90,13 +88,13 @@ type bfgWs bssWs // XXX: use protocol.WSConn directly
 
 // Setup some private keys and authenticators
 var (
-	privateKey *dcrsecp256k1.PrivateKey
+	privateKey *secp256k1.PrivateKey
 	authClient *auth.Secp256k1Auth
 )
 
 func init() {
 	var err error
-	privateKey, err = dcrsecp256k1.GeneratePrivateKey()
+	privateKey, err = secp256k1.GeneratePrivateKey()
 	if err != nil {
 		panic(err)
 	}
@@ -131,7 +129,7 @@ func EnsureCanConnect(t *testing.T, url string, timeout time.Duration) error {
 	select {
 	case <-doneCh:
 	case <-ctx.Done():
-		return fmt.Errorf("timed out trying to reach WS server in tests, last error: %s", err)
+		return fmt.Errorf("timed out trying to reach WS server in tests, last error: %w", err)
 	}
 
 	return nil
@@ -343,9 +341,9 @@ func createBfgServer(ctx context.Context, t *testing.T, pgUri string, electrsAdd
 	return createBfgServerGeneric(ctx, t, pgUri, electrsAddr, btcStartHeight, "")
 }
 
-func createBfgServerConnectedToAnother(ctx context.Context, t *testing.T, pgUri string, electrsAddr string, btcStartHeight uint64, otherBfgUrl string) (*bfg.Server, string, string, string) {
-	return createBfgServerGeneric(ctx, t, pgUri, electrsAddr, btcStartHeight, otherBfgUrl)
-}
+// func createBfgServerConnectedToAnother(ctx context.Context, t *testing.T, pgUri string, electrsAddr string, btcStartHeight uint64, otherBfgUrl string) (*bfg.Server, string, string)
+// 	return createBfgServerGeneric(ctx, t, pgUri, electrsAddr, btcStartHeight, otherBfgUrl)
+// }
 
 func createBssServer(ctx context.Context, t *testing.T, bfgWsurl string) (*bss.Server, string, string) {
 	bssListenAddress := fmt.Sprintf(":%d", nextPort(ctx, t))
@@ -658,7 +656,7 @@ func bfgdL2KeystoneToHemiL2Keystone(l2KeystoneSavedDB *bfgd.L2Keystone) *hemi.L2
 }
 
 func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, minerPrivateKeyBytes []byte) []byte {
-	btx := &btcwire.MsgTx{
+	btx := &wire.MsgTx{
 		Version:  2,
 		LockTime: uint32(btcHeight),
 	}
@@ -672,7 +670,7 @@ func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, mi
 		t.Fatal(err)
 	}
 
-	privateKey := dcrsecp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
+	privateKey := secp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
 	publicKey := privateKey.PubKey()
 	pubKeyBytes := publicKey.SerializeCompressed()
 	btcAddress, err := btcutil.NewAddressPubKey(pubKeyBytes, &btcchaincfg.TestNet3Params)
@@ -689,13 +687,13 @@ func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, mi
 		t.Fatalf("incorrect length for pay to public key script (%d != 25)", len(payToScript))
 	}
 
-	outPoint := btcwire.OutPoint{Hash: btcchainhash.Hash(fillOutBytes("hash", 32)), Index: 0}
-	btx.TxIn = []*btcwire.TxIn{btcwire.NewTxIn(&outPoint, payToScript, nil)}
+	outPoint := wire.OutPoint{Hash: btcchainhash.Hash(fillOutBytes("hash", 32)), Index: 0}
+	btx.TxIn = []*wire.TxIn{wire.NewTxIn(&outPoint, payToScript, nil)}
 
 	changeAmount := int64(100)
-	btx.TxOut = []*btcwire.TxOut{btcwire.NewTxOut(changeAmount, payToScript)}
+	btx.TxOut = []*wire.TxOut{wire.NewTxOut(changeAmount, payToScript)}
 
-	btx.TxOut = append(btx.TxOut, btcwire.NewTxOut(0, popTxOpReturn))
+	btx.TxOut = append(btx.TxOut, wire.NewTxOut(0, popTxOpReturn))
 
 	sig := dcrecdsa.Sign(privateKey, []byte{})
 	sigBytes := append(sig.Serialize(), byte(btctxscript.SigHashAll))
@@ -747,7 +745,7 @@ func TestBFGPublicDisabled(t *testing.T) {
 }
 
 // TestNewL2Keystone sends an L2Keystone, via websocket, to BSS which proxies
-// it to BFG.  This test then ensures that that L2Keystone was saved in the db
+// it to BFG.  This test then ensures that L2Keystone was saved in the db
 // 1. Create a new L2Keystone
 // 2. Send aforementioned L2Keystone to BSS via websocket
 // 3. Query database to ensure that the L2Keystone was saved
@@ -1463,7 +1461,7 @@ func TestBitcoinBroadcast(t *testing.T) {
 
 	defer c.CloseNow()
 
-	privateKey := dcrsecp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
+	privateKey := secp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
 
 	authClient, err := auth.NewSecp256k1AuthClient(privateKey)
 	if err != nil {
@@ -1587,7 +1585,7 @@ func TestBitcoinBroadcastDuplicate(t *testing.T) {
 	}
 	defer c.CloseNow()
 
-	privateKey := dcrsecp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
+	privateKey := secp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
 
 	authClient, err := auth.NewSecp256k1AuthClient(privateKey)
 	if err != nil {
@@ -1892,7 +1890,7 @@ loop:
 
 	btcHeaderHash := btcchainhash.DoubleHashB(btcHeader)
 
-	privateKey := dcrsecp256k1.PrivKeyFromBytes([]byte{1, 2, 3})
+	privateKey := secp256k1.PrivKeyFromBytes([]byte{1, 2, 3})
 	publicKey := privateKey.PubKey()
 	publicKeyUncompressed := publicKey.SerializeUncompressed()
 
@@ -2006,7 +2004,7 @@ func TestBitcoinBroadcastThenUpdate(t *testing.T) {
 
 	defer c.CloseNow()
 
-	privateKey := dcrsecp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
+	privateKey := secp256k1.PrivKeyFromBytes(minerPrivateKeyBytes)
 
 	authClient, err := auth.NewSecp256k1AuthClient(privateKey)
 	if err != nil {
@@ -2130,14 +2128,14 @@ func TestPopPayouts(t *testing.T) {
 	ctx, cancel := defaultTestContext()
 	defer cancel()
 
-	privateKey := dcrsecp256k1.PrivKeyFromBytes([]byte{9, 8, 7})
+	privateKey := secp256k1.PrivKeyFromBytes([]byte{9, 8, 7})
 	publicKey := privateKey.PubKey()
 	publicKeyUncompressed := publicKey.SerializeUncompressed()
 	minerHash := crypto.Keccak256(publicKeyUncompressed[1:])
 	minerHash = minerHash[len(minerHash)-20:]
 	minerAddress := common.BytesToAddress(minerHash)
 
-	privateKey = dcrsecp256k1.PrivKeyFromBytes([]byte{1, 2, 3})
+	privateKey = secp256k1.PrivKeyFromBytes([]byte{1, 2, 3})
 	publicKey = privateKey.PubKey()
 	otherPublicKeyUncompressed := publicKey.SerializeUncompressed()
 	minerHash = crypto.Keccak256(otherPublicKeyUncompressed[1:])
@@ -2376,7 +2374,7 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 	addresses := []string{}
 
 	for range 151 {
-		privateKey, err := dcrsecp256k1.GeneratePrivateKeyFromRand(rand.Reader)
+		privateKey, err := secp256k1.GeneratePrivateKeyFromRand(rand.Reader)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/hemi/electrs/conn_pool.go
+++ b/hemi/electrs/conn_pool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -148,7 +148,7 @@ func (p *connPool) freeConn(conn *clientConn) {
 
 // size returns the number of connections in the pool.
 //
-//nolint:unused // False positive, used in tests.
+
 func (p *connPool) size() int {
 	p.poolMx.Lock()
 	defer p.poolMx.Unlock()

--- a/hemi/electrs/conn_pool.go
+++ b/hemi/electrs/conn_pool.go
@@ -147,8 +147,6 @@ func (p *connPool) freeConn(conn *clientConn) {
 }
 
 // size returns the number of connections in the pool.
-//
-
 func (p *connPool) size() int {
 	p.poolMx.Lock()
 	defer p.poolMx.Unlock()

--- a/rawdb/rawdb_test.go
+++ b/rawdb/rawdb_test.go
@@ -11,10 +11,7 @@ import (
 )
 
 func TestRawDB(t *testing.T) {
-	home, err := os.MkdirTemp("", "rawdb")
-	if err != nil {
-		t.Fatal(err)
-	}
+	home := t.TempDir()
 	remove := true
 	defer func() {
 		if !remove {

--- a/service/bfg/bfg_test.go
+++ b/service/bfg/bfg_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -47,7 +47,7 @@ func checkBitcoinFinality(bf *BitcoinFinality) error {
 	btcTxHash := btcchainhash.DoubleHashB(bf.BTCRawTransaction)
 
 	// Verify transaction to block header.
-	var merkleHashes [][]byte
+	merkleHashes := make([][]byte, len(bf.BTCMerkleHashes))
 	for _, merkleHash := range bf.BTCMerkleHashes {
 		merkleHashes = append(merkleHashes, merkleHash)
 	}

--- a/service/bfg/bfg_test.go
+++ b/service/bfg/bfg_test.go
@@ -48,8 +48,8 @@ func checkBitcoinFinality(bf *BitcoinFinality) error {
 
 	// Verify transaction to block header.
 	merkleHashes := make([][]byte, len(bf.BTCMerkleHashes))
-	for _, merkleHash := range bf.BTCMerkleHashes {
-		merkleHashes = append(merkleHashes, merkleHash)
+	for i, merkleHash := range bf.BTCMerkleHashes {
+		merkleHashes[i] = merkleHash
 	}
 	if err := bitcoin.CheckMerkleChain(btcTxHash, bf.BTCTransactionIndex, merkleHashes, btcHeader.MerkleRoot[:]); err != nil {
 		return fmt.Errorf("verify merkle path for transaction: %w", err)

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -242,7 +242,6 @@ func TestProcessReceivedKeystonesSameL2BlockNumber(t *testing.T) {
 		if diff := deep.Equal(miner.l2Keystones[key].l2Keystone, v); len(diff) > 0 {
 			t.Fatalf("unexpected diff: %s", diff)
 		}
-
 	}
 }
 
@@ -1315,7 +1314,6 @@ func createMockBFG(ctx context.Context, t *testing.T, publicKeys []string, keyst
 
 		log.Tracef("successful handshake with public key: %s", publicKeyEncoded)
 		if len(publicKeys) > 0 {
-
 			found := false
 			for _, v := range publicKeys {
 				if publicKeyEncoded == v {

--- a/service/tbc/peer/peer_test.go
+++ b/service/tbc/peer/peer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -136,7 +136,6 @@ func TestPeer(t *testing.T) {
 				panic(fmt.Sprintf("nonce not found: %v", nonce))
 			}
 		}(uint64(i))
-
 	}
 	wg.Wait()
 	pongs.Range(func(k, v any) bool {

--- a/service/tbc/peer/rawpeer/rawpeer_test.go
+++ b/service/tbc/peer/rawpeer/rawpeer_test.go
@@ -100,7 +100,9 @@ func TestConcurrentReadWrite(t *testing.T) {
 			for range writeCount {
 				bh := wire.NewBlockHeader(int32(k), &fakeCh, &fakeCh, uint32(k), uint32(k))
 				mva := wire.NewMsgHeaders()
-				mva.AddBlockHeader(bh)
+				if err := mva.AddBlockHeader(bh); err != nil {
+					panic(err)
+				}
 				if err := p1.Write(0, mva); err != nil {
 					panic(err)
 				}

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -615,7 +615,6 @@ func TestForksWithGen(t *testing.T) {
 				earliestB := ""
 
 				for i := 0; i < 3; i++ {
-
 					// invalidate B and reconsider A to grow chain A
 					if earliestB != "" {
 						invalidateBlock(ctx, t, bitcoindContainer, earliestB)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1241,7 +1241,7 @@ func EnsureCanConnect(t *testing.T, url string, timeout time.Duration) error {
 	select {
 	case <-doneCh:
 	case <-ctx.Done():
-		return fmt.Errorf("timed out trying to reach WS server in tests, last error: %s", err)
+		return fmt.Errorf("timed out trying to reach WS server in tests, last error: %w", err)
 	}
 
 	return nil
@@ -1422,7 +1422,10 @@ func createTbcServerExternalHeaderMode(ctx context.Context, t *testing.T) *Serve
 		t.Fatal(err)
 	}
 
-	tbcServer.ExternalHeaderSetup(ctx, defaultUpstreamStateId[:])
+	err = tbcServer.ExternalHeaderSetup(ctx, defaultUpstreamStateId[:])
+	if err != nil {
+		t.Fatalf("external header setup: %v", err)
+	}
 	return tbcServer
 }
 
@@ -2081,6 +2084,10 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 		// Subtract 1 from start and end because the ranges refer to block heights,
 		// but the defined simple chain headers/hashes start at block #1
 		_, msgHeaders, _, err := getHeaderHashesRange(start-1, end-1, simpleChainHeaders[:], simpleChainHashes[:])
+		if err != nil {
+			t.Errorf("getHeaderHashesRange: %v", err)
+		}
+
 		rawWouldBeCanonical, _, _, err := getRegtestGenesisHeaderAndHash()
 		if err != nil {
 			t.Error(err)
@@ -2146,6 +2153,10 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 	start := 3
 	end := 9
 	_, msgHeaders, _, err = getHeaderHashesRange(start-1, end-1, simpleChainHeaders[:], simpleChainHashes[:])
+	if err != nil {
+		t.Errorf("getHeaderHashesRange: %v", err)
+	}
+
 	rawShouldBeCanonical, _, shouldBeCanonicalHash, err := getHeaderHashIndex(start-2, simpleChainHeaders[:], simpleChainHashes[:])
 	if err != nil {
 		t.Error(err)
@@ -2229,6 +2240,10 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 		}
 
 		_, _, hash, err := getHeaderHashIndex(i-1, simpleChainHeaders[:], simpleChainHashes[:])
+		if err != nil {
+			t.Errorf("getHeaderHashIndex: %v", err)
+		}
+
 		header, height, err := tbc.BlockHeaderByHash(ctx, *hash)
 		if err == nil {
 			t.Errorf("getting header by hash %x should have returned an error but did not", hash[:])

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -772,7 +772,6 @@ func (b *btcNode) mine(name string, from *chainhash.Hash, payToAddress btcutil.A
 		}
 		b.t.Logf("tx %v: %v spent from %v", nextBlockHeight, tx.Hash(),
 			tx.MsgTx().TxIn[0].PreviousOutPoint)
-		//nolint: ineffassign, staticcheck // test
 		mempool = []*btcutil.Tx{tx}
 
 		// spend above tx in same block
@@ -782,7 +781,7 @@ func (b *btcNode) mine(name string, from *chainhash.Hash, payToAddress btcutil.A
 		}
 		b.t.Logf("tx %v: %v spent from %v", nextBlockHeight, tx2.Hash(),
 			tx2.MsgTx().TxIn[0].PreviousOutPoint)
-		mempool = []*btcutil.Tx{tx, tx2}
+		mempool = append(mempool, tx2)
 	}
 
 	bt, err := newBlockTemplate(b.t, b.params, payToAddress, nextBlockHeight,


### PR DESCRIPTION
**Summary**
Previously, we were not linting any test files. This enables linting test sources, and fixes all linting issues currently reported for the tests.

**Changes**
- Enable golangci-lint linting test sources
- Ignore `websocket.Close` for the `bodyclose` linter, as closing the response body is handled by the websocket library.
- Fix issues reported by golangci-lint for tests (mostly duplicated packages, unused code, etc.)

There were a few ineffective assignments, two of which I was unable to determine why they were there - they both have `nolint` comments. Please let me know if you think they should be removed or kept.

I have commented out unused functions, however I think removing them would be best if we do not plan on using them in the near future - @marcopeereboom?