### PR TITLE
e2e: revert legacy dockerfile

### DIFF
--- a/e2e/optimism-stack-legacy.Dockerfile
+++ b/e2e/optimism-stack-legacy.Dockerfile
@@ -17,7 +17,7 @@ RUN make
 
 RUN go build -o /tmp ./...
 
-FROM golang:1.22.6-bookworm@sha256:f020456572fc292e9627b3fb435c6de5dfb8020fbcef1fd7b65dd092c0ac56bb AS build_2
+FROM golang:1.22.12-bookworm@sha256:3d699e4d15d0f8f13c9195c0632a16702b8cbdece2955af1c23b37ae5d55a253 AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /tmp/geth /bin/geth

--- a/e2e/optimism-stack-legacy.Dockerfile
+++ b/e2e/optimism-stack-legacy.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Hemi Labs, Inc.
+# Copyright (c) 2024-2025 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 

--- a/e2e/optimism-stack-legacy.Dockerfile
+++ b/e2e/optimism-stack-legacy.Dockerfile
@@ -1,8 +1,8 @@
-# Copyright (c) 2024-2025 Hemi Labs, Inc.
+# Copyright (c) 2024 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
-FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122 AS build_1
+FROM golang:1.23.4-bookworm@sha256:ef30001eeadd12890c7737c26f3be5b3a8479ccdcdc553b999c84879875a27ce AS build_1
 
 WORKDIR /git
 
@@ -17,7 +17,7 @@ RUN make
 
 RUN go build -o /tmp ./...
 
-FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122AS build_2
+FROM golang:1.22.6-bookworm@sha256:f020456572fc292e9627b3fb435c6de5dfb8020fbcef1fd7b65dd092c0ac56bb AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /tmp/geth /bin/geth


### PR DESCRIPTION
**Summary**
as of now, the way we build localnet is that we "snapshot" network
creation at certain versions, if we want to update those versions we
need to ensure all dependencies work together.  as of now, they do not.
revert the changes that caused this.

**Changes**
see summary
