### PR TITLE
level: re-enable db v3 upgrade warning

### DIFF
--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -368,14 +368,14 @@ func (l *ldb) v3(ctx context.Context) error {
 		}
 	}
 
-	//if !l.cfg.nonInteractive {
-	//	log.Infof("This operation will take a long time. " +
-	//		"Press ctrl-c within 30 seconds to abort upgrade!")
-	//	select {
-	//	case <-ctx.Done():
-	//	case <-time.Tick(30 * time.Second):
-	//	}
-	//}
+	if !l.cfg.nonInteractive {
+		log.Infof("This operation will take a long time. " +
+			"Press ctrl-c within 30 seconds to abort upgrade!")
+		select {
+		case <-ctx.Done():
+		case <-time.Tick(30 * time.Second):
+		}
+	}
 
 	// sort database names
 	keys := make([]string, 0, len(l.pool))


### PR DESCRIPTION
**Summary**
When merging the [db v4 PR](https://github.com/hemilabs/heminetwork/pull/539), I thought the commenting out of the warning given to the user prior to a v3 upgrade was done on purpose. It wasn't 🙂

**Changes**
Uncommented the warning.
