### PR TITLE
cmd/keygen: remove duplicate flag.Parse call

### DIFF
--- a/cmd/keygen/keygen.go
+++ b/cmd/keygen/keygen.go
@@ -106,7 +106,6 @@ func main() {
 		fmt.Printf("v%v\n", version.String())
 		os.Exit(0)
 	}
-	flag.Parse()
 
 	if err := _main(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
This PR makes the following changes and improvements to the keygen command-line tool:

Removed duplicate flag.Parse() call in main()
Calling flag.Parse() more than once can cause a panic in newer Go versions (see flag.Parse() docs). The redundant second call was removed to prevent unexpected behavior.


