### PR TITLE
fix typo Update README.md

### DIFF
--- a/cmd/hemictl/README.md
+++ b/cmd/hemictl/README.md
@@ -23,7 +23,7 @@ hemictl <daemon> <action> [json parameters]
 
 #### Basic Ping Command
 ```bash
-hemictl bss ping '{"timestamp":1}'
+hemictl bss ping '{\"timestamp\":1}'
 ```
 
 Response:
@@ -66,7 +66,7 @@ Response:
 
 #### Custom Database Connection
 ```bash
-LOGLEVEL=INFO PGURI="user=username password=secretpassword database=bfgdb" hemictl bfgdb version
+LOGLEVEL=INFO PGURI="postgresql://username:secretpassword@host:port/bfgdb" version
 ```
 
 ### Error Handling


### PR DESCRIPTION
This PR enhances the documentation for the hemictl CLI tool by fixing several inconsistencies, clarifying JSON usage in shell examples, and correcting the PostgreSQL connection string format. These improvements aim to make the tool more user-friendly and prevent common mistakes when executing commands.
This have confusion with malformed JSON inputs in bash, as well as issues with incorrect PostgreSQL URIs. This PR addresses those usability issues directly in the documentation.

1) hemictl bss ping '{"timestamp":1}' -> hemictl bss ping "{\"timestamp\":1}"
2) PGURI="user=username password=secretpassword database=bfgdb" -> PGURI="postgresql://username:secretpassword@host:port/bfgdb"


