### PR TITLE
github: add 'area: localnode' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,6 +51,11 @@
       - any-glob-to-any-file:
           - "web/packages/pop-miner/**"
 
+# Local node
+'area: localnode':
+  - changed-files:
+      - any-glob-to-any-file: "localnode/**"
+
 # Makefiles
 'area: make':
   - changed-files:


### PR DESCRIPTION
**Summary**
Add entry to `.github/labeler.yml` config to automatically apply the `area: localnode` label to pull requests that modify `localnode/`.

**Changes**
<!-- A list of changes made by this pull request. -->
