### PR TITLE
deucalion: add health route

### DIFF
--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -1981,7 +1981,7 @@ func (s *Server) Run(pctx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := d.Run(ctx, cs); !errors.Is(err, context.Canceled) {
+			if err := d.Run(ctx, cs, nil); !errors.Is(err, context.Canceled) {
 				log.Errorf("prometheus terminated with error: %v", err)
 				return
 			}

--- a/service/bss/bss.go
+++ b/service/bss/bss.go
@@ -788,7 +788,7 @@ func (s *Server) Run(parentCtx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := d.Run(ctx, cs); !errors.Is(err, context.Canceled) {
+			if err := d.Run(ctx, cs, nil); !errors.Is(err, context.Canceled) {
 				log.Errorf("prometheus terminated with error: %v", err)
 				return
 			}

--- a/service/popm/prometheus.go
+++ b/service/popm/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -33,7 +33,7 @@ func (m *Miner) handlePrometheus(ctx context.Context) error {
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
-		if err := d.Run(ctx, cs); !errors.Is(err, context.Canceled) {
+		if err := d.Run(ctx, cs, nil); !errors.Is(err, context.Canceled) {
 			log.Errorf("prometheus terminated with error: %v", err)
 			return
 		}

--- a/service/tbc/crawler.go
+++ b/service/tbc/crawler.go
@@ -163,9 +163,9 @@ func h2b(wbh *wire.BlockHeader) [80]byte {
 }
 
 type HashHeight struct {
-	Hash      chainhash.Hash
-	Height    uint64
-	Timestamp int64 // optional
+	Hash      chainhash.Hash `json:"hash"`
+	Height    uint64         `json:"height"`
+	Timestamp int64          `json:"timestamp"` // optional
 }
 
 func (h HashHeight) String() string {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -7,10 +7,8 @@ package tbc
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -2534,17 +2532,12 @@ func (s *Server) isHealthy(_ context.Context) bool {
 	return connected > 0
 }
 
-func (s *Server) health(ctx context.Context) (bool, io.Reader, error) {
+func (s *Server) health(ctx context.Context) (bool, any, error) {
 	log.Tracef("health")
 	defer log.Tracef("health exit")
 
-	si := s.synced(ctx)
-	j, err := json.Marshal(si)
-	if err != nil {
-		return false, nil, fmt.Errorf("health marshal: %w", err)
-	}
 	healthy := s.isHealthy(ctx)
-	return healthy, bytes.NewReader(j), nil
+	return healthy, s.synced(ctx), nil
 }
 
 func (s *Server) Run(pctx context.Context) error {

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2536,8 +2536,7 @@ func (s *Server) health(ctx context.Context) (bool, any, error) {
 	log.Tracef("health")
 	defer log.Tracef("health exit")
 
-	healthy := s.isHealthy(ctx)
-	return healthy, s.synced(ctx), nil
+	return s.isHealthy(ctx), s.synced(ctx), nil
 }
 
 func (s *Server) Run(pctx context.Context) error {


### PR DESCRIPTION
**Summary**
All our cloud infrastructure apparently needs an additional health route instead of calling RPCs.

**Changes**
Add a `/health` route to the same mux as the prometheus server for cloud infra.
