### PR TITLE
ensure updating keystones doesn't happen for every block all of the time

### DIFF
--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -590,7 +590,7 @@ func (s *Server) updateKeystonesForBtcBlock(ctx context.Context, btcHeaderHash [
 	return lastErr
 }
 
-func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
+func (s *Server) processBitcoinBlock(ctx context.Context, height uint64, forceUpdateKeystones bool) error {
 	log.Tracef("Processing Bitcoin block at height %d...", height)
 
 	netCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -609,22 +609,27 @@ func (s *Server) processBitcoinBlock(ctx context.Context, height uint64) error {
 	btcHeight := height
 	btcHeader := rbh
 
-	defer func() {
-		// unconditionally update l2 keystones found in a btc block after
-		// we're done processing that block.  this is a cheap operation and should
-		// always be kept up with the latest in the database
-		if err := s.updateKeystonesForBtcBlock(ctx, btcHeaderHash, btcHeight, s.l2KeystoneIgnoreAfter()); err != nil {
-			log.Errorf("update keystones for btc block: %w", err)
-		}
-	}()
-
 	btcBlockTmpChk, err := s.db.BtcBlockByHash(ctx, [32]byte(btcHeaderHash))
 	if err != nil && !errors.Is(err, database.ErrNotFound) {
 		return err
 	}
 
+	alreadyProcessed := btcBlockTmpChk != nil && btcBlockTmpChk.Height == btcHeight
+
+	// if we have already processed this block, but are "forcing" an update
+	// OR
+	// we have NOT already processed this block
+	// then update keystones
+	if alreadyProcessed && forceUpdateKeystones || !alreadyProcessed {
+		defer func() {
+			if err := s.updateKeystonesForBtcBlock(ctx, btcHeaderHash, btcHeight, s.l2KeystoneIgnoreAfter()); err != nil {
+				log.Errorf("update keystones for btc block: %w", err)
+			}
+		}()
+	}
+
 	// block with hash is already at height, no-reorg
-	if btcBlockTmpChk != nil && btcBlockTmpChk.Height == btcHeight {
+	if alreadyProcessed {
 		return fmt.Errorf("already processed block block: %w", ErrAlreadyProcessed)
 	}
 
@@ -854,7 +859,7 @@ func (s *Server) walkChain(ctx context.Context, tip uint64, exitFast bool) error
 	log.Tracef("starting to walk chain; tip=%d, s.cfg.BTCStartHeight=%d, exitFast=%b", tip, s.cfg.BTCStartHeight, exitFast)
 	for tip >= s.cfg.BTCStartHeight {
 		log.Tracef("walkChain progress; processing block at height %d", tip)
-		err := s.processBitcoinBlock(ctx, tip)
+		err := s.processBitcoinBlock(ctx, tip, !exitFast)
 		if errors.Is(err, ErrAlreadyProcessed) {
 			log.Tracef("block known at height %d", tip)
 


### PR DESCRIPTION
prior, we would unconditionally update the lowest l2 keystone (the finality) _BEFORE_ we would error if a block was seen.  on startup, this is fine and expected, but afterwards we should not be updating keystones for blocks that we have seen already as this has already happened.

add a check to prevent this

**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->

**Changes**
<!-- A list of changes made by this pull request. -->
