### PR TITLE
fix Update bdf.go

### DIFF
--- a/cmd/btctool/bdf/bdf.go
+++ b/cmd/btctool/bdf/bdf.go
@@ -152,16 +152,14 @@ func writeHeight(height int, hash, dir string) error {
 	f, err := os.Open(filename)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			// do nothing
-			defer f.Close()
+			// File does not exist, proceed to create it
 		} else {
 			return fmt.Errorf("open file: %w", err)
 		}
 	} else {
 		defer f.Close()
 		d := json.NewDecoder(f)
-		err = d.Decode(&lh)
-		if err != nil {
+		if err := d.Decode(&lh); err != nil {
 			return fmt.Errorf("%v corrupt: %w", filename, err)
 		}
 	}


### PR DESCRIPTION
This PR refactors the error handling logic in the writeHeight function when opening the height file. Specifically:

Replaces the defer f.Close() in the fs.ErrNotExist case with a cleaner conditional structure: Replaces the defer f.Close() in the fs.ErrNotExist case with a cleaner conditional structure

This avoids unnecessary defer on a potentially nil file handle and improves clarity by explicitly separating the two error cases: "file not found" vs. "other I/O error."

There are no changes to the function’s behavior — it still proceeds to create the height file if it doesn't exist, and returns a wrapped error for all other failure modes.


