### PR TITLE
tbc: fix miscellaneous typos

### DIFF
--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1471,7 +1471,7 @@ func TestIndexNoFork(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make sure tbc dowloads blocks
+	// make sure tbc downloads blocks
 	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -1674,7 +1674,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make sure tbc dowloads blocks
+	// make sure tbc downloads blocks
 	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -1951,7 +1951,7 @@ func TestIndexFork(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make sure tbc dowloads blocks
+	// make sure tbc downloads blocks
 	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -2005,7 +2005,7 @@ func TestIndexFork(t *testing.T) {
 	// Verify linear indexing. Current TxIndex is sitting at b3
 	t.Logf("b3: %v", b3)
 
-	// b3 -> genesis should work with postive direction (cdiff is greater than target)
+	// b3 -> genesis should work with positive direction (cdiff is greater than target)
 	direction, err = s.TxIndexIsLinear(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("expected success b3 -> genesis, got %v", err)
@@ -2285,7 +2285,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make sure tbc dowloads blocks
+	// make sure tbc downloads blocks
 	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -2376,7 +2376,7 @@ func TestKeystoneIndexFork(t *testing.T) {
 	// Verify linear indexing. Current TxIndex is sitting at b3
 	t.Logf("b3: %v", b3)
 
-	// b3 -> genesis should work with postive direction (cdiff is greater than target)
+	// b3 -> genesis should work with positive direction (cdiff is greater than target)
 	direction, err = s.TxIndexIsLinear(ctx, *s.chainParams.GenesisHash)
 	if err != nil {
 		t.Fatalf("expected success b3 -> genesis, got %v", err)
@@ -2799,7 +2799,7 @@ func TestForkCanonicity(t *testing.T) {
 	}
 	altChainHashes["b3aa"] = b3aa.Hash()
 
-	// make sure tbc dowloads blocks
+	// make sure tbc downloads blocks
 	if err := n.MineAndSendEmpty(ctx); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION


**Description:**  
This pull request corrects minor typos in comments within the test file:
- Replaces "dowloads" with "downloads"
- Replaces "postive" with "positive"

