### PR TITLE
docker: add tbcd image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -200,11 +200,7 @@ builds:
       - "linux"
       - "windows"
       - "darwin"
-    goarch: [ "amd64", "arm64", "arm" ]
-    goarm: [ "7" ]
-    ignore:
-      - goos: "windows"
-        goarch: arm
+    goarch: [ "amd64", "arm64" ]
 
 archives:
   - format: "tar.gz"
@@ -360,6 +356,36 @@ dockers:
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
 
+  # tbcd amd64
+  - id: "tbcd-amd64"
+    goos: "linux"
+    goarch: "amd64"
+    dockerfile: "docker/tbcd/goreleaser.Dockerfile"
+    use: "buildx"
+    image_templates:
+      - "hemilabs/tbcd:{{ .Version }}-amd64"
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=VCS_REF={{ .FullCommit }}"
+      - "--build-arg=BUILD_DATE={{ .Date }}"
+
+  # tbcd arm64
+  - id: "tbcd-arm64"
+    goos: "linux"
+    goarch: "arm64"
+    dockerfile: "docker/tbcd/goreleaser.Dockerfile"
+    use: "buildx"
+    image_templates:
+      - "hemilabs/tbcd:{{ .Version }}-arm64"
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=VCS_REF={{ .FullCommit }}"
+      - "--build-arg=BUILD_DATE={{ .Date }}"
+
 # Creates Docker manifests for each image containing the images for each
 # architecture.
 docker_manifests:
@@ -478,6 +504,42 @@ docker_manifests:
       - "ghcr.io/hemilabs/popmd:{{ .Version }}-amd64"
       - "ghcr.io/hemilabs/popmd:{{ .Version }}-arm64"
       - "ghcr.io/hemilabs/popmd:{{ .Version }}-armv7"
+
+  # tbcd - Docker Hub
+  - name_template: "hemilabs/tbcd:latest"
+    image_templates:
+      - "hemilabs/tbcd:{{ .Version }}-amd64"
+      - "hemilabs/tbcd:{{ .Version }}-arm64"
+  - name_template: "hemilabs/tbcd:{{ .Major }}"
+    image_templates:
+      - "hemilabs/tbcd:{{ .Version }}-amd64"
+      - "hemilabs/tbcd:{{ .Version }}-arm64"
+  - name_template: "hemilabs/tbcd:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "hemilabs/tbcd:{{ .Version }}-amd64"
+      - "hemilabs/tbcd:{{ .Version }}-arm64"
+  - name_template: "hemilabs/tbcd:{{ .Version }}"
+    image_templates:
+      - "hemilabs/tbcd:{{ .Version }}-amd64"
+      - "hemilabs/tbcd:{{ .Version }}-arm64"
+
+  # tbcd - GitHub Container Registry
+  - name_template: "ghcr.io/hemilabs/tbcd:latest"
+    image_templates:
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-amd64"
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/hemilabs/tbcd:{{ .Major }}"
+    image_templates:
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-amd64"
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/hemilabs/tbcd:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-amd64"
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/hemilabs/tbcd:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-amd64"
+      - "ghcr.io/hemilabs/tbcd:{{ .Version }}-arm64"
 
 # Signs Docker images and manifests.
 docker_signs:

--- a/docker/tbcd/Dockerfile
+++ b/docker/tbcd/Dockerfile
@@ -1,0 +1,81 @@
+# Copyright (c) 2024-2025 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+# Build stage
+FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
+
+ARG GO_LDFLAGS
+
+# Add ca-certificates, timezone data, make and git
+RUN apk --no-cache add --update ca-certificates tzdata make git
+
+# Create non-root user
+RUN addgroup --gid 65532 tbcd && \
+    adduser --disabled-password --gecos "" \
+        --home "/etc/tbcd/" --shell "/sbin/nologin" \
+        -G tbcd --uid 65532 tbcd
+
+WORKDIR /build/
+
+COPY Makefile .
+COPY go.mod .
+COPY go.sum .
+RUN make go-deps
+
+COPY . .
+RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GOGC=off make GO_LDFLAGS="$GO_LDFLAGS" tbcd
+
+# Run stage
+FROM scratch
+
+# Build metadata
+ARG VERSION
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Hemi Labs" \
+      org.opencontainers.image.url="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.source="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="Hemi Labs" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="Tiny Bitcoin Daemon" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Tiny Bitcoin Daemon" \
+      org.label-schema.url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vendor="Hemi Labs" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"
+
+# Copy files
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /build/bin/tbcd /usr/local/bin/tbcd
+
+# Environment variables
+ENV TBC_ADDRESS=""
+ENV TBC_AUTO_INDEX=""
+ENV TBC_BLOCK_CACHE_SIZE=""
+ENV TBC_BLOCKHEADER_CACHE_SIZE=""
+ENV TBC_BLOCK_SANITY=""
+ENV TBC_HEMI_INDEX=""
+ENV TBC_LEVELDB_HOME="/etc/tbcd/"
+ENV TBC_LISTEN_ADDRESS=""
+ENV TBC_LOG_LEVEL=""
+ENV TBC_MAX_CACHED_KEYSTONES=""
+ENV TBC_MAX_CACHED_TXS=""
+ENV TBC_MEMPOOL_ENABLED=""
+ENV TBC_NETWORK=""
+ENV TBC_PEERS_WANTED=""
+ENV TBC_PPROF_ADDRESS=""
+ENV TBC_SEEDS=""
+
+USER tbcd:tbcd
+WORKDIR /etc/tbcd/
+ENTRYPOINT ["/usr/local/bin/tbcd"]

--- a/docker/tbcd/goreleaser.Dockerfile
+++ b/docker/tbcd/goreleaser.Dockerfile
@@ -1,0 +1,69 @@
+# Copyright (c) 2024-2025 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+# Build stage
+FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS builder
+
+# Add ca-certificates, timezone data
+RUN apk --no-cache add --update ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup --gid 65532 tbcd && \
+    adduser --disabled-password --gecos "" \
+        --home "/etc/tbcd/" --shell "/sbin/nologin" \
+        -G tbcd --uid 65532 tbcd
+
+# Run stage
+FROM scratch
+
+# Build metadata
+ARG VERSION
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.authors="Hemi Labs" \
+      org.opencontainers.image.url="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.source="https://github.com/hemilabs/heminetwork" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.vendor="Hemi Labs" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="Tiny Bitcoin Daemon" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Tiny Bitcoin Daemon" \
+      org.label-schema.url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-url="https://github.com/hemilabs/heminetwork" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vendor="Hemi Labs" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"
+
+# Copy files
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY tbcd /usr/local/bin/tbcd
+
+# Environment variables
+ENV TBC_ADDRESS=""
+ENV TBC_AUTO_INDEX=""
+ENV TBC_BLOCK_CACHE_SIZE=""
+ENV TBC_BLOCKHEADER_CACHE_SIZE=""
+ENV TBC_BLOCK_SANITY=""
+ENV TBC_HEMI_INDEX=""
+ENV TBC_LEVELDB_HOME="/etc/tbcd/"
+ENV TBC_LISTEN_ADDRESS=""
+ENV TBC_LOG_LEVEL=""
+ENV TBC_MAX_CACHED_KEYSTONES=""
+ENV TBC_MAX_CACHED_TXS=""
+ENV TBC_MEMPOOL_ENABLED=""
+ENV TBC_NETWORK=""
+ENV TBC_PEERS_WANTED=""
+ENV TBC_PPROF_ADDRESS=""
+ENV TBC_SEEDS=""
+
+USER tbcd:tbcd
+WORKDIR /etc/tbcd/
+ENTRYPOINT ["/usr/local/bin/tbcd"]


### PR DESCRIPTION
**Summary**
Add Docker image for `tbcd`, and setup GoReleaser to build and publish the image.

**Changes**
- Add scratch Docker image for `tbcd`.
- Add GoReleaser-specific scratch Docker image for `tbcd`.
- Remove building `tbcd` for armv7 in releases.
- Setup GoReleaser to build and publish `hemilabs/tbcd` image for amd64 and arm64.
- Setup GoReleaser to publish Docker multi-arch manifests for `hemilabs/tbcd`.
