### PR TITLE
tbc: avoid race with r.index on Close

### DIFF
--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -483,7 +483,6 @@ func (l *ldb) v3(ctx context.Context) error {
 				return fmt.Errorf("copy raw data %v: %w", dbs, err)
 			}
 		}
-
 	}
 
 	// Write version to destination and close the database.


### PR DESCRIPTION
**Summary**
Saw a panic on rad database close close for using `r.index` after it was reset to nil. Use a bool to indicate if a db is open instead of relying on r.index thus removing the possibility of a race.

**Changes**
<!-- A list of changes made by this pull request. -->
