### PR TITLE
break up finality and effectiveHeight query

### DIFF
--- a/database/bfgd/database.go
+++ b/database/bfgd/database.go
@@ -38,8 +38,8 @@ type Database interface {
 	PopBasisUpdateBTCFields(ctx context.Context, pb *PopBasis) (int64, error)
 	PopBasisUpdateBTCFieldsWithTx(ctx context.Context, tx *sql.Tx, pb *PopBasis) (int64, error)
 
-	L2BTCFinalityMostRecent(ctx context.Context, limit uint32) ([]L2BTCFinality, error)
-	L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2KeystoneAbrevHashes []database.ByteArray) ([]L2BTCFinality, error)
+	L2BTCFinalityMostRecent(ctx context.Context, limit uint32, ignoreAfterL2Block int64) ([]L2BTCFinality, error)
+	L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2KeystoneAbrevHashes []database.ByteArray, ignoreAfterL2Block int64) ([]L2BTCFinality, error)
 
 	BtcBlockCanonicalHeight(ctx context.Context) (uint64, error)
 

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1604,7 +1604,7 @@ func TestPublications(t *testing.T) {
 				l2BlockNumber++
 			}
 
-			bfs, err := db.L2BTCFinalityMostRecent(ctx, 100)
+			bfs, err := db.L2BTCFinalityMostRecent(ctx, 100, 999999999)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1645,6 +1645,7 @@ func TestL2BtcFinalitiesByL2Keystone(t *testing.T) {
 	finalities, err := db.L2BTCFinalityByL2KeystoneAbrevHash(
 		ctx,
 		[]database.ByteArray{firstKeystone.Hash},
+		999999999999,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1687,6 +1688,7 @@ func TestL2BtcFinalitiesByL2KeystoneNotPublishedHeight(t *testing.T) {
 	finalities, err := db.L2BTCFinalityByL2KeystoneAbrevHash(
 		ctx,
 		[]database.ByteArray{firstKeystone.Hash},
+		99999999999
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -732,6 +732,7 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 				LIMIT 1
 			) btc_blocks_tmp ON TRUE
 			WHERE l2_keystones.l2_keystone_abrev_hash = ANY($1)
+			
 		)
 		SELECT
 			btc_block_hash,
@@ -744,25 +745,29 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 			l2_keystones_lowest_btc_block.state_root,
 			l2_keystones_lowest_btc_block.ep_hash,
 			l2_keystones_lowest_btc_block.version,
-			COALESCE((SELECT height
-				FROM 
-				(
-					SELECT height FROM btc_blocks
-						LEFT JOIN pop_basis ON pop_basis.btc_block_hash 
-							= btc_blocks.hash
-						LEFT JOIN l2_keystones ll ON ll.l2_keystone_abrev_hash 
-							= pop_basis.l2_keystone_abrev_hash
-			
-					AND ll.l2_block_number >= l2_keystones_lowest_btc_block.l2_block_number
-					WHERE ll.l2_keystone_abrev_hash IS NOT NULL
-					ORDER BY height ASC LIMIT 1
-				)), 0),
 			COALESCE((SELECT height FROM btc_blocks ORDER BY height DESC LIMIT 1),0)
+			
+			FROM l2_keystones_lowest_btc_block
+			
+			ORDER BY l2_keystones_lowest_btc_block.l2_block_number DESC
+		`
 
-		FROM l2_keystones_lowest_btc_block
-
-		ORDER BY l2_keystones_lowest_btc_block.l2_block_number DESC
-	`
+	// for all keystones greater than or equal to the one we're querying for,
+	// find the lowest btc block that contains a pop basis that is for that
+	// keystone.  this is the "effective height"
+	effectiveHeightSql := `
+			SELECT COALESCE((
+				SELECT MIN(btc_blocks.height) FROM l2_keystones
+				LEFT JOIN LATERAL (
+					SELECT MIN(btc_blocks.height) AS height FROM btc_blocks
+					WHERE EXISTS (
+						SELECT * FROM pop_basis WHERE btc_block_hash = btc_blocks.hash
+						AND pop_basis.l2_keystone_abrev_hash = l2_keystones.l2_keystone_abrev_hash
+					)
+				) btc_blocks ON TRUE
+				WHERE l2_block_number >= $1 LIMIT 1
+			), 0)
+		`
 
 	l2KeystoneAbrevHashesStr := [][]byte{}
 	for _, l := range l2KeystoneAbrevHashes {
@@ -791,7 +796,6 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 			&l2BtcFinality.L2Keystone.StateRoot,
 			&l2BtcFinality.L2Keystone.EPHash,
 			&l2BtcFinality.L2Keystone.Version,
-			&l2BtcFinality.EffectiveHeight,
 			&l2BtcFinality.BTCTipHeight,
 		)
 		if err != nil {
@@ -801,6 +805,15 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 		if l2BtcFinality.BTCPubHeaderHash == nil {
 			l2BtcFinality.BTCPubHeight = -1
 		}
+
+		var effectiveHeight uint32
+
+		if err := p.db.QueryRow(effectiveHeightSql, l2BtcFinality.L2Keystone.L2BlockNumber).Scan(&effectiveHeight); err != nil {
+			return nil, fmt.Errorf("error querying for rows: %w", err)
+		}
+
+		l2BtcFinality.EffectiveHeight = effectiveHeight
+
 		finalities = append(finalities, l2BtcFinality)
 	}
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -2574,7 +2574,7 @@ func TestGetMostRecentL2BtcFinalitiesBSS(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100, 9999999999)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2641,7 +2641,7 @@ func TestGetFinalitiesByL2KeystoneBSS(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// first and second btcBlocks
-	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100, 9999999999)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2739,7 +2739,7 @@ func TestGetFinalitiesByL2KeystoneBSSLowerServerHeight(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// first and second btcBlocks
-	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100, 9999999999)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2854,7 +2854,7 @@ func TestGetMostRecentL2BtcFinalitiesBFG(t *testing.T) {
 		}
 	}
 
-	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100, 9999999999)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2919,7 +2919,7 @@ func TestGetFinalitiesByL2KeystoneBFG(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// first and second btcBlocks
-	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100)
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 100, 9999999999)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3000,7 +3000,7 @@ func TestGetFinalitiesByL2KeystoneBFGVeryOld(t *testing.T) {
 	createBtcBlock(ctx, t, db, 1, height, []byte{}, l2BlockNumber)
 	// get the btc block's finality, this is the only one that
 	// we care about in this test
-	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 1)
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 1, 9999999999)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3103,7 +3103,7 @@ func TestGetFinalitiesByL2KeystoneBFGNotThatOld(t *testing.T) {
 	createBtcBlock(ctx, t, db, 1, height, []byte{}, l2BlockNumber)
 	// get the btc block's finality, this is the only one that
 	// we care about in this test
-	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 1)
+	recentFinalities, err := db.L2BTCFinalityMostRecent(ctx, 1, 9999999999)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hemi/hemi.go
+++ b/hemi/hemi.go
@@ -19,6 +19,7 @@ const (
 	HeaderVersion1       = 1
 	HeaderSize           = 73 // XXX rename
 	KeystoneHeaderPeriod = 25 // XXX debate and set
+	L2BlockTimeSeconds   = 12
 
 	OldHeaderSize = 65
 

--- a/service/bfg/bfg_test.go
+++ b/service/bfg/bfg_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
 	btcwire "github.com/btcsuite/btcd/wire"
@@ -718,5 +719,30 @@ func TestErrorIfNotPrivKeyConnectingToBFG(t *testing.T) {
 
 	if !errors.Is(err, ErrBTCPrivateKeyMissing) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIgnoringL2Blocks(t *testing.T) {
+	bfgServer, err := NewServer(&Config{
+		BaselineBlockHeight:    1000,
+		BaselineBlockTimestamp: 777,
+		RequestLimit:           1,
+		RequestTimeout:         4,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// repeat code of algorithm
+
+	// in 10 minutes, what is the expected l2 block given the baseline block and l2 block time
+	expectedDelay := (time.Now().Add(10 * time.Minute).Unix()) - 777
+	expectedDelayInblocks := expectedDelay / hemi.L2BlockTimeSeconds
+	expected := 1000 + expectedDelayInblocks
+
+	ignoreL2BlocksAfter := bfgServer.l2KeystoneIgnoreAfter()
+	if ignoreL2BlocksAfter != expected {
+		t.Fatalf("unexpected delay: %d != %d", ignoreL2BlocksAfter, expected)
 	}
 }


### PR DESCRIPTION
**Summary**
split up the finality query, separating the "effective height" query. modified this slightly to avoid a sort.  it performs slighty better in the short term

**Changes**
NOTE: this does not change any functionality.

this splits out the large query into two smaller ones, that are easier to measure.  the "effective height" query was modified a bit to avoid sorting.


the first query, in the "worst case" of 100 keystones, will execute in  1.7ms
```sql
                                                                                                  QUERY PLAN                                                                                 
                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-----------------
 Sort  (cost=2942.42..2942.67 rows=100 width=234) (actual time=1.708..1.717 rows=100 loops=1)
   Sort Key: l2_keystones.l2_block_number DESC
   Sort Method: quicksort  Memory: 50kB
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.42..0.46 rows=1 width=8) (actual time=0.008..0.008 rows=1 loops=1)
           ->  Index Only Scan Backward using btc_blocks_height_key on btc_blocks btc_blocks_1  (cost=0.42..23510.73 rows=772107 width=8) (actual time=0.008..0.008 rows=1 loops=1)
                 Heap Fetches: 1
   ->  Nested Loop Left Join  (cost=18.74..2938.64 rows=100 width=234) (actual time=0.102..1.673 rows=100 loops=1)
         ->  Nested Loop  (cost=9.72..817.58 rows=100 width=185) (actual time=0.080..0.525 rows=100 loops=1)
               ->  HashAggregate  (cost=9.30..10.30 rows=100 width=33) (actual time=0.055..0.071 rows=100 loops=1)
                     Group Key: l2_keystones_1.l2_keystone_abrev_hash
                     Batches: 1  Memory Usage: 24kB
                     ->  Limit  (cost=0.29..8.05 rows=100 width=41) (actual time=0.007..0.038 rows=100 loops=1)
                           ->  Index Scan Backward using l2_keystone_l2_block_number_idx on l2_keystones l2_keystones_1  (cost=0.29..4848.67 rows=62462 width=41) (actual time=0.007..0.031 r
ows=100 loops=1)
               ->  Index Scan using l2_keystones_pkey on l2_keystones  (cost=0.41..8.07 rows=1 width=185) (actual time=0.004..0.004 rows=1 loops=100)
                     Index Cond: (l2_keystone_abrev_hash = l2_keystones_1.l2_keystone_abrev_hash)
         ->  Limit  (cost=9.03..21.19 rows=1 width=73) (actual time=0.011..0.011 rows=0 loops=100)
               ->  Nested Loop Left Join  (cost=9.03..18192.88 rows=1495 width=73) (actual time=0.011..0.011 rows=0 loops=100)
                     ->  Index Scan using l2_keystone_abrev_hash_idx on pop_basis  (cost=0.56..6018.66 rows=1495 width=33) (actual time=0.007..0.007 rows=0 loops=100)
                           Index Cond: (l2_keystone_abrev_hash = l2_keystones.l2_keystone_abrev_hash)
                     ->  Memoize  (cost=8.46..8.47 rows=1 width=41) (actual time=0.008..0.008 rows=1 loops=50)
                           Cache Key: pop_basis.btc_block_hash
                           Cache Mode: binary
                           Hits: 0  Misses: 50  Evictions: 0  Overflows: 0  Memory Usage: 8kB
                           ->  Limit  (cost=8.45..8.46 rows=1 width=41) (actual time=0.007..0.007 rows=1 loops=50)
                                 ->  Sort  (cost=8.45..8.46 rows=1 width=41) (actual time=0.007..0.007 rows=1 loops=50)
                                       Sort Key: btc_blocks.height
                                       Sort Method: quicksort  Memory: 25kB
                                       ->  Index Scan using btc_blocks_pkey on btc_blocks  (cost=0.42..8.44 rows=1 width=41) (actual time=0.006..0.006 rows=1 loops=50)
                                             Index Cond: (hash = pop_basis.btc_block_hash)
 Planning Time: 0.289 ms
 Execution Time: 1.760 ms
(32 rows)
```

the second is not as good, but I am unsure how to make it better in the short-term, it finishes in roughly 700ms.  note this is per-keystone.  so if you're just querying for 1, the whole query would take roughly 800ms.  which is not great.  but there is no "quick fix" at the moment
```sql
                                                                                      QUERY PLAN                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Result  (cost=10947710.88..10947710.89 rows=1 width=8) (actual time=770.152..770.155 rows=1 loops=1)
   InitPlan 1 (returns $2)
     ->  Limit  (cost=10947710.87..10947710.88 rows=1 width=8) (actual time=653.202..653.204 rows=1 loops=1)
           ->  Aggregate  (cost=10947710.87..10947710.88 rows=1 width=8) (actual time=653.196..653.197 rows=1 loops=1)
                 ->  Nested Loop Left Join  (cost=17487.78..10947709.30 rows=626 width=8) (actual time=0.077..653.171 rows=5 loops=1)
                       ->  Index Scan using l2_keystone_l2_block_number_idx on l2_keystones  (cost=0.29..527.60 rows=626 width=33) (actual time=0.016..0.023 rows=5 loops=1)
                             Index Cond: (l2_block_number >= 3305425)
                       ->  Aggregate  (cost=17487.49..17487.50 rows=1 width=8) (actual time=130.628..130.628 rows=1 loops=5)
                             ->  Nested Loop  (cost=5961.58..17483.75 rows=1495 width=8) (actual time=99.728..130.146 rows=9768 loops=5)
                                   ->  HashAggregate  (cost=5961.16..5975.51 rows=1435 width=33) (actual time=99.717..101.595 rows=9768 loops=5)
                                         Group Key: pop_basis.btc_block_hash
                                         Batches: 1  Memory Usage: 5137kB
                                         ->  Bitmap Heap Scan on pop_basis  (cost=24.15..5957.42 rows=1495 width=33) (actual time=4.958..89.061 rows=63793 loops=5)
                                               Recheck Cond: (l2_keystone_abrev_hash = l2_keystones.l2_keystone_abrev_hash)
                                               Rows Removed by Index Recheck: 85689
                                               Heap Blocks: exact=29294 lossy=98147
                                               ->  Bitmap Index Scan on l2_keystone_abrev_hash_idx  (cost=0.00..23.78 rows=1495 width=0) (actual time=3.947..3.947 rows=66849 loops=5)
                                                     Index Cond: (l2_keystone_abrev_hash = l2_keystones.l2_keystone_abrev_hash)
                                   ->  Index Scan using btc_blocks_pkey on btc_blocks  (cost=0.42..8.04 rows=1 width=41) (actual time=0.003..0.003 rows=1 loops=48840)
                                         Index Cond: (hash = pop_basis.btc_block_hash)
 Planning Time: 0.380 ms
 JIT:
   Functions: 23
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 0.876 ms, Inlining 9.092 ms, Optimization 67.168 ms, Emission 40.763 ms, Total 117.899 ms
 Execution Time: 771.135 ms
(26 rows)
```