### PR TITLE
all: update golangci-lint, golicenser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GO_VERSION: "1.24.x"
-  GOLICENSER_VERSION: "0.1.0"
+  GOLICENSER_VERSION: "0.3"
 
 permissions:
   contents: read
@@ -42,7 +42,7 @@ jobs:
       - name: "golangci-lint"
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: "v2.0"
+          version: "v2.1"
 
       - name: "golangci-lint fmt"
         run: golangci-lint fmt --diff ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,24 +17,31 @@ linters:
     - "errname" # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
     - "gocheckcompilerdirectives" # Checks that go compiler directive comments (//go:) are valid.
     - "gochecksumtype" # Run exhaustiveness checks on Go "sum types".
-    # TODO enable gosec, when bored run 'golangci-lint run -Egosec' to fix these
+    # TODO: enable gosec - when bored, run 'golangci-lint run -Egosec' and fix issues
     # - "gosec" # Checks for potential security issues
     - "gomoddirectives" # Manages 'replace', 'retract' and 'excludes' directives in go.mod.
     - "gosmopolitan" # Report certain i18n/l10n anti-patterns in your Go codebase.
     - "govet" # Runs go vet.
     - "ineffassign" # Detects when assignments to variables are not used.
-    # TODO enable revive, when bored run 'golangci-lint run -Erevive' to fix these
-    # - "revive" # Miscellaneous linter
+    - "makezero" # 	Finds slice declarations with non-zero initial length and later used with append.
     - "nilerr" # Finds the code that returns nil even if it checks that the error is not nil.
+    - "noctx" # Finds http requests without context.Context.
     - "nolintlint" # Reports ill-formed or insufficient nolint directives.
     - "prealloc" # Finds slice declarations that could potentially be pre-allocated.
     - "predeclared" # Find code that shadows one of Go's predeclared identifiers.
     - "promlinter" # Check Prometheus metrics naming via promlint.
+    # TODO: enable revive - when bored, run 'golangci-lint run -Erevive' and fix issues
+    # - "revive" # Miscellaneous linter
     - "staticcheck" # Runs staticcheck.
     - "sqlclosecheck" # Checks that sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed.
     - "rowserrcheck" # Checks whether Rows.Err of rows is checked successfully.
     - "unconvert" # Checks for unnecessary type conversions.
+    - "usestdlibvars" # Detects the possibility to use variables/constants from stdlib.
+    - "usetesting" # Reports use of functions with replacements inside the testing package.
     - "unused" # Checks for unused constants, variables, functions and types.
+    - "whitespace" # Checks for unnecessary newlines at the start and end of functions, if, for, etc.
+    # TODO: enable wrapcheck - when bored, run 'golangci-lint run -Ewrapcheck' and fix issues
+    # - "wrapcheck" # Checks that errors returned from external packages are wrapped.
   settings:
     errcheck:
       exclude-functions:

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ lint:
 	$(shell go env GOPATH)/bin/golicenser -tmpl="$$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range -fix ./...
 
 lint-deps:
-	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0
-	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@v0.1.0
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@v0.3
 
 tidy:
 	go mod tidy

--- a/cmd/keygen/keygen.go
+++ b/cmd/keygen/keygen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -89,7 +89,6 @@ func _main() error {
 			fmt.Printf("private key: %x\n", privKey.Serialize())
 			fmt.Printf("public key : %x\n", privKey.PubKey().SerializeCompressed())
 			fmt.Printf("pubkey hash:  %v\n", hash)
-
 		}
 
 	default:

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -276,7 +276,6 @@ func NewServer(cfg *Config) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
-
 	}
 
 	// XXX this is not right. NewServer should always return. The call to
@@ -551,7 +550,6 @@ func (s *Server) handleBitcoinUTXOs(ctx context.Context, bur *bfgapi.BitcoinUTXO
 		return &bfgapi.BitcoinUTXOsResponse{
 			Error: e.ProtocolError(),
 		}, e
-
 	}
 	buResp := bfgapi.BitcoinUTXOsResponse{}
 	for _, utxo := range utxos {
@@ -1882,7 +1880,6 @@ func (s *Server) Run(pctx context.Context) error {
 				if err := s.db.BtcTransactionBroadcastRequestTrim(ctx); err != nil {
 					log.Errorf("error trimming old requests: %v", err)
 				}
-
 			}
 		}
 	}()

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -1269,7 +1269,6 @@ func (s *Server) TxIndexerUnwind(ctx context.Context, startBH, endBH *tbcd.Block
 		if endHash.IsEqual(&last.Hash) {
 			break
 		}
-
 	}
 	return nil
 }
@@ -1323,7 +1322,6 @@ func (s *Server) TxIndexerWind(ctx context.Context, startBH, endBH *tbcd.BlockHe
 		if endHash.IsEqual(&last.Hash) {
 			break
 		}
-
 	}
 
 	return nil
@@ -1619,7 +1617,6 @@ func (s *Server) KeystoneIndexerUnwind(ctx context.Context, startBH, endBH *tbcd
 		if endHash.IsEqual(&last.Hash) {
 			break
 		}
-
 	}
 	return nil
 }
@@ -1673,7 +1670,6 @@ func (s *Server) KeystoneIndexerWind(ctx context.Context, startBH, endBH *tbcd.B
 		if endHash.IsEqual(&last.Hash) {
 			break
 		}
-
 	}
 
 	return nil

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -814,7 +814,6 @@ func (s *Server) promPoll(ctx context.Context) error {
 				s.prom.blockCache.Items)
 			s.mtx.RUnlock()
 		}
-
 	}
 }
 
@@ -1159,7 +1158,6 @@ func (s *Server) syncBlocks(ctx context.Context) {
 					}
 				}
 				s.pm.All(ctx, hp)
-
 			} else {
 				log.Debugf("handle all")
 				s.pm.All(ctx, s.headersPeer)


### PR DESCRIPTION
**Summary**
Update golangci-lint to `v2.1` and golicenser to `v0.3`.

**Changes**
- Update `golangci-lint` from `v2.0` to `v2.1`
- Update `golicenser` from `v0.1` to `v0.3`
- Enable `makezero` linter: Detects slice declarations with non-zero length which are later used in `append` (detects bugs).
- Enable `noctx` linter: Detects HTTP requests without `context.Context`.
- Enable `usestdlibvars` linter: Detects variables that could be replaced with a variable/constant from stdlib.
- Enable `usetesting` linter: Detects use of functions that have a `testing` package alternative in tests (e.g. `os.CreateTemp`, `os.TempDir`, etc.)
- Enable `whitespace` linter: Detects unnecessary newlines at the start and end of functions, if, for, etc.

**Notes**
Hopefully golicenser will be included in a `golangci-lint` release soon, meaning it won't need to be installed separately and will run faster.