### PR TITLE
all: update go to 1.24 (toolchain 1.24.4)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 version: "2"
 run:
   tests: true
-  go: "1.23"
 
 issues:
   max-issues-per-linter: 0

--- a/api/auth/secp256k1_test.go
+++ b/api/auth/secp256k1_test.go
@@ -5,7 +5,6 @@
 package auth
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
@@ -101,7 +100,7 @@ func server(t *testing.T, want *int64) *httptest.Server {
 			t.Fatal(err)
 		}
 		t.Logf("server handshake starting")
-		ctx := context.TODO()
+		ctx := t.Context()
 		err = serverAuth.HandshakeServer(ctx, pconn)
 		if err != nil {
 			t.Fatalf("Failed to handshake connection for %v: %v",
@@ -157,7 +156,7 @@ func TestProtocolHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Logf("connect %v", clientURI)
 	err = conn.Connect(ctx)
 	if err != nil {

--- a/database/bfgd/database_ext_test.go
+++ b/database/bfgd/database_ext_test.go
@@ -135,7 +135,7 @@ func applySQLFiles(ctx context.Context, t *testing.T, sdb *sql.DB, path string) 
 }
 
 func TestDatabaseTestData(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
 	defer func() {
@@ -153,7 +153,7 @@ func TestDatabaseTestData(t *testing.T) {
 }
 
 func TestDatabasePostgres(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
 	defer func() {
@@ -307,7 +307,7 @@ func (b *btcBlocksNtfn) handleBtcBlocksNotification(pctx context.Context, table 
 }
 
 func TestBtcBlockReplaceNotIfSameBlock(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -352,7 +352,7 @@ func TestBtcBlockReplaceNotIfSameBlock(t *testing.T) {
 }
 
 func TestBtcBlockReplaceIfDifferentBlocks(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -400,7 +400,7 @@ func TestBtcBlockReplaceIfDifferentBlocks(t *testing.T) {
 }
 
 func TestBtcBlockNoReplaceIfDifferentBlocksAtDifferentHeights(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -462,7 +462,7 @@ func TestBtcBlockNoReplaceIfDifferentBlocksAtDifferentHeights(t *testing.T) {
 }
 
 func TestDatabaseNotification(t *testing.T) {
-	pctx := context.Background()
+	pctx := t.Context()
 
 	db, sdb, cleanup := createTestDB(pctx, t)
 	defer func() {
@@ -502,8 +502,8 @@ func TestDatabaseNotification(t *testing.T) {
 	}
 }
 
-func defaultTestContext() (context.Context, func()) {
-	return context.WithTimeout(context.Background(), 300*time.Second)
+func defaultTestContext(t *testing.T) (context.Context, func()) {
+	return context.WithTimeout(t.Context(), 300*time.Second)
 }
 
 // fillOutBytes will take a string and return a slice of bytes
@@ -518,7 +518,7 @@ func fillOutBytes(prefix string, size int) []byte {
 }
 
 func TestL2KeystoneInsertSuccess(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -565,7 +565,7 @@ func TestL2KeystoneInsertSuccess(t *testing.T) {
 }
 
 func TestL2KeystoneInsertMultipleSuccess(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -633,7 +633,7 @@ func TestL2KeystoneInsertMultipleSuccess(t *testing.T) {
 }
 
 func TestL2KeystoneInsertIgnoreDuplicates(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -706,7 +706,7 @@ func TestL2KeystoneInsertIgnoreDuplicates(t *testing.T) {
 }
 
 func TestL2KeystoneInsertInvalidHashLength(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -743,7 +743,7 @@ func TestL2KeystoneInsertInvalidHashLength(t *testing.T) {
 }
 
 func TestL2KeystoneInsertInvalidEPHashLength(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -780,7 +780,7 @@ func TestL2KeystoneInsertInvalidEPHashLength(t *testing.T) {
 }
 
 func TestL2KeystoneInsertInvalidStateRootLength(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -817,7 +817,7 @@ func TestL2KeystoneInsertInvalidStateRootLength(t *testing.T) {
 }
 
 func TestL2KeystoneInsertInvalidPrevKeystoneEPHashLength(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -854,7 +854,7 @@ func TestL2KeystoneInsertInvalidPrevKeystoneEPHashLength(t *testing.T) {
 }
 
 func TestL2KeystoneInsertInvalidParentEPHashLength(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -891,7 +891,7 @@ func TestL2KeystoneInsertInvalidParentEPHashLength(t *testing.T) {
 }
 
 func TestL2KeystoneByAbrevHashNotFound(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -908,7 +908,7 @@ func TestL2KeystoneByAbrevHashNotFound(t *testing.T) {
 }
 
 func TestL2KeystoneByAbrevHashFound(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -946,7 +946,7 @@ func TestL2KeystoneByAbrevHashFound(t *testing.T) {
 }
 
 func TestL2KeystoneInsertMostRecentNMoreThanSaved(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -999,7 +999,7 @@ func TestL2KeystoneInsertMostRecentNMoreThanSaved(t *testing.T) {
 }
 
 func TestL2KeystoneInsertMostRecentNFewerThanSaved(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1051,7 +1051,7 @@ func TestL2KeystoneInsertMostRecentNFewerThanSaved(t *testing.T) {
 }
 
 func TestL2KeystoneInsertMostRecentNLimit100(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1098,7 +1098,7 @@ func TestL2KeystoneInsertMostRecentNLimit100(t *testing.T) {
 }
 
 func TestL2KeystoneInsertMultipleAtomicFailure(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1146,7 +1146,7 @@ func TestL2KeystoneInsertMultipleAtomicFailure(t *testing.T) {
 }
 
 func TestL2KeystoneInsertDuplicateOK(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1194,7 +1194,7 @@ func TestL2KeystoneInsertDuplicateOK(t *testing.T) {
 }
 
 func TestPopBasisInsertNilMerklePath(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1239,7 +1239,7 @@ func TestPopBasisInsertNilMerklePath(t *testing.T) {
 }
 
 func TestPopBasisInsertNotNilMerklePath(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1285,7 +1285,7 @@ func TestPopBasisInsertNotNilMerklePath(t *testing.T) {
 }
 
 func TestPopBasisInsertNilMerklePathFromPopM(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1330,7 +1330,7 @@ func TestPopBasisInsertNilMerklePathFromPopM(t *testing.T) {
 }
 
 func TestPopBasisUpdateNoneExist(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1374,7 +1374,7 @@ func TestPopBasisUpdateNoneExist(t *testing.T) {
 }
 
 func TestPopBasisUpdateOneExistsWithNonNullBTCFields(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1487,7 +1487,7 @@ func TestPopBasisUpdateOneExistsWithNonNullBTCFields(t *testing.T) {
 }
 
 func TestPopBasisUpdateOneExistsWithNullBTCFields(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1586,7 +1586,7 @@ func TestPublications(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-			ctx, cancel := defaultTestContext()
+			ctx, cancel := defaultTestContext(t)
 			defer cancel()
 
 			db, sdb, cleanup := createTestDB(ctx, t)
@@ -1632,7 +1632,7 @@ func TestPublications(t *testing.T) {
 }
 
 func TestL2BtcFinalitiesByL2Keystone(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1675,7 +1675,7 @@ func TestL2BtcFinalitiesByL2Keystone(t *testing.T) {
 }
 
 func TestL2BtcFinalitiesByL2KeystoneWithCutoff(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1719,7 +1719,7 @@ func TestL2BtcFinalitiesByL2KeystoneWithCutoffReverseMining(t *testing.T) {
 	// if a newer keystone gets mined before an older
 	// one, take that into account with effective height
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1760,7 +1760,7 @@ func TestL2BtcFinalitiesByL2KeystoneWithCutoffReverseMining(t *testing.T) {
 }
 
 func TestL2BtcFinalitiesByL2KeystoneNotPublishedHeight(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1808,7 +1808,7 @@ type BtcTransactionBroadcastRequest struct {
 }
 
 func TestBtcTransactionBroadcastRequestInsert(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1861,7 +1861,7 @@ func TestBtcTransactionBroadcastRequestInsert(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestGetNext(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1890,7 +1890,7 @@ func TestBtcTransactionBroadcastRequestGetNext(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestGetNextMultiple(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1945,7 +1945,7 @@ func TestBtcTransactionBroadcastRequestGetNextMultiple(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestGetNextBefore10Minutes(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -1985,7 +1985,7 @@ func TestBtcTransactionBroadcastRequestGetNextBefore10Minutes(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestGetNextRetry(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -2028,7 +2028,7 @@ func TestBtcTransactionBroadcastRequestGetNextRetry(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestGetNextAfter2Hours(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -2062,7 +2062,7 @@ func TestBtcTransactionBroadcastRequestGetNextAfter2Hours(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestGetNextAlreadyBroadcast(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -2096,7 +2096,7 @@ func TestBtcTransactionBroadcastRequestGetNextAlreadyBroadcast(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestConfirmBroadcast(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -2130,7 +2130,7 @@ func TestBtcTransactionBroadcastRequestConfirmBroadcast(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestTrimTooNew(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)
@@ -2168,7 +2168,7 @@ func TestBtcTransactionBroadcastRequestTrimTooNew(t *testing.T) {
 }
 
 func TestBtcTransactionBroadcastRequestTrim(t *testing.T) {
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	db, sdb, cleanup := createTestDB(ctx, t)

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMD(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	home := t.TempDir()
@@ -204,7 +204,7 @@ func TestKssEncoding(t *testing.T) {
 }
 
 func TestKeystoneUpdate(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	kssList := []hemi.L2Keystone{
@@ -400,7 +400,7 @@ func newKeystone(blockhash *chainhash.Hash, l1, l2 uint32) (*chainhash.Hash, tbc
 }
 
 func TestKeystoneDBWindUnwind(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	home := t.TempDir()
@@ -468,7 +468,7 @@ func TestKeystoneDBWindUnwind(t *testing.T) {
 }
 
 func TestKeystoneDBCache(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	home := t.TempDir()

--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
+FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
+FROM golang:1.24.4-alpine3.22@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/bssd/Dockerfile
+++ b/docker/bssd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
+FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/bssd/Dockerfile
+++ b/docker/bssd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
+FROM golang:1.24.4-alpine3.22@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
+FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
+FROM golang:1.24.4-alpine3.22@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a AS builder
 
 ARG GO_LDFLAGS
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -108,7 +108,7 @@ func init() {
 }
 
 func EnsureCanConnect(t *testing.T, url string, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	t.Logf("connecting to %s", url)
@@ -606,8 +606,8 @@ func handleMockElectrsConnection(ctx context.Context, t *testing.T, conn net.Con
 	}
 }
 
-func defaultTestContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 30*time.Second)
+func defaultTestContext(t *testing.T) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(t.Context(), 30*time.Second)
 }
 
 // assertPing is a short helper method to assert reading a ping after connecting
@@ -714,14 +714,14 @@ func createBtcTx(t *testing.T, btcHeight uint64, l2Keystone *hemi.L2Keystone, mi
 }
 
 func TestBFGPublicDisabled(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, _, bfgPublicWsUrl := createBfgServerWithAccess(ctx, t, pgUri, "", 1, "", true)
@@ -752,14 +752,14 @@ func TestBFGPublicDisabled(t *testing.T) {
 // 2. Send aforementioned L2Keystone to BSS via websocket
 // 3. Query database to ensure that the L2Keystone was saved
 func TestNewL2Keystone(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1)
@@ -837,14 +837,14 @@ func TestNewL2Keystone(t *testing.T) {
 // 3. Query BFG via http json rpc for latest keystones
 // 4. Assert that the saved keystones are returned ordered by L2BlockNumber desc
 func TestL2Keystone(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, _, bfgPublicWsUrl := createBfgServer(ctx, t, pgUri, "", 1)
@@ -950,14 +950,14 @@ func TestL2Keystone(t *testing.T) {
 }
 
 func TestPublicPing(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, _, bfgPublicWsUrl := createBfgServer(ctx, t, pgUri, "", 1)
@@ -976,14 +976,14 @@ func TestPublicPing(t *testing.T) {
 }
 
 func TestBitcoinBalance(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -1140,14 +1140,14 @@ func TestBFGPublicErrorCases(t *testing.T) {
 			if tti.skip {
 				t.Skip()
 			}
-			db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+			db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 			defer func() {
 				db.Close()
 				sdb.Close()
 				cleanup()
 			}()
 
-			ctx, cancel := defaultTestContext()
+			ctx, cancel := defaultTestContext(t)
 			defer cancel()
 
 			electrsAddr := ""
@@ -1237,14 +1237,14 @@ func TestBFGPublicErrorCases(t *testing.T) {
 }
 
 func TestBitcoinInfo(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -1321,14 +1321,14 @@ func TestBitcoinInfo(t *testing.T) {
 }
 
 func TestBitcoinUTXOs(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -1412,14 +1412,14 @@ func TestBitcoinUTXOs(t *testing.T) {
 // 2. call BitcoinBroadcast RPC on BFG
 // 3. ensure that a pop_basis was inserted with the expected values
 func TestBitcoinBroadcast(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -1542,14 +1542,14 @@ func TestBitcoinBroadcast(t *testing.T) {
 // 5 assert error received
 func TestBitcoinBroadcastDuplicate(t *testing.T) {
 	t.Skip()
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -1705,14 +1705,14 @@ func TestBitcoinBroadcastDuplicate(t *testing.T) {
 // 2 ensure that btc_block is inserted with correct values.  this is checked on
 // an internal timer, so give this a timeout
 func TestProcessBitcoinBlockNewBtcBlock(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -1821,14 +1821,14 @@ loop:
 // 3 query database for newly created pop_basis, this happens on a timer
 // 4 ensure pop_basis was inserted and filled out with correct fields
 func TestProcessBitcoinBlockNewFullPopBasis(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -1962,14 +1962,14 @@ loop:
 // 4 wait for full pop_basis to be in database
 // 5 assert the pop_basis fields are correct
 func TestBitcoinBroadcastThenUpdate(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -2120,14 +2120,14 @@ loop:
 // 2 query for the pop payouts by calling BSS.popPayouts
 // 3 ensure the correct values
 func TestPopPayouts(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	privateKey := secp256k1.PrivKeyFromBytes([]byte{9, 8, 7})
@@ -2337,14 +2337,14 @@ func TestPopPayouts(t *testing.T) {
 }
 
 func TestPopPayoutsMultiplePages(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	includedL2Keystone := hemi.L2Keystone{
@@ -2520,14 +2520,14 @@ func TestPopPayoutsMultiplePages(t *testing.T) {
 }
 
 func TestGetMostRecentL2BtcFinalitiesBSS(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1000)
@@ -2624,14 +2624,14 @@ func updateFinalityForBtcBlock(t *testing.T, ctx context.Context, db bfgd.Databa
 }
 
 func TestGetFinalitiesByL2KeystoneBSS(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1000)
@@ -2726,14 +2726,14 @@ func TestGetFinalitiesByL2KeystoneBSS(t *testing.T) {
 }
 
 func TestGetFinalitiesByL2KeystoneBSSLowerServerHeight(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 999)
@@ -2827,14 +2827,14 @@ func TestGetFinalitiesByL2KeystoneBSSLowerServerHeight(t *testing.T) {
 }
 
 func TestGetMostRecentL2BtcFinalitiesBFG(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1000)
@@ -2916,14 +2916,14 @@ func TestGetMostRecentL2BtcFinalitiesBFG(t *testing.T) {
 }
 
 func TestGetFinalitiesByL2KeystoneBFG(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1000)
@@ -3017,14 +3017,14 @@ func TestGetFinalitiesByL2KeystoneBFG(t *testing.T) {
 }
 
 func TestGetFinalitiesByL2KeystoneBFGVeryOld(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1)
 
@@ -3123,14 +3123,14 @@ func TestGetFinalitiesByL2KeystoneBFGVeryOld(t *testing.T) {
 }
 
 func TestGetFinalitiesByL2KeystoneBFGNotThatOld(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, bfgWsurl, _ := createBfgServer(ctx, t, pgUri, "", 1)
@@ -3233,14 +3233,14 @@ func TestGetFinalitiesByL2KeystoneBFGNotThatOld(t *testing.T) {
 // 1. connect client
 // 2. wait for notification
 func TestNotifyOnNewBtcBlockBFGClients(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -3303,14 +3303,14 @@ func TestNotifyOnNewBtcBlockBFGClients(t *testing.T) {
 // 1. connect client
 // 2. wait for notification
 func TestNotifyOnNewBtcFinalityBFGClients(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -3367,14 +3367,14 @@ func TestNotifyOnNewBtcFinalityBFGClients(t *testing.T) {
 }
 
 func TestNotifyOnL2KeystonesBFGClients(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, _, bfgPublicWsUrl := createBfgServer(ctx, t, pgUri, "", 1)
@@ -3429,21 +3429,21 @@ func TestNotifyOnL2KeystonesBFGClients(t *testing.T) {
 }
 
 func TestNotifyOnL2KeystonesBFGClientsViaOtherBFG(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	otherDb, otherPgUri, otherSdb, otherCleanup := createTestDB(context.Background(), t)
+	otherDb, otherPgUri, otherSdb, otherCleanup := createTestDB(t.Context(), t)
 	defer func() {
 		otherDb.Close()
 		otherSdb.Close()
 		otherCleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, _, bfgPublicWsUrl := createBfgServer(ctx, t, pgUri, "", 1)
@@ -3505,21 +3505,21 @@ func TestNotifyOnL2KeystonesBFGClientsViaOtherBFG(t *testing.T) {
 func TestOtherBFGSavesL2KeystonesOnNotifications(t *testing.T) {
 	t.Parallel()
 
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	otherDb, otherPgUri, otherSdb, otherCleanup := createTestDB(context.Background(), t)
+	otherDb, otherPgUri, otherSdb, otherCleanup := createTestDB(t.Context(), t)
 	defer func() {
 		otherDb.Close()
 		otherSdb.Close()
 		otherCleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	_, _, _, bfgPublicWsUrl := createBfgServer(ctx, t, pgUri, "", 1)
@@ -3658,14 +3658,14 @@ func TestOtherBFGSavesL2KeystonesOnNotifications(t *testing.T) {
 // 1. connect client
 // 2. wait for notification
 func TestNotifyOnNewBtcBlockBSSClients(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -3728,14 +3728,14 @@ func TestNotifyOnNewBtcBlockBSSClients(t *testing.T) {
 // 1. connect client
 // 2. wait for notification
 func TestNotifyOnNewBtcFinalityBSSClients(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -3793,14 +3793,14 @@ func TestNotifyOnNewBtcFinalityBSSClients(t *testing.T) {
 }
 
 func TestNotifyMultipleBFGClients(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{
@@ -3864,14 +3864,14 @@ func TestNotifyMultipleBFGClients(t *testing.T) {
 }
 
 func TestNotifyMultipleBSSClients(t *testing.T) {
-	db, pgUri, sdb, cleanup := createTestDB(context.Background(), t)
+	db, pgUri, sdb, cleanup := createTestDB(t.Context(), t)
 	defer func() {
 		db.Close()
 		sdb.Close()
 		cleanup()
 	}()
 
-	ctx, cancel := defaultTestContext()
+	ctx, cancel := defaultTestContext(t)
 	defer cancel()
 
 	l2Keystone := hemi.L2Keystone{

--- a/e2e/monitor/go.mod
+++ b/e2e/monitor/go.mod
@@ -1,8 +1,6 @@
 module github.com/hemilabs/heminetwork/e2e/monitor
 
-go 1.23
-
-toolchain go1.24.3
+go 1.24.3
 
 replace github.com/hemilabs/heminetwork => ../../
 

--- a/e2e/monitor/go.mod
+++ b/e2e/monitor/go.mod
@@ -1,6 +1,6 @@
 module github.com/hemilabs/heminetwork/e2e/monitor
 
-go 1.24.3
+go 1.24.4
 
 replace github.com/hemilabs/heminetwork => ../../
 

--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -112,7 +112,7 @@ func TestMonitor(t *testing.T) {
 }
 
 func TestL1L2Comms(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Minute)
 	defer cancel()
 
 	l1Client, err := ethclient.Dial("http://localhost:8545")
@@ -150,7 +150,7 @@ func TestL1L2Comms(t *testing.T) {
 }
 
 func TestOperatorFeeVaultIsPresent(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	l2Client, err := ethclient.Dial("http://localhost:8546")

--- a/e2e/optimism-stack-legacy.Dockerfile
+++ b/e2e/optimism-stack-legacy.Dockerfile
@@ -1,8 +1,8 @@
-# Copyright (c) 2024 Hemi Labs, Inc.
+# Copyright (c) 2024-2025 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
-FROM golang:1.23.4-bookworm@sha256:ef30001eeadd12890c7737c26f3be5b3a8479ccdcdc553b999c84879875a27ce AS build_1
+FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21 AS build_1
 
 WORKDIR /git
 
@@ -17,7 +17,7 @@ RUN make
 
 RUN go build -o /tmp ./...
 
-FROM golang:1.22.6-bookworm@sha256:f020456572fc292e9627b3fb435c6de5dfb8020fbcef1fd7b65dd092c0ac56bb AS build_2
+FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /tmp/geth /bin/geth

--- a/e2e/optimism-stack-legacy.Dockerfile
+++ b/e2e/optimism-stack-legacy.Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
-FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21 AS build_1
+FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122 AS build_1
 
 WORKDIR /git
 
@@ -17,7 +17,7 @@ RUN make
 
 RUN go build -o /tmp ./...
 
-FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21AS build_2
+FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /tmp/geth /bin/geth

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
-FROM golang:1.23.4-bookworm@sha256:ef30001eeadd12890c7737c26f3be5b3a8479ccdcdc553b999c84879875a27ce AS build_1
+FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21 AS build_1
 
 WORKDIR /git
 
@@ -13,7 +13,7 @@ RUN git checkout e79d9922c9acaa5c46597b1ffe0259597aa9499d
 
 RUN go run build/ci.go install -static ./cmd/geth
 
-FROM golang:1.24.2-bookworm@sha256:00eccd446e023d3cd9566c25a6e6a02b90db3e1e0bbe26a48fc29cd96e800901 AS build_2
+FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21 AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /git/op-geth/build/bin/geth /bin/geth

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
-FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21 AS build_1
+FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122 AS build_1
 
 WORKDIR /git
 
@@ -13,7 +13,7 @@ RUN git checkout e79d9922c9acaa5c46597b1ffe0259597aa9499d
 
 RUN go run build/ci.go install -static ./cmd/geth
 
-FROM golang:1.24.3-bookworm@sha256:29d97266c1d341b7424e2f5085440b74654ae0b61ecdba206bc12d6264844e21 AS build_2
+FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122 AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /git/op-geth/build/bin/geth /bin/geth

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hemilabs/heminetwork
 
-go 1.24.3
+go 1.24
+
+toolchain go1.24.4
 
 // Temporary replace until we upstream our ws_js patch.
 replace github.com/coder/websocket v1.8.12 => github.com/hemilabs/websocket v0.0.0-20240813101919-bf33653e9aa5

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hemilabs/heminetwork
 
-go 1.23
-
-toolchain go1.24.3
+go 1.24.3
 
 // Temporary replace until we upstream our ws_js patch.
 replace github.com/coder/websocket v1.8.12 => github.com/hemilabs/websocket v0.0.0-20240813101919-bf33653e9aa5

--- a/hemi/electrs/conn_pool_test.go
+++ b/hemi/electrs/conn_pool_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -21,7 +21,7 @@ var testClientOpts = &ClientOptions{
 }
 
 func TestConnPool(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	server := createMockServer(t)

--- a/hemi/electrs/conn_test.go
+++ b/hemi/electrs/conn_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -23,7 +23,7 @@ import (
 )
 
 func TestClientConn(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	server := createMockServer(t)
@@ -94,7 +94,7 @@ func TestWriteRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			if err := writeRequest(context.Background(), &buf, tt.req); err != nil {
+			if err := writeRequest(t.Context(), &buf, tt.req); err != nil {
 				t.Errorf("writeRequest() err = %v", err)
 			}
 
@@ -143,7 +143,7 @@ func TestReadResponse(t *testing.T) {
 			buf := bytes.NewBuffer(b)
 			_ = buf.WriteByte('\n')
 
-			res, err := readResponse(context.Background(), buf, tt.reqID)
+			res, err := readResponse(t.Context(), buf, tt.reqID)
 			switch {
 			case (err != nil) != tt.wantErr:
 				t.Errorf("readResponse() err = %v, want err %v",
@@ -177,7 +177,7 @@ func TestClose(t *testing.T) {
 	c := newClientConn(conn, nil, nil)
 
 	// Ping the server.
-	if err := c.ping(context.Background()); err != nil {
+	if err := c.ping(t.Context()); err != nil {
 		t.Errorf("failed to ping server: %v", err)
 	}
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -168,7 +168,7 @@ func TestProcessReceivedKeystones(t *testing.T) {
 		l2Keystones: make(map[string]L2KeystoneProcessingContainer),
 	}
 
-	miner.processReceivedKeystones(context.Background(), firstBatchOfL2Keystones)
+	miner.processReceivedKeystones(t.Context(), firstBatchOfL2Keystones)
 	diff := deep.Equal(*miner.lastKeystone, hemi.L2Keystone{
 		L2BlockNumber: 3,
 		EPHash:        []byte{3},
@@ -178,7 +178,7 @@ func TestProcessReceivedKeystones(t *testing.T) {
 		t.Fatalf("unexpected diff: %v", diff)
 	}
 
-	miner.processReceivedKeystones(context.Background(), secondBatchOfL2Keystones)
+	miner.processReceivedKeystones(t.Context(), secondBatchOfL2Keystones)
 	diff = deep.Equal(*miner.lastKeystone, hemi.L2Keystone{
 		L2BlockNumber: 6,
 		EPHash:        []byte{6},
@@ -233,8 +233,8 @@ func TestProcessReceivedKeystonesSameL2BlockNumber(t *testing.T) {
 	}
 	miner.cfg.RetryMineThreshold = 1
 
-	miner.processReceivedKeystones(context.Background(), firstBatchOfL2Keystones)
-	miner.processReceivedKeystones(context.Background(), secondBatchOfL2Keystones)
+	miner.processReceivedKeystones(t.Context(), firstBatchOfL2Keystones)
+	miner.processReceivedKeystones(t.Context(), secondBatchOfL2Keystones)
 
 	for _, v := range append(firstBatchOfL2Keystones, secondBatchOfL2Keystones...) {
 		serialized := hemi.L2KeystoneAbbreviate(v).Serialize()
@@ -288,8 +288,8 @@ func TestProcessReceivedKeystonesOverThreshold(t *testing.T) {
 	}
 	miner.cfg.RetryMineThreshold = 1
 
-	miner.processReceivedKeystones(context.Background(), firstBatchOfL2Keystones)
-	miner.processReceivedKeystones(context.Background(), secondBatchOfL2Keystones)
+	miner.processReceivedKeystones(t.Context(), firstBatchOfL2Keystones)
+	miner.processReceivedKeystones(t.Context(), secondBatchOfL2Keystones)
 
 	for _, v := range firstBatchOfL2Keystones {
 		serialized := hemi.L2KeystoneAbbreviate(v).Serialize()
@@ -638,7 +638,7 @@ func TestProcessReceivedInAscOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	miner.processReceivedKeystones(context.Background(), firstBatchOfL2Keystones)
+	miner.processReceivedKeystones(t.Context(), firstBatchOfL2Keystones)
 	receivedKeystones := miner.l2KeystonesForProcessing()
 
 	slices.Reverse(receivedKeystones)
@@ -673,7 +673,7 @@ func TestProcessReceivedOnlyOnce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	miner.processReceivedKeystones(context.Background(), keystones)
+	miner.processReceivedKeystones(t.Context(), keystones)
 
 	processedKeystonesFirstTime := 0
 	for range miner.l2KeystonesForProcessing() {
@@ -717,7 +717,7 @@ func TestProcessReceivedOnlyOnceWithError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	miner.processReceivedKeystones(context.Background(), keystones)
+	miner.processReceivedKeystones(t.Context(), keystones)
 
 	processedKeystonesFirstTime := 0
 	for _, c := range miner.l2KeystonesForProcessing() {
@@ -779,7 +779,7 @@ func TestProcessReceivedNoDuplicates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	miner.processReceivedKeystones(context.Background(), keystones)
+	miner.processReceivedKeystones(t.Context(), keystones)
 	receivedKeystones := miner.l2KeystonesForProcessing()
 
 	slices.Reverse(keystones)
@@ -858,7 +858,7 @@ func TestProcessReceivedInAscOrderOverride(t *testing.T) {
 	}
 
 	for _, keystone := range keystones {
-		miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{keystone})
+		miner.processReceivedKeystones(t.Context(), []hemi.L2Keystone{keystone})
 	}
 
 	receivedKeystones := miner.l2KeystonesForProcessing()
@@ -885,7 +885,7 @@ func TestProcessAllKeystonesIfAble(t *testing.T) {
 			L2BlockNumber: i,
 			EPHash:        []byte{byte(i)},
 		}
-		miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{keystone})
+		miner.processReceivedKeystones(t.Context(), []hemi.L2Keystone{keystone})
 		for _, c := range miner.l2KeystonesForProcessing() {
 			diff := deep.Equal(c, keystone)
 			if len(diff) != 0 {
@@ -955,11 +955,11 @@ func TestProcessReceivedInAscOrderNoInsertIfTooOld(t *testing.T) {
 	}
 
 	for _, keystone := range keystones {
-		miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{keystone})
+		miner.processReceivedKeystones(t.Context(), []hemi.L2Keystone{keystone})
 	}
 
 	// this one should be dropped
-	miner.processReceivedKeystones(context.Background(), []hemi.L2Keystone{
+	miner.processReceivedKeystones(t.Context(), []hemi.L2Keystone{
 		{
 			L2BlockNumber: 1,
 			EPHash:        []byte{1},
@@ -984,7 +984,7 @@ func TestConnectToBFGAndPerformMineWithAuth(t *testing.T) {
 
 	publicKey := hex.EncodeToString(privateKey.PubKey().SerializeCompressed())
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), defaultTestTimeout)
 	defer cancel()
 	server, msgCh, cleanup := createMockBFG(ctx, t, []string{publicKey}, false, 1)
 	defer cleanup()
@@ -1047,7 +1047,7 @@ func TestConnectToBFGAndPerformMine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), defaultTestTimeout)
 	defer cancel()
 	server, msgCh, cleanup := createMockBFG(ctx, t, []string{}, false, 1)
 	defer cleanup()
@@ -1110,7 +1110,7 @@ func TestConnectToBFGAndPerformMineMultiple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), defaultTestTimeout)
 	defer cancel()
 	server, msgCh, cleanup := createMockBFG(ctx, t, []string{}, false, 2)
 	defer cleanup()
@@ -1174,7 +1174,7 @@ func TestConnectToBFGAndPerformMineALot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), defaultTestTimeout)
 	defer cancel()
 	server, msgCh, cleanup := createMockBFG(ctx, t, []string{}, false, 100)
 	defer cleanup()
@@ -1238,7 +1238,7 @@ func TestConnectToBFGAndPerformMineWithAuthError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), defaultTestTimeout)
 	defer cancel()
 	server, msgCh, cleanup := createMockBFG(ctx, t, []string{"incorrect"}, false, 1)
 	defer cleanup()

--- a/service/tbc/crawler_test.go
+++ b/service/tbc/crawler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -21,7 +21,7 @@ import (
 //		t.Fatal(err)
 //	}
 //
-//	ctx, cancel := context.WithCancel(context.Background())
+//	ctx, cancel := context.WithCancel(t.Context())
 //	defer cancel()
 //
 //	// Open db.

--- a/service/tbc/peer/peer_test.go
+++ b/service/tbc/peer/peer_test.go
@@ -36,7 +36,7 @@ func TestPeer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	if err = p.Connect(ctx); err != nil {

--- a/service/tbc/peer/rawpeer/rawpeer_test.go
+++ b/service/tbc/peer/rawpeer/rawpeer_test.go
@@ -54,7 +54,7 @@ func mockPeerServer(ctx context.Context, id int, listener net.Listener, msgCh ch
 }
 
 func TestConcurrentReadWrite(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	msgCh := make(chan string)

--- a/service/tbc/peermanager_test.go
+++ b/service/tbc/peermanager_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -44,7 +44,7 @@ func TestPeerManager(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	go func() {

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -74,7 +74,7 @@ func slice2Header(header []byte) (*wire.BlockHeader, error) {
 func TestBlockHeadersByHeightRaw(t *testing.T) {
 	skipIfNoDocker(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 100, "")
@@ -144,7 +144,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 func TestBlockHeadersByHeight(t *testing.T) {
 	skipIfNoDocker(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 100, "")
@@ -208,7 +208,7 @@ func TestBlockHeadersByHeight(t *testing.T) {
 func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 	skipIfNoDocker(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 100, "")
@@ -266,7 +266,7 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 func TestBlockHeaderBestRaw(t *testing.T) {
 	skipIfNoDocker(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 50, "")
@@ -334,7 +334,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 func TestBtcBlockHeaderBest(t *testing.T) {
 	skipIfNoDocker(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 100, "")
@@ -477,7 +477,7 @@ func TestBalanceByAddress(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 			defer cancel()
 
 			initialBlocks := 0
@@ -699,7 +699,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 			defer cancel()
 
 			var bitcoindContainer testcontainers.Container
@@ -911,7 +911,7 @@ func TestUtxosByAddress(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 			defer cancel()
 
 			var bitcoindContainer testcontainers.Container
@@ -1008,7 +1008,7 @@ func TestUtxosByAddress(t *testing.T) {
 
 func TestTxByIdRaw(t *testing.T) {
 	skipIfNoDocker(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	_, _, address, err := bitcoin.KeysAndAddressFromHexString(
@@ -1091,7 +1091,7 @@ func TestTxByIdRaw(t *testing.T) {
 
 func TestTxByIdRawInvalid(t *testing.T) {
 	skipIfNoDocker(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	_, _, address, err := bitcoin.KeysAndAddressFromHexString(
 		privateKey,
@@ -1165,7 +1165,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 
 func TestTxByIdRawNotFound(t *testing.T) {
 	skipIfNoDocker(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 0, "")
 	defer func() {
@@ -1254,7 +1254,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 
 func TestTxById(t *testing.T) {
 	skipIfNoDocker(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	_, _, address, err := bitcoin.KeysAndAddressFromHexString(
@@ -1334,7 +1334,7 @@ func TestTxById(t *testing.T) {
 
 func TestTxByIdInvalid(t *testing.T) {
 	skipIfNoDocker(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	_, _, address, err := bitcoin.KeysAndAddressFromHexString(
 		privateKey,
@@ -1408,7 +1408,7 @@ func TestTxByIdInvalid(t *testing.T) {
 
 func TestTxByIdNotFound(t *testing.T) {
 	skipIfNoDocker(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 0, "")
 	defer func() {
@@ -1546,7 +1546,7 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
 			port, err := nat.NewPort("tcp", "9999")
 			if err != nil {

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -134,7 +134,7 @@ func TestDbUpgradePipeline(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer func() {
 		cancel()
 	}()
@@ -285,7 +285,7 @@ func TestDbUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer func() {
 		cancel()
 	}()
@@ -461,7 +461,7 @@ func TestKeystonesInBlock(t *testing.T) {
 func TestServerBlockHeadersBest(t *testing.T) {
 	skipIfNoDocker(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	blocks := uint64(100)
@@ -948,7 +948,7 @@ func TestForksWithGen(t *testing.T) {
 
 	for _, tt := range testTable {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 			defer cancel()
 
 			// generate 200 to btcAddress
@@ -1217,7 +1217,7 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 }
 
 func EnsureCanConnect(t *testing.T, url string, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	t.Logf("connecting to %s", url)
@@ -1596,7 +1596,7 @@ func getHeaderHashesRange(start int, end int, headerStrs []string, hashStrs []st
 // This test also tests to make sure upstreamStateIds are stored correctly.
 // XXX TODO: Refactor this to use convenience methods
 func TestExternalHeaderModeSimpleSingleBlockChunks(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	tbc := createTbcServerExternalHeaderMode(ctx, t)
@@ -1797,7 +1797,7 @@ func TestExternalHeaderModeSimpleSingleBlockChunks(t *testing.T) {
 // at a time until only genesis remains.
 // XXX TODO: Refactor this to use convenience methods
 func TestExternalHeaderModeSimpleThreeBlockChunks(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	tbc := createTbcServerExternalHeaderMode(ctx, t)
@@ -1990,7 +1990,7 @@ func TestExternalHeaderModeSimpleThreeBlockChunks(t *testing.T) {
 // Finally, this test adds blocks [3-8] again and ensures block 8
 // is correctly set as the canonical tip.
 func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	// XXX all t.Error in here should be t.Fatal. There is no point in

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1138,7 +1138,7 @@ func (s *Server) hasAllBlocks(ctx context.Context, m map[int32][]*block) (bool, 
 }
 
 func TestFork(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
 	defer func() {
 		cancel()
 	}()
@@ -1406,7 +1406,7 @@ func TestWork(t *testing.T) {
 }
 
 func TestIndexNoFork(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
 	defer func() {
 		cancel()
 	}()
@@ -1594,7 +1594,7 @@ func TestIndexNoFork(t *testing.T) {
 }
 
 func TestKeystoneIndexNoFork(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
 	defer func() {
 		cancel()
 	}()
@@ -1864,7 +1864,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 }
 
 func TestIndexFork(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
 	defer func() {
 		cancel()
 	}()
@@ -2183,7 +2183,7 @@ func TestIndexFork(t *testing.T) {
 }
 
 func TestKeystoneIndexFork(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
 	defer func() {
 		cancel()
 	}()
@@ -2694,7 +2694,7 @@ func TestTransactions(t *testing.T) {
 }
 
 func TestForkCanonicity(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
 	defer func() {
 		cancel()
 	}()

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -34,7 +34,7 @@ func TestTTLExpireAuto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var wg sync.WaitGroup
@@ -69,7 +69,7 @@ func TestTTLCancelAuto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var wg sync.WaitGroup
@@ -107,7 +107,7 @@ func TestTTLExpire(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var wg sync.WaitGroup
@@ -152,7 +152,7 @@ func TestTTLCancel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var wg sync.WaitGroup
@@ -190,7 +190,7 @@ func TestTTLDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	for i := 0; i < count; i++ {
@@ -223,7 +223,7 @@ func TestTTLDeleteByValue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	x := 1337


### PR DESCRIPTION
**Summary**
Update Go version to `1.24` (and toolchain `go1.24.4`).

**Changes**
- Update required go version in `go.mod` to `1.24`.
- Update go toolchain version in `go.mod` to `1.24.4`.
- Update golang Docker images to `1.24.4-alpine3.22` and `1.24.4-bookworm`.
- Update tests to use `(*testing.T).Context()` instead of `context.Background()` or `context.TODO()`.