### PR TITLE
fix escaping quotes that were re-recreating geth datadir

### DIFF
--- a/localnode/gen-files.sh
+++ b/localnode/gen-files.sh
@@ -84,8 +84,8 @@ cat >"$ENTRYFILE" <<EOF
 
 set -xe
 
-if [ -d \"/tmp/datadir/geth\" ]; then
-	echo \"geth data dir exists, skipping genesis.\"
+if [ -d "/tmp/datadir/geth" ]; then
+	echo "geth data dir exists, skipping genesis."
 else
 	geth init --datadir /tmp/datadir/geth /tmp/$GENESIS
 fi


### PR DESCRIPTION
**Summary**
prior, the way we were escaping quotes was preventing the entrypoint.sh file to recognize an existing datadir, fix those

**Changes**
see summary
