### PR TITLE
fix typo in Update blockstream.go

### DIFF
--- a/cmd/btctool/blockstream/blockstream.go
+++ b/cmd/btctool/blockstream/blockstream.go
@@ -54,7 +54,7 @@ func Tip(ctx context.Context) (int, error) {
 	}
 	height, err := strconv.ParseInt(string(b), 10, 0)
 	if err != nil {
-		return 0, fmt.Errorf("parse uint: %w", err)
+		return 0, fmt.Errorf("parse int: %w", err)
 	}
 	if height < 0 {
 		return 0, fmt.Errorf("parse uint: unexpected negative value")


### PR DESCRIPTION
This PR fixes a misleading error message in the Tip() function. The function uses strconv.ParseInt, but the error message previously said "parse uint", which is incorrect and could confuse during debugging.

Updated the error message from "parse uint" to "parse int" in Tip().

