### PR TITLE
docs: update ubuntu version

### DIFF
--- a/localnode/NODE_RUNNING.md
+++ b/localnode/NODE_RUNNING.md
@@ -64,7 +64,7 @@ sequencer.*
 ## Prerequisites
 
 This guide assumes you are running [Docker](https://docs.docker.com/get-started/get-docker/)
-and [Docker Compose](https://docs.docker.com/compose/) on Ubuntu 24.04 (the latest LTS). Running on other setups is
+and [Docker Compose](https://docs.docker.com/compose/) on Ubuntu 22.04 (the latest LTS). Running on other setups is
 possible, but may not be fully supported.
 
 Docker images for each Hemi Network component is published to [Docker Hub](https://hub.docker.com/u/hemilabs).


### PR DESCRIPTION
In NODE_RUNNING.md, there's a reference to "Ubuntu 24.04" which doesn't exist yet (the latest LTS is 22.04). This should be corrected.