### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -781,10 +781,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 
 			// we generated 4 blocks to this address previously, therefore
 			// there should be 4 utxos
-			expectedCount := 4 - tti.start
-			if tti.limit < expectedCount {
-				expectedCount = tti.limit
-			}
+			expectedCount := min(tti.limit, 4-tti.start)
 
 			if !tti.doNotGenerate && len(response.UTXOs) != int(expectedCount) {
 				t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.UTXOs))
@@ -993,10 +990,7 @@ func TestUtxosByAddress(t *testing.T) {
 
 			// we generated 4 blocks to this address previously, therefore
 			// there should be 4 utxos
-			expectedCount := 4 - tti.start
-			if tti.limit < expectedCount {
-				expectedCount = tti.limit
-			}
+			expectedCount := min(tti.limit, 4-tti.start)
 
 			if !tti.doNotGenerate && len(response.UTXOs) != int(expectedCount) {
 				t.Fatalf("should have %d utxos, received: %d", expectedCount, len(response.UTXOs))


### PR DESCRIPTION
**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


**Changes**
<!-- A list of changes made by this pull request. -->
