### PR TITLE
do not include invalid keystones in effectiveHeight

### DIFF
--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1707,7 +1707,6 @@ func TestL2BtcFinalitiesByL2KeystoneWithCutoff(t *testing.T) {
 }
 
 func TestL2BtcFinalitiesByL2KeystoneWithCutoffReverseMining(t *testing.T) {
-
 	// if a newer keystone gets mined before gets mined before an older
 	// one, take that into account with effective height
 

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -1707,7 +1707,7 @@ func TestL2BtcFinalitiesByL2KeystoneWithCutoff(t *testing.T) {
 }
 
 func TestL2BtcFinalitiesByL2KeystoneWithCutoffReverseMining(t *testing.T) {
-	// if a newer keystone gets mined before gets mined before an older
+	// if a newer keystone gets mined before an older
 	// one, take that into account with effective height
 
 	ctx, cancel := defaultTestContext()

--- a/database/bfgd/postgres/postgres.go
+++ b/database/bfgd/postgres/postgres.go
@@ -767,7 +767,9 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 						AND pop_basis.l2_keystone_abrev_hash = l2_keystones.l2_keystone_abrev_hash
 					)
 				) btc_blocks ON TRUE
-				WHERE l2_block_number >= $1 LIMIT 1
+				WHERE 
+				l2_block_number >= $1 
+				AND l2_block_number <= $2
 			), 0)
 		`
 
@@ -810,7 +812,7 @@ func (p *pgdb) L2BTCFinalityByL2KeystoneAbrevHash(ctx context.Context, l2Keyston
 
 		var effectiveHeight uint32
 
-		if err := p.db.QueryRow(effectiveHeightSql, l2BtcFinality.L2Keystone.L2BlockNumber).Scan(&effectiveHeight); err != nil {
+		if err := p.db.QueryRow(effectiveHeightSql, l2BtcFinality.L2Keystone.L2BlockNumber, ignoreAfterL2Block).Scan(&effectiveHeight); err != nil {
 			return nil, fmt.Errorf("error querying for rows: %w", err)
 		}
 


### PR DESCRIPTION


**Summary**
when calculating effectiveHeight, we're not taking into account the ignore (we only do so when querying for blocks), add that to the effectiveHeight calculation

add test case for this

**Changes**
make sure that the invalid keystones are taken into account with effectiveHeight
