### PR TITLE
make: install gofumpt in lint-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ lint:
 lint-deps:
 	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1
 	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@v0.3
+	GOBIN=$(shell go env GOPATH)/bin go install mvdan.cc/gofumpt@v0.8.0
 
 tidy:
 	go mod tidy


### PR DESCRIPTION
The linter and real world should be kept in sync. This is destroying my workflow.

---

Install `gofumpt` in the `lint-deps` Make target so that the version of gofumpt on Marco's machine does not get out of sync with the version used by golangci-lint. Slowdown in CI is thankfully minimal because we use golangci-lint directly instead of via Make.