### PR TITLE
hproxy: Add hproxy, a much simpler proxyd replacement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ cmds = \
 	bssd	\
 	extool	\
 	hemictl	\
+	hproxyd	\
 	keygen	\
 	popmd	\
 	tbcd

--- a/bitcoin/bitcoin_test.go
+++ b/bitcoin/bitcoin_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/bitcoin/wallet/README.md
+++ b/bitcoin/wallet/README.md
@@ -1,0 +1,29 @@
+# wallet
+
+Wallet is a collection of convenience structures, functions and interfaces that
+can be tied together to create a bitcoin wallet. All wallets have slightly
+different requirements and these packages try to break a wallet down into its
+constituent components.
+
+The components are:
+* gozer - Interface to a bitcoin source of truth.
+* vinzclortho - Package that handles creation and derivation bitcoin addresses.
+* zuul - Package that handles storage of secret material. 
+
+## Canon
+
+Gozer was originally worshiped as a god by the Hittites, Mesopotamians, and the
+Sumerians around 6000 BC. Gozer was genderless and could assume any form it
+wanted. Gozer had two trusted minions – themselves worshiped as demigods – that
+were harbingers of destruction and primary agents for its arrival: Vinz
+Clortho, The Keymaster and Zuul, The Gatekeeper. The Sumerians believed in a
+land of the dead, a dark and shadowy realm within the bowels of the earth where
+the souls of the dead were ruled by Gozer and protected by the Gatekeeper and
+Keymaster. Gozer also consumed the souls of those sacrificed to it. In order
+for Gozer to rise up and walk the human plane again, the Gatekeeper and
+Keymaster had to assume the form of beasts. During the rectification of
+the Vuldronaii, Gozer came as a large moving Torb. Then, during the third
+reconciliation of the last of the Meketrex Supplicants, they chose the form of
+a giant Sloar.
+
+Source https://ghostbusters.fandom.com/wiki/Gozer

--- a/bitcoin/wallet/gozer/blockstream/blockstream.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+// Package blockstream implements [gozer.Gozer] and retrieves Bitcoin data from
+// Blockstream (https://blockstream.info/).
+package blockstream
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+
+	"github.com/hemilabs/heminetwork/api/protocol"
+	"github.com/hemilabs/heminetwork/api/tbcapi"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/gozer"
+	"github.com/hemilabs/heminetwork/cmd/btctool/httpclient"
+)
+
+var (
+	bsMainnetURL  = "https://blockstream.info/api"
+	bsTestne3tURL = "https://blockstream.info/testnet/api"
+)
+
+// blockstreamGozer implements [gozer.Gozer] and retrieves Bitcoin data from
+// Blockstream.
+type blockstreamGozer struct {
+	url string
+}
+
+var _ gozer.Gozer = (*blockstreamGozer)(nil)
+
+// Run returns a new Blockstream Gozer.
+func Run(params *chaincfg.Params) (gozer.Gozer, error) {
+	bs := &blockstreamGozer{}
+	switch params {
+	case &chaincfg.MainNetParams:
+		bs.url = bsMainnetURL
+	case &chaincfg.TestNet3Params:
+		bs.url = bsTestne3tURL
+	default:
+		return nil, errors.New("invalid net")
+	}
+	return bs, nil
+}
+
+func (bs *blockstreamGozer) BtcHeight(ctx context.Context) (uint64, error) {
+	u := fmt.Sprintf("%v/blocks/tip/height", bs.url)
+	rawHeight, err := httpclient.Request(ctx, "GET", u, nil)
+	if err != nil {
+		return 0, fmt.Errorf("request: %w", err)
+	}
+
+	var height uint64
+	err = json.Unmarshal(rawHeight, &height)
+	if err != nil {
+		return 0, err
+	}
+
+	return height, nil
+}
+
+func (bs *blockstreamGozer) FeeEstimates(ctx context.Context) ([]*tbcapi.FeeEstimate, error) {
+	u := fmt.Sprintf("%v/fee-estimates", bs.url)
+	feeEstimates, err := httpclient.Request(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+
+	fm := make(map[uint]float64, len(u))
+	err = json.Unmarshal(feeEstimates, &fm)
+	if err != nil {
+		return nil, err
+	}
+
+	frv := make([]*tbcapi.FeeEstimate, 0, len(fm))
+	for k, v := range fm {
+		frv = append(frv, &tbcapi.FeeEstimate{Blocks: k, SatsPerByte: v})
+	}
+
+	return frv, nil
+}
+
+func (bs *blockstreamGozer) BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.Hash, error) {
+	u := fmt.Sprintf("%v/tx", bs.url)
+
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		return nil, err
+	}
+	hexTx := hex.EncodeToString(buf.Bytes())
+
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u,
+		strings.NewReader(hexTx))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request: %v %v",
+			resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	respb, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	txidBytes, err := hex.DecodeString(string(respb))
+	if err != nil {
+		return nil, err
+	}
+	slices.Reverse(txidBytes)
+
+	txidHash, err := chainhash.NewHash(txidBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return txidHash, nil
+}
+
+func (bs *blockstreamGozer) UtxosByAddress(ctx context.Context, filterMempool bool, addr btcutil.Address, start, count uint) ([]*tbcapi.UTXO, error) {
+	u := fmt.Sprintf("%v/address/%v/utxo", bs.url, addr)
+	utxos, err := httpclient.Request(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+
+	// XXX figure out if we need to set ot do something with filterMempool here
+	type statusJSON struct {
+		Confirmed   bool           `json:"confirmed"`
+		BlockHeight uint64         `json:"block_height"`
+		BlockHash   chainhash.Hash `json:"block_hash"`
+		BlockTime   int64          `json:"block_time"`
+	}
+	type utxosJSON struct {
+		TxId   chainhash.Hash `json:"txid"`
+		Vout   uint32         `json:"vout"`
+		Value  btcutil.Amount `json:"value"`
+		Status statusJSON     `json:"status"`
+	}
+	var uj []utxosJSON
+	err = json.Unmarshal(utxos, &uj)
+	if err != nil {
+		return nil, err
+	}
+
+	urv := make([]*tbcapi.UTXO, 0, len(uj))
+	for _, v := range uj {
+		if !v.Status.Confirmed {
+			continue
+		}
+		urv = append(urv, &tbcapi.UTXO{
+			TxId:     v.TxId,
+			OutIndex: v.Vout,
+			Value:    v.Value,
+		})
+	}
+	return urv, nil
+}
+
+func (bs *blockstreamGozer) BlocksByL2AbrevHashes(ctx context.Context, hashes []chainhash.Hash) *gozer.BlocksByL2AbrevHashesResponse {
+	return &gozer.BlocksByL2AbrevHashesResponse{
+		Error: protocol.Errorf("not supported yet"),
+	}
+}
+
+func (bs *blockstreamGozer) KeystonesByHeight(ctx context.Context, height uint32, depth int) (*gozer.KeystonesByHeightResponse, error) {
+	err := errors.New("not supported yet")
+	return &gozer.KeystonesByHeightResponse{
+		Error: protocol.Errorf("%v", err),
+	}, err
+}

--- a/bitcoin/wallet/gozer/blockstream/blockstream_test.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package blockstream
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/gozer"
+)
+
+func mockHttpServer() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/address/") && strings.HasSuffix(r.URL.Path, "/utxo"):
+			utxos := []map[string]interface{}{
+				{
+					"txid":  chainhash.Hash{},
+					"vout":  1,
+					"value": 100000000,
+					"status": map[string]interface{}{
+						"confirmed":    true,
+						"block_height": 1,
+						"block_hash":   chainhash.Hash{},
+						"block_time":   1,
+					},
+				},
+			}
+			resp, err := json.Marshal(utxos)
+			if err != nil {
+				http.NotFound(w, r)
+				break
+			}
+			w.WriteHeader(http.StatusOK)
+			if _, err = w.Write(resp); err != nil {
+				panic(err)
+			}
+		case r.URL.Path == "/fee-estimates":
+			response := []byte(`{"1":1.0,"2":1.0,"3":1.0,"4":1.0,"5":1.0,"6":1.0}`)
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write(response); err != nil {
+				panic(err)
+			}
+		case r.URL.Path == "/blocks/tip/height":
+			response := []byte(`1000`)
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write(response); err != nil {
+				panic(err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return ts
+}
+
+func TestBlockstreamGozer(t *testing.T) {
+	testAddrString := "n2BosBT7DvxWk1tZprk1tR1kyQmXwcv8M8"
+
+	testAddr, err := btcutil.DecodeAddress(testAddrString, &chaincfg.TestNet3Params)
+	if err != nil {
+		t.Fatalf("Failed to decode address: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	// use mock http server rather than blockstream api
+	ts := mockHttpServer()
+	defer ts.Close()
+
+	// can't use Run() for custom urls
+	b := &blockstreamGozer{}
+	b.url = ts.URL
+
+	feeEstimates, err := b.FeeEstimates(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feeEstimate, err := gozer.FeeByConfirmations(6, feeEstimates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(feeEstimate))
+
+	// XXX antonio, is true correct here
+	utxos, err := b.UtxosByAddress(ctx, true, testAddr, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("balance %v: %v", testAddr, gozer.BalanceFromUtxos(utxos))
+
+	height, err := b.BtcHeight(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("BTC tip height: %v", height)
+}

--- a/bitcoin/wallet/gozer/gozer.go
+++ b/bitcoin/wallet/gozer/gozer.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+// Package gozer provides an interface for accessing Bitcoin data.
+//
+// Gozer was originally worshiped as a god by the Hittites, Mesopotamians, and
+// the Sumerians around 6000 BC. Gozer was genderless and could assume any form
+// it wanted.
+package gozer
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+
+	"github.com/hemilabs/heminetwork/api"
+	"github.com/hemilabs/heminetwork/api/protocol"
+	"github.com/hemilabs/heminetwork/api/tbcapi"
+	"github.com/hemilabs/heminetwork/hemi"
+)
+
+// Gozer is an interface providing access to Bitcoin data.
+type Gozer interface {
+	FeeEstimates(ctx context.Context) ([]*tbcapi.FeeEstimate, error)
+	UtxosByAddress(ctx context.Context, filterMempool bool, addr btcutil.Address, start, count uint) ([]*tbcapi.UTXO, error)
+	BlocksByL2AbrevHashes(ctx context.Context, hashes []chainhash.Hash) *BlocksByL2AbrevHashesResponse
+	KeystonesByHeight(ctx context.Context, height uint32, depth int) (*KeystonesByHeightResponse, error)
+	BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.Hash, error)
+	BtcHeight(ctx context.Context) (uint64, error)
+}
+
+// FeeByConfirmations picks a suitable fee by matching the exact number of
+// blocks provided by the caller.
+func FeeByConfirmations(blocks uint, feeEstimates []*tbcapi.FeeEstimate) (*tbcapi.FeeEstimate, error) {
+	if len(feeEstimates) == 0 {
+		return nil, errors.New("no estimates")
+	}
+
+	// We should probably add a variance check but for now be exact.
+	for _, v := range feeEstimates {
+		if v.Blocks == blocks {
+			return v, nil
+		}
+	}
+
+	return nil, errors.New("no suitable fee estimate")
+}
+
+// BalanceFromUtxos returns the total amount of the provided utxos.
+func BalanceFromUtxos(utxos []*tbcapi.UTXO) btcutil.Amount {
+	var amount btcutil.Amount
+	for k := range utxos {
+		amount += utxos[k].Value
+	}
+	return amount
+}
+
+// L2KeystoneAbrev is the abbreviated format of an L2Keystone. It simply clips
+// various hashes to a shorter version.
+type L2KeystoneAbrev struct {
+	Version            uint          `json:"version"`
+	L1BlockNumber      uint          `json:"l1_block_number"`
+	L2BlockNumber      uint          `json:"l2_block_number"`
+	ParentEPHash       api.ByteSlice `json:"parent_ep_hash"`
+	PrevKeystoneEPHash api.ByteSlice `json:"prev_keystone_ep_hash"`
+	StateRoot          api.ByteSlice `json:"state_root"`
+	EPHash             api.ByteSlice `json:"ep_hash"`
+}
+
+func (a *L2KeystoneAbrev) Serialize() [72]byte {
+	var r [72]byte
+	r[0] = uint8(a.Version)
+	binary.BigEndian.PutUint32(r[1:5], uint32(a.L1BlockNumber))
+	binary.BigEndian.PutUint32(r[5:9], uint32(a.L2BlockNumber))
+	copy(r[9:], a.ParentEPHash[:])
+	copy(r[20:], a.PrevKeystoneEPHash[:])
+	copy(r[32:], a.StateRoot[:])
+	copy(r[64:], a.EPHash[:])
+	return r
+}
+
+func TBC2Gozer(req *tbcapi.BlocksByL2AbrevHashesResponse) *BlocksByL2AbrevHashesResponse {
+	blkInfos := make([]L2KeystoneBlockInfo, 0, len(req.L2KeystoneBlocks))
+	for _, info := range req.L2KeystoneBlocks {
+		var gi L2KeystoneBlockInfo
+		if info.Error != nil {
+			gi.Error = info.Error
+		} else {
+			gi = L2KeystoneBlockInfo{
+				L2KeystoneAbrev: L2KeystoneAbrev{
+					Version:            uint(info.L2KeystoneAbrev.Version),
+					L1BlockNumber:      uint(info.L2KeystoneAbrev.L1BlockNumber),
+					L2BlockNumber:      uint(info.L2KeystoneAbrev.L2BlockNumber),
+					ParentEPHash:       info.L2KeystoneAbrev.ParentEPHash[:],
+					PrevKeystoneEPHash: info.L2KeystoneAbrev.PrevKeystoneEPHash[:],
+					StateRoot:          info.L2KeystoneAbrev.StateRoot[:],
+					EPHash:             info.L2KeystoneAbrev.EPHash[:],
+				},
+				L2KeystoneBlockHash:   *info.L2KeystoneBlockHash,
+				L2KeystoneBlockHeight: info.L2KeystoneBlockHeight,
+			}
+		}
+		blkInfos = append(blkInfos, gi)
+	}
+	r := &BlocksByL2AbrevHashesResponse{
+		L2KeystoneBlocks:  blkInfos,
+		BtcTipBlockHash:   *req.BtcTipBlockHash,
+		BtcTipBlockHeight: req.BtcTipBlockHeight,
+	}
+
+	return r
+}
+
+type L2KeystoneBlockInfo struct {
+	L2KeystoneAbrev       L2KeystoneAbrev `json:"l2_keystone_abrev"`
+	L2KeystoneBlockHash   chainhash.Hash  `json:"l2_keystone_block_hash"`
+	L2KeystoneBlockHeight uint            `json:"l2_keystone_block_height"`
+	Error                 *protocol.Error `json:"error,omitempty"`
+}
+
+// BlocksByL2AbrevHashesResponse JSON response to keystone
+// finality route. Note that if the keystone exists that, by definition, the
+// keystone lives on the canonical chain. This is why we can return the best
+// tip height and hash.
+type BlocksByL2AbrevHashesResponse struct {
+	L2KeystoneBlocks  []L2KeystoneBlockInfo `json:"l2_keystone_blocks"`
+	BtcTipBlockHash   chainhash.Hash        `json:"btc_tip_block_hash"`
+	BtcTipBlockHeight uint                  `json:"btc_tip_block_height"`
+	Error             *protocol.Error       `json:"error,omitempty"`
+}
+
+type KeystonesByHeightResponse struct {
+	L2KeystoneAbrevs []*hemi.L2KeystoneAbrev `json:"l2_keystone_abrevs"`
+	BTCTipHeight     uint64                  `json:"btc_tip_height"`
+	Error            *protocol.Error         `json:"error,omitempty"`
+}

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+// Package tbcgozer provides an implementation of [gozer.Gozer] which receives
+// Bitcoin data from a TBC server over RPC.
+package tbcgozer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/juju/loggo"
+
+	"github.com/hemilabs/heminetwork/api/protocol"
+	"github.com/hemilabs/heminetwork/api/tbcapi"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/gozer"
+)
+
+const (
+	logLevel              = "tbcgozer=INFO"
+	defaultRequestTimeout = 10 * time.Second
+
+	DefaultURL = "ws://localhost:8082/v1/ws"
+)
+
+var log = loggo.GetLogger("tbcgozer")
+
+func init() {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
+		panic(err)
+	}
+}
+
+// tbcCmd wraps tbc commands.
+type tbcCmd struct {
+	msg any
+	ch  chan any
+}
+
+// tbcGozer implements [gozer.Gozer] and retrieves Bitcoin data from a TBC
+// server over RPC.
+type tbcGozer struct {
+	mtx       sync.Mutex
+	wg        sync.WaitGroup
+	url       string
+	cmdCh     chan tbcCmd // commands to send to tbc
+	connected bool
+}
+
+var _ gozer.Gozer = (*tbcGozer)(nil)
+
+// Run returns and starts a new TBC Gozer.
+func Run(ctx context.Context, tbcUrl string) (gozer.Gozer, error) {
+	t := &tbcGozer{
+		url:   tbcUrl,
+		cmdCh: make(chan tbcCmd, 10),
+	}
+
+	go t.run(ctx)
+
+	return t, nil
+}
+
+func (t *tbcGozer) Connected() bool {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	return t.connected
+}
+
+func (t *tbcGozer) BtcHeight(ctx context.Context) (uint64, error) {
+	bur := &tbcapi.BlockHeaderBestRequest{}
+
+	res, err := t.callTBC(ctx, defaultRequestTimeout, bur)
+	if err != nil {
+		return 0, err
+	}
+
+	buResp, ok := res.(*tbcapi.BlockHeaderBestResponse)
+	if !ok {
+		return 0, fmt.Errorf("not a fee estimate response %T", res)
+	}
+
+	if buResp.Error != nil {
+		return 0, buResp.Error
+	}
+
+	return buResp.Height, nil
+}
+
+func (t *tbcGozer) FeeEstimates(ctx context.Context) ([]*tbcapi.FeeEstimate, error) {
+	bur := &tbcapi.FeeEstimateRequest{}
+
+	res, err := t.callTBC(ctx, defaultRequestTimeout, bur)
+	if err != nil {
+		return nil, err
+	}
+
+	buResp, ok := res.(*tbcapi.FeeEstimateResponse)
+	if !ok {
+		return nil, fmt.Errorf("not a fee estimate response %T", res)
+	}
+
+	if buResp.Error != nil {
+		return nil, buResp.Error
+	}
+
+	return buResp.FeeEstimates, nil
+}
+
+func (t *tbcGozer) BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.Hash, error) {
+	bur := &tbcapi.TxBroadcastRequest{
+		Tx:    tx,
+		Force: false, // XXX allow this to be passed in some way
+	}
+
+	res, err := t.callTBC(ctx, defaultRequestTimeout, bur)
+	if err != nil {
+		return nil, err
+	}
+
+	buResp, ok := res.(*tbcapi.TxBroadcastResponse)
+	if !ok {
+		return nil, fmt.Errorf("not a broadcast response %T", res)
+	}
+
+	if buResp.Error != nil {
+		return nil, buResp.Error
+	}
+
+	return buResp.TxID, nil
+}
+
+func (t *tbcGozer) UtxosByAddress(ctx context.Context, filterMempool bool, addr btcutil.Address, start, count uint) ([]*tbcapi.UTXO, error) {
+	maxCount := uint(1000)
+	if count > maxCount {
+		return nil, fmt.Errorf("count must not exceed %v", maxCount)
+	}
+
+	bur := &tbcapi.UTXOsByAddressRequest{
+		FilterMempool: filterMempool,
+		Address:       addr.String(),
+		Start:         start,
+		Count:         count,
+	}
+
+	res, err := t.callTBC(ctx, defaultRequestTimeout, bur)
+	if err != nil {
+		return nil, err
+	}
+
+	buResp, ok := res.(*tbcapi.UTXOsByAddressResponse)
+	if !ok {
+		return nil, fmt.Errorf("not a utxos by address respose %T", res)
+	}
+
+	if buResp.Error != nil {
+		return nil, buResp.Error
+	}
+
+	return buResp.UTXOs, nil
+}
+
+func (t *tbcGozer) BlocksByL2AbrevHashes(ctx context.Context, hashes []chainhash.Hash) *gozer.BlocksByL2AbrevHashesResponse {
+	ksr := &tbcapi.BlocksByL2AbrevHashesRequest{
+		L2KeystoneAbrevHashes: hashes,
+	}
+
+	res, err := t.callTBC(ctx, defaultRequestTimeout, ksr)
+	if err != nil {
+		r := &gozer.BlocksByL2AbrevHashesResponse{
+			Error: protocol.Errorf("%v", err),
+		}
+		return r
+	}
+
+	bksr, ok := res.(*tbcapi.BlocksByL2AbrevHashesResponse)
+	if !ok {
+		r := &gozer.BlocksByL2AbrevHashesResponse{
+			Error: protocol.Errorf("not a keystone response %T", res),
+		}
+		return r
+	}
+	if bksr.Error != nil {
+		r := &gozer.BlocksByL2AbrevHashesResponse{
+			Error: bksr.Error,
+		}
+		return r
+	}
+	return gozer.TBC2Gozer(bksr)
+}
+
+func (t *tbcGozer) KeystonesByHeight(ctx context.Context, height uint32, depth int) (*gozer.KeystonesByHeightResponse, error) {
+	ksr := &tbcapi.KeystonesByHeightRequest{
+		Height: height,
+		Depth:  depth,
+	}
+
+	res, err := t.callTBC(ctx, defaultRequestTimeout, ksr)
+	if err != nil {
+		r := &gozer.KeystonesByHeightResponse{
+			Error: protocol.Errorf("%v", err),
+		}
+		return r, err
+	}
+
+	bksr, ok := res.(*tbcapi.KeystonesByHeightResponse)
+	if !ok {
+		err = fmt.Errorf("not a keystone by height response %T", res)
+		r := &gozer.KeystonesByHeightResponse{
+			Error: protocol.Errorf("%v", err),
+		}
+		return r, err
+	}
+	//nolint:nilerr // only return internal error
+	if bksr.Error != nil {
+		r := &gozer.KeystonesByHeightResponse{
+			Error: bksr.Error,
+		}
+		return r, nil
+	}
+
+	r := &gozer.KeystonesByHeightResponse{
+		L2KeystoneAbrevs: bksr.L2KeystoneAbrevs,
+		BTCTipHeight:     bksr.BTCTipHeight,
+	}
+	return r, nil
+}
+
+func (t *tbcGozer) callTBC(pctx context.Context, timeout time.Duration, msg any) (any, error) {
+	log.Tracef("callTBC %T", msg)
+	defer log.Tracef("callTBC exit %T", msg)
+
+	if !t.Connected() {
+		return nil, errors.New("not connected to tbc")
+	}
+
+	bc := tbcCmd{
+		msg: msg,
+		ch:  make(chan any),
+	}
+
+	ctx, cancel := context.WithTimeout(pctx, timeout)
+	defer cancel()
+
+	// attempt to send
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case t.cmdCh <- bc:
+	default:
+		return nil, errors.New("tbc command queue full")
+	}
+
+	// Wait for response
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case payload := <-bc.ch:
+		if err, ok := payload.(error); ok {
+			return nil, err
+		}
+		return payload, nil
+	}
+
+	// Won't get here
+}
+
+func (t *tbcGozer) handleTBCWebsocketCall(ctx context.Context, conn *protocol.Conn) {
+	defer t.wg.Done()
+
+	log.Tracef("handleTBCWebsocketCall")
+	defer log.Tracef("handleTBCWebsocketCall exit")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case bc := <-t.cmdCh:
+			_, _, payload, err := tbcapi.Call(ctx, conn, bc.msg)
+			if err != nil {
+				log.Errorf("handleTBCWebsocketCall %T: %v", bc.msg, err)
+				select {
+				case bc.ch <- err:
+				default:
+				}
+			}
+			select {
+			case bc.ch <- payload:
+				log.Tracef("handleTBCWebsocketCall returned: %v", spew.Sdump(payload))
+			default:
+			}
+		}
+	}
+}
+
+func (t *tbcGozer) handleTBCWebsocketRead(ctx context.Context, conn *protocol.Conn) {
+	defer t.wg.Done()
+
+	log.Tracef("handleTBCWebsocketRead")
+	defer log.Tracef("handleTBCWebsocketRead exit")
+	pcc := conn.ConnectCount()
+	for {
+		_, _, _, err := tbcapi.ReadConn(ctx, conn)
+		if err != nil {
+			// See if we were terminated
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
+
+			cc := conn.ConnectCount()
+			if pcc == cc {
+				log.Infof("Connection with TBC server was lost, reconnecting...")
+				pcc++
+			}
+			continue
+		}
+	}
+}
+
+func (t *tbcGozer) connectTBC(pctx context.Context) error {
+	log.Tracef("connectTBC")
+	defer log.Tracef("connectTBC exit")
+
+	conn, err := protocol.NewConn(t.url, &protocol.ConnOptions{
+		ReadLimit: 6 * (1 << 20), // 6 MiB
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(pctx)
+	defer cancel()
+
+	// TODO: implement exponential backoff retry
+	if err = conn.Connect(ctx); err != nil {
+		return err
+	}
+
+	t.mtx.Lock()
+	t.connected = true
+	t.mtx.Unlock()
+	defer func() {
+		t.mtx.Lock()
+		t.connected = false
+		t.mtx.Unlock()
+	}()
+
+	t.wg.Add(1)
+	go t.handleTBCWebsocketRead(ctx, conn)
+
+	t.wg.Add(1)
+	go t.handleTBCWebsocketCall(ctx, conn)
+
+	log.Debugf("Connected to tbc: %s", t.url)
+
+	// Wait for exit
+	t.wg.Wait()
+
+	return nil
+}
+
+func (t *tbcGozer) run(ctx context.Context) {
+	for {
+		if err := t.connectTBC(ctx); err != nil {
+			log.Errorf("Failed to connect to TBC: %v", err)
+		}
+		// See if we were terminated
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+
+		log.Debugf("Reconnecting to: %v", t.url)
+	}
+}

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package tbcgozer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/juju/loggo"
+
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/gozer"
+	"github.com/hemilabs/heminetwork/service/tbc"
+)
+
+func TestTBCGozer(t *testing.T) {
+	testAddrString := "n2BosBT7DvxWk1tZprk1tR1kyQmXwcv8M8"
+
+	testAddr, err := btcutil.DecodeAddress(testAddrString, &chaincfg.TestNet3Params)
+	if err != nil {
+		t.Fatalf("Failed to decode address: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Connect tbc service
+	tbcCfg := &tbc.Config{
+		AutoIndex:            false,
+		BlockCacheSize:       "10mb",
+		BlockheaderCacheSize: "1mb",
+		BlockSanity:          false,
+		LevelDBHome:          t.TempDir(),
+		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
+		MaxCachedTxs:            1000, // XXX
+		Network:                 "localnet",
+		PrometheusListenAddress: "",
+		MempoolEnabled:          true,
+		Seeds:                   []string{"127.0.0.1:18444"},
+		ListenAddress:           "localhost:8881",
+	}
+	_ = loggo.ConfigureLoggers(tbcCfg.LogLevel)
+	s, err := tbc.NewServer(tbcCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	time.Sleep(1 * time.Second)
+
+	b, err := Run(ctx, "http://localhost:8881/v1/ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	feeEstimates, err := b.FeeEstimates(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	feeEstimate, err := gozer.FeeByConfirmations(6, feeEstimates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(feeEstimate))
+
+	utxos, err := b.UtxosByAddress(ctx, true, testAddr, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("balance %v: %v", testAddr, gozer.BalanceFromUtxos(utxos))
+
+	height, err := b.BtcHeight(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("BTC tip height: %v", height)
+}

--- a/bitcoin/wallet/vinzclortho/vinzclortho.go
+++ b/bitcoin/wallet/vinzclortho/vinzclortho.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+// Package vinzclortho handles creation and deriviation of Bitcoin addresses.
+//
+// Vinz Clortho, a minion of the god known as Gozer, was worshiped as a demigod
+// by the Sumerians, Mesopotamians and Hittites in 6000 BC.
+package vinzclortho
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// VinzClortho is a wallet implementation that handles the creation and
+// derivation of Bitcoin addresses.
+type VinzClortho struct {
+	mtx sync.Mutex
+
+	params *chaincfg.Params
+
+	// secret information
+	master *hdkeychain.ExtendedKey
+}
+
+// New returns a new VinzClortho with the given chain params.
+func New(params *chaincfg.Params) (*VinzClortho, error) {
+	vc := &VinzClortho{
+		params: params,
+	}
+	return vc, nil
+}
+
+// Lock locks the wallet.
+func (vc *VinzClortho) Lock() error {
+	if vc.master == nil {
+		return errors.New("wallet already locked")
+	}
+
+	vc.mtx.Lock()
+	vc.master.Zero()
+	vc.master = nil
+	vc.mtx.Unlock()
+
+	return nil
+}
+
+// Unlock unlocks the wallet by deriving a seed from the provided secret.
+// Supports xprv, hex encoded seed and mnemonic.
+func (vc *VinzClortho) Unlock(secret string) error {
+	vc.mtx.Lock()
+	defer vc.mtx.Unlock()
+	if vc.master != nil {
+		return fmt.Errorf("wallet already unlocked")
+	}
+
+	switch {
+	case strings.HasPrefix(secret, "0x"):
+		secret = secret[2:]
+	case strings.HasPrefix(secret, "xpub"):
+		return fmt.Errorf("not an extended private key")
+	case strings.HasPrefix(secret, "xprv"):
+		var err error
+		vc.master, err = hdkeychain.NewKeyFromString(secret)
+		if err != nil {
+			return fmt.Errorf("new master key: %w", err)
+		}
+		return nil
+	}
+
+	// try hex first, if this works it's a seed
+	seed, err := hex.DecodeString(secret)
+	if err == nil {
+		// we got a seed
+		vc.master, err = hdkeychain.NewMaster(seed, vc.params)
+		if err != nil {
+			return fmt.Errorf("new master key: %w", err)
+		}
+		return nil
+	}
+
+	// try mnemonic
+	seed, err = bip39.NewSeedWithErrorChecking(secret, "")
+	if err == nil {
+		// we got a seed
+		vc.master, err = hdkeychain.NewMaster(seed, vc.params)
+		if err != nil {
+			return fmt.Errorf("new master key: %w", err)
+		}
+		return nil
+	}
+
+	return err
+}
+
+// derive derives the public extended key and address from the account and
+// child using BIP32 derivation. When offset is greater or equal to
+// hdkeychain.HardenedKeyStart it returns a hardened address.
+//
+// Hardened addresses require the private key to derive public keys whereas a
+// regular address can derive public keys without.
+//
+// This function uses the same paths as used in Bitcoin core and Electrum.
+func (vc *VinzClortho) derive(account, child, offset uint32) (*hdkeychain.ExtendedKey, error) {
+	if vc.master == nil {
+		return nil, errors.New("wallet locked")
+	}
+
+	// Derive child key for (hardened) account.
+	// E.g. hardened account 0: m/0'
+	acct, err := vc.master.Derive(offset + account)
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive child key for external (hardened) account.
+	// E.g. hardened account 0 external 0 -> m/0'/0'
+	ek, err := acct.Derive(offset + child)
+	if err != nil {
+		return nil, err
+	}
+
+	return ek, nil
+}
+
+// DeriveHD derives a hardened extended public key and address.
+// E.g. account 1 child 4 m/1'/4'
+func (vc *VinzClortho) DeriveHD(account, child uint32) (*hdkeychain.ExtendedKey, error) {
+	return vc.derive(account, child, hdkeychain.HardenedKeyStart)
+}
+
+// Derive derives an extended public key and address.
+// E.g. account 0 child 1 m/0/1
+func (vc *VinzClortho) Derive(account, child uint32) (*hdkeychain.ExtendedKey, error) {
+	return vc.derive(account, child, 0)
+}
+
+// AddressAndPublicFromExtended returns the public bits from a private extended
+// key.
+func AddressAndPublicFromExtended(params *chaincfg.Params, ek *hdkeychain.ExtendedKey) (btcutil.Address, *hdkeychain.ExtendedKey, error) {
+	// Generate address
+	addr, err := ek.Address(params)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Generate pubkey
+	pub, err := ek.Neuter()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return addr, pub, nil
+}
+
+// Compressed converts an extended key to the compressed public key representation.
+func Compressed(pub *hdkeychain.ExtendedKey) ([]byte, error) {
+	ecpub, err := pub.ECPubKey()
+	if err != nil {
+		return nil, err
+	}
+	return ecpub.SerializeCompressed(), nil
+}
+
+// ScriptFromPubKeyHash creates a spend script for the specified address.
+func ScriptFromPubKeyHash(pkh btcutil.Address) ([]byte, error) {
+	payToScript, err := txscript.PayToAddrScript(pkh)
+	if err != nil {
+		return nil, err
+	}
+	return payToScript, nil
+}
+
+// ScriptHashFromScript returns the script hash of the provided script. Note
+// that this is a simple sha256 wrapped in a chainhash.Hash.
+func ScriptHashFromScript(pkscript []byte) chainhash.Hash {
+	return chainhash.Hash(sha256.Sum256(pkscript))
+}

--- a/bitcoin/wallet/vinzclortho/vinzclortho_test.go
+++ b/bitcoin/wallet/vinzclortho/vinzclortho_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package vinzclortho
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/tyler-smith/go-bip39"
+)
+
+func TestEntropyMnemonicSeed(t *testing.T) {
+	// Do the whole rigamarole of Entropy -> Mnemonic -> Seed
+	entropy, err := bip39.NewEntropy(128) // 128 bits of entropy
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(entropy))
+
+	mnemonic, err := bip39.NewMnemonic(entropy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(mnemonic))
+
+	entropyX, err := bip39.EntropyFromMnemonic(mnemonic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(entropyX))
+
+	if !bytes.Equal(entropy, entropyX) {
+		t.Fatal("entropy not equal")
+	}
+
+	// The following is educational only on how to get to a master key.
+	seed, err := bip39.NewSeedWithErrorChecking(mnemonic, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(seed))
+
+	seed2 := bip39.NewSeed(mnemonic, "")
+	t.Log(spew.Sdump(seed2))
+	if !bytes.Equal(seed, seed2) {
+		t.Fatal("seeds not equal")
+	}
+
+	mk, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(mk)) // check on https://iancoleman.io/bip39
+}
+
+func TestDeriveAddresses(t *testing.T) {
+	// Test vectors generated on https://iancoleman.io/bip39 using bip32
+	mnemonic := "dinosaur banner version pistol need area dream champion kiss thank business shrug explain intact puzzle"
+
+	seed, err := bip39.NewSeedWithErrorChecking(mnemonic, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mk, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(mk)) // check on https://iancoleman.io/bip39
+
+	// Derive extended key for hardened account 0: m/0'
+	acct0, err := mk.Derive(hdkeychain.HardenedKeyStart + 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(acct0))
+
+	// Derive extended key for external hardened account 0 m/0'/0'
+	acct0eh, err := acct0.Derive(hdkeychain.HardenedKeyStart + 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(acct0eh))
+	pkHHash, err := acct0eh.Address(&chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(pkHHash))
+	if pkHHash.String() != "14fjqmZJU7qrRtWHgVjh6jcoKjqu6y1gyM" {
+		t.Fatal("invalid hardned address")
+	}
+
+	// Derive extended key for external account 0 m/0'/0
+	acct0e, err := acct0.Derive(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(acct0e))
+	pkHash, err := acct0e.Address(&chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(pkHash))
+	if pkHash.String() != "1KWtnYZmQwnwCdGNwjbzpvh3YibNV6KWb9" {
+		t.Fatal("invalid address")
+	}
+}
+
+func TestVinzClorthoCreate(t *testing.T) {
+	mnemonic := "dinosaur banner version pistol need area dream champion kiss thank business shrug explain intact puzzle"
+	seed := "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634cb0602599b867332dfec245547baafae40dad247f21564a0de925527f2445a086fd"
+	xpriv := "xprv9s21ZrQH143K4H14eaYTxfuxn6eDqoPhuQx2sRr9ZvmvkBQ39KMHfaNQ9GDdUkgRbibGXu66XQTZj9QJRSXBEibqrHb34BdJRPvqqiZMTCA"
+	expectedAddress := "14fjqmZJU7qrRtWHgVjh6jcoKjqu6y1gyM"
+	expectedPub, _ := hex.DecodeString("02dc2f5439d4e4e1d7da99daa5707d7d7da72caf4e31c5aa206322e00bc1f2ce8c")
+
+	vc, err := New(&chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range []string{mnemonic, seed, "0x" + seed, xpriv} {
+		t.Logf("using secret: %v", v)
+		err = vc.Unlock(v)
+		if err != nil {
+			t.Fatalf("failed %v: %v", k, err)
+		}
+
+		ek, err := vc.DeriveHD(0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr, pub, err := AddressAndPublicFromExtended(&chaincfg.MainNetParams, ek)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if addr.String() != expectedAddress {
+			t.Fatal("invalid hardened address")
+		}
+		expub, err := Compressed(pub)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(expub, expectedPub) {
+			t.Fatal("invalid hardened compressed public key")
+		}
+		err = vc.Lock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// use a pub key to test negative path
+	failpub := "xpub68GbL9kRsJSW9YgqXTnAy1JsiCjZEwbecAx1dcNhxdypbFmsDP7NviUgvWmX7ighnsTe9eLJQHDcnoGQUtVKViSnAKzxQ2DHC6QeNbYiztE"
+	err = vc.Unlock(failpub)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/bitcoin/wallet/wallet.go
+++ b/bitcoin/wallet/wallet.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/mempool"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/txsizes"
+
+	"github.com/hemilabs/heminetwork/api/tbcapi"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/gozer"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/zuul"
+	"github.com/hemilabs/heminetwork/hemi"
+	"github.com/hemilabs/heminetwork/hemi/pop"
+)
+
+// UtxoPickerMultiple is a simple utxo picker that returns a random set of utxos from
+// the provided list that combined have a larger value than amount + fee.
+func UtxoPickerMultiple(amount, fee btcutil.Amount, utxos []*tbcapi.UTXO) ([]*tbcapi.UTXO, error) {
+	finalUTXO := make([]*tbcapi.UTXO, 0, len(utxos))
+
+	// find large enough utxo
+	total := amount + fee
+	for k := range utxos {
+		finalUTXO = append(finalUTXO, utxos[k])
+		total -= utxos[k].Value
+		if total > 0 {
+			continue
+		}
+
+		return finalUTXO, nil
+	}
+
+	return nil, errors.New("no suitable utxos found")
+}
+
+// UtxoPickerSingle is a simple utxo picker that returns a random utxo from the
+// provided list that has a larger value than amount + fee.
+func UtxoPickerSingle(amount, fee btcutil.Amount, utxos []*tbcapi.UTXO) (*tbcapi.UTXO, error) {
+	// find large enough utxo
+	total := amount + fee
+	for k := range utxos {
+		if utxos[k].Value < total {
+			continue
+		}
+		return utxos[k], nil
+	}
+
+	return nil, errors.New("no suitable utxo found")
+}
+
+func TransactionCreate(locktime uint32, amount, satsPerByte btcutil.Amount, address btcutil.Address, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, map[string][]byte, error) {
+	// Create TxOut
+	payToScript, err := txscript.PayToAddrScript(address)
+	if err != nil {
+		return nil, nil, err
+	}
+	txOut := wire.NewTxOut(int64(amount), payToScript)
+	if mempool.IsDust(txOut, mempool.DefaultMinRelayTxFee) {
+		return nil, nil, errors.New("amount is dust")
+	}
+
+	// Calculate fee for worst case input number and assume there is change
+	txSize := txsizes.EstimateSerializeSize(len(utxos), []*wire.TxOut{txOut}, true)
+	fee := btcutil.Amount(txSize) * satsPerByte
+
+	// Find utxo list that is big enough for entire transaction
+	utxoList, err := UtxoPickerMultiple(amount, fee, utxos)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Calculate fee for real input number and assume there is change
+	txSize = txsizes.EstimateSerializeSize(len(utxoList), []*wire.TxOut{txOut}, true)
+	fee = btcutil.Amount(txSize) * satsPerByte
+
+	// Assemble transaction
+	tx := wire.NewMsgTx(2) // Latest supported version
+	tx.LockTime = locktime
+	prevOuts := make(map[string][]byte, len(utxoList))
+	for _, utxo := range utxoList {
+		outpoint := wire.NewOutPoint(&utxo.TxId, utxo.OutIndex)
+		tx.AddTxIn(wire.NewTxIn(outpoint, script, nil))
+		prevOuts[outpoint.String()] = script
+	}
+
+	// Change
+	change := gozer.BalanceFromUtxos(utxoList) - (fee + amount)
+	changeTxOut := wire.NewTxOut(int64(change), script)
+	if !mempool.IsDust(changeTxOut, mempool.DefaultMinRelayTxFee) {
+		tx.AddTxOut(changeTxOut)
+	}
+
+	tx.AddTxOut(txOut)
+
+	return tx, prevOuts, nil
+}
+
+func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerByte btcutil.Amount, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, map[string][]byte, error) {
+	// Create OP_RETURN
+	aks := hemi.L2KeystoneAbbreviate(*l2keystone)
+	popTx := pop.TransactionL2{L2Keystone: aks}
+	popTxOpReturn, err := popTx.EncodeToOpReturn()
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode pop transaction: %w", err)
+	}
+	popTxOut := wire.NewTxOut(0, popTxOpReturn)
+
+	// Calculate fee for 1 input and assume there is change
+	txSize := txsizes.EstimateSerializeSize(1, []*wire.TxOut{popTxOut}, true)
+	fee := btcutil.Amount(txSize) * satsPerByte
+
+	// Find utxo that is big enough for entire transaction
+	utxo, err := UtxoPickerSingle(0, fee, utxos) // no amount, just fees
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Assemble transaction
+	tx := wire.NewMsgTx(2) // Latest supported version
+	tx.LockTime = locktime
+	outpoint := wire.NewOutPoint(&utxo.TxId, utxo.OutIndex)
+	tx.AddTxIn(wire.NewTxIn(outpoint, script, nil))
+
+	// Return previous outs to caller so that they can be signed.
+	// This is a bit odd but in a real transaction we have to return all
+	// the scripts (and somehow obtain them). Think about this some more.
+	prevOuts := map[string][]byte{outpoint.String(): script}
+
+	// Change
+	change := utxo.Value - fee
+	changeTxOut := wire.NewTxOut(int64(change), script)
+	if !mempool.IsDust(changeTxOut, mempool.DefaultMinRelayTxFee) {
+		tx.AddTxOut(changeTxOut)
+	}
+
+	// OP_RETURN
+	tx.AddTxOut(wire.NewTxOut(0, popTxOpReturn))
+
+	return tx, prevOuts, nil
+}
+
+func TransactionSign(params *chaincfg.Params, z zuul.Zuul, tx *wire.MsgTx, prevOuts map[string][]byte) error {
+	for i, txIn := range tx.TxIn {
+		prevPkScript, ok := prevOuts[txIn.PreviousOutPoint.String()]
+		if !ok {
+			return fmt.Errorf("previous out not found: %v",
+				txIn.PreviousOutPoint)
+		}
+		sigScript, err := txscript.SignTxOutput(params, tx, i,
+			prevPkScript, txscript.SigHashAll,
+			txscript.KeyClosure(z.LookupKeyByAddr), nil, nil)
+		if err != nil {
+			return err
+		}
+		tx.TxIn[i].SignatureScript = sigScript
+	}
+
+	return nil
+}

--- a/bitcoin/wallet/wallet_test.go
+++ b/bitcoin/wallet/wallet_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/gozer"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/gozer/tbcgozer"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/vinzclortho"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/zuul"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/zuul/memory"
+	"github.com/hemilabs/heminetwork/hemi"
+	"github.com/hemilabs/heminetwork/testutil/mock"
+)
+
+func digest256(x []byte) []byte {
+	xx := sha256.Sum256(x)
+	return xx[:]
+}
+
+// XXX make this a generic non-testing specific function.
+func executeTX(t *testing.T, dump bool, scriptPubKey []byte, tx *btcutil.Tx) error {
+	flags := txscript.ScriptBip16 | txscript.ScriptVerifyDERSignatures |
+		txscript.ScriptStrictMultiSig | txscript.ScriptDiscourageUpgradableNops
+	vm, err := txscript.NewEngine(scriptPubKey, tx.MsgTx(), 0, flags, nil, nil, -1, nil)
+	if err != nil {
+		return err
+	}
+	if dump {
+		t.Logf("=== executing tx %v", tx.Hash())
+	}
+	for i := 0; ; i++ {
+		d, err := vm.DisasmPC()
+		if err != nil {
+			return err
+		}
+		if dump {
+			t.Logf("%v: %v", i, d)
+		}
+		done, err := vm.Step()
+		if err != nil {
+			return err
+		}
+		stack := vm.GetStack()
+		if dump {
+			t.Logf("%v: stack %v", i, spew.Sdump(stack))
+		}
+		if done {
+			break
+		}
+	}
+	err = vm.CheckErrorCondition(true)
+	if err != nil {
+		return err
+	}
+
+	if dump {
+		t.Logf("=== SUCCESS tx %v", tx.Hash())
+	}
+	return nil
+}
+
+func TestIntegration(t *testing.T) {
+	// KeyStore for key looksups during signing
+	m, err := memory.New(&chaincfg.TestNet3Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mnemonic := "dinosaur banner version pistol need area dream champion kiss thank business shrug explain intact puzzle"
+	w, err := vinzclortho.New(&chaincfg.TestNet3Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w.Unlock(mnemonic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ek, err := w.DeriveHD(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, pub, err := vinzclortho.AddressAndPublicFromExtended(&chaincfg.TestNet3Params, ek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%v", addr)
+	t.Logf("%v", pub)
+
+	// Store in key store
+	err = m.PutKey(&zuul.NamedKey{
+		Name:       "my private key",
+		Account:    0,
+		Child:      0,
+		HD:         true,
+		PrivateKey: ek,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkscript, err := vinzclortho.ScriptFromPubKeyHash(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%x", pkscript)
+	scripthash := vinzclortho.ScriptHashFromScript(pkscript)
+	t.Logf("%v", scripthash)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 10)
+	msgCh := make(chan string, 10)
+
+	// Create tbc test server with the request handler.
+	mtbc := mock.NewMockTBC(ctx, errCh, msgCh, nil, 0, 10)
+	defer mtbc.Shutdown()
+
+	tg, err := tbcgozer.Run(ctx, mtbc.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for connection to TBC
+	time.Sleep(50 * time.Millisecond)
+
+	feeEstimates, err := tg.FeeEstimates(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feeEstimateForPop, err := gozer.FeeByConfirmations(6, feeEstimates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(feeEstimateForPop))
+
+	feeEstimateForTx, err := gozer.FeeByConfirmations(2, feeEstimates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(spew.Sdump(feeEstimateForTx))
+
+	// XXX antonio we want test cases for true as well
+	utxos, err := tg.UtxosByAddress(ctx, true, addr, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("balance %v: %v", addr, gozer.BalanceFromUtxos(utxos))
+
+	// // pick utxo
+	// amount := btcutil.Amount(1000000) // 0.01000000 BTC
+	// fee := btcutil.Amount(50000)      // 0.00050000 BTC
+	// total := amount + fee             // 0.01050000 BTC
+	// utxo, err := UtxoPickerSingle(amount, fee, utxos)
+	// if err != nil {
+	//	t.Fatal(err)
+	// }
+	// t.Logf("utxo: %v > %v", btcutil.Amount(utxo.Value), total)
+
+	keystone := &hemi.L2Keystone{
+		Version:            1,
+		L1BlockNumber:      0xbadc0ffe,
+		L2BlockNumber:      0xdeadbeef,
+		ParentEPHash:       digest256([]byte{1, 1, 3, 7}),
+		PrevKeystoneEPHash: digest256([]byte{0x04, 0x20, 69}),
+		StateRoot:          digest256([]byte("Hello, world!")),
+		EPHash:             digest256([]byte{0xaa, 0x55}),
+	}
+
+	tx, prevOut, err := TransactionCreate(uint32(time.Now().Unix()),
+		btcutil.Amount(550), btcutil.Amount(feeEstimateForTx.SatsPerByte), addr, utxos, pkscript)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = TransactionSign(&chaincfg.TestNet3Params, m, tx, prevOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("tx: %v", spew.Sdump(tx))
+
+	err = executeTX(t, true, tx.TxOut[0].PkScript, btcutil.NewTx(tx))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	popTx, prevOut, err := PoPTransactionCreate(keystone, uint32(time.Now().Unix()),
+		btcutil.Amount(feeEstimateForPop.SatsPerByte+0.5), utxos, pkscript)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = TransactionSign(&chaincfg.TestNet3Params, m, popTx, prevOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("poptx: %v", spew.Sdump(popTx))
+
+	for _, txout := range popTx.TxOut {
+		opCode := txout.PkScript[0]
+		if opCode != txscript.OP_RETURN {
+			err = executeTX(t, true, txout.PkScript, btcutil.NewTx(popTx))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	txID, err := tg.BroadcastTx(ctx, tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("txID: %v", txID)
+}

--- a/bitcoin/wallet/zuul/memory/memory.go
+++ b/bitcoin/wallet/zuul/memory/memory.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+// Package memory provides an in-memory implementation of [zuul.Zuul].
+package memory
+
+import (
+	"sync"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/zuul"
+)
+
+// memoryZuul is an in-memory implementation of [zuul.Zuul].
+type memoryZuul struct {
+	mtx    sync.Mutex
+	params *chaincfg.Params
+	keys   map[string]*zuul.NamedKey
+}
+
+var _ zuul.Zuul = (*memoryZuul)(nil)
+
+// New returns a new [zuul.Zuul] implementation that stores data in-memory.
+func New(params *chaincfg.Params) (zuul.Zuul, error) {
+	m := &memoryZuul{
+		params: params,
+		keys:   make(map[string]*zuul.NamedKey, 10),
+	}
+	return m, nil
+}
+
+func (m *memoryZuul) PutKey(nk *zuul.NamedKey) error {
+	// Generate address for lookup
+	addr, err := nk.PrivateKey.Address(m.params)
+	if err != nil {
+		return err
+	}
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if _, ok := m.keys[addr.String()]; ok {
+		return zuul.ErrKeyExists
+	}
+	m.keys[addr.String()] = nk
+	return nil
+}
+
+func (m *memoryZuul) GetKey(addr btcutil.Address) (*zuul.NamedKey, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	nk, ok := m.keys[addr.String()]
+	if !ok {
+		return nil, zuul.ErrKeyDoesntExist
+	}
+	return nk, nil
+}
+
+func (m *memoryZuul) PurgeKey(addr btcutil.Address) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	nk, ok := m.keys[addr.String()]
+	if !ok {
+		return zuul.ErrKeyDoesntExist
+	}
+	delete(m.keys, addr.String())
+	nk.PrivateKey.Zero()
+	nk.PrivateKey = nil
+	return nil
+}
+
+func (m *memoryZuul) LookupKeyByAddr(addr btcutil.Address) (*btcec.PrivateKey, bool, error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	nk, ok := m.keys[addr.String()]
+	if !ok {
+		return nil, false, zuul.ErrKeyDoesntExist
+	}
+	priv, err := nk.PrivateKey.ECPrivKey()
+	if err != nil {
+		return nil, false, err
+	}
+	return priv, true, nil
+}

--- a/bitcoin/wallet/zuul/memory/memory_test.go
+++ b/bitcoin/wallet/zuul/memory/memory_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package memory
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/go-test/deep"
+
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/vinzclortho"
+	"github.com/hemilabs/heminetwork/bitcoin/wallet/zuul"
+)
+
+type keyInfo struct {
+	ek   *hdkeychain.ExtendedKey
+	priv *btcec.PrivateKey
+	addr *btcutil.Address
+	nk   *zuul.NamedKey
+}
+
+func keyInfoFromXprevs(xprevs []string) ([]keyInfo, error) {
+	keyInfoList := make([]keyInfo, 0)
+
+	for _, xp := range xprevs {
+		ek, err := hdkeychain.NewKeyFromString(xp)
+		if err != nil {
+			return nil, err
+		}
+
+		addr, _, err := vinzclortho.AddressAndPublicFromExtended(&chaincfg.TestNet3Params, ek)
+		if err != nil {
+			return nil, err
+		}
+
+		nk := zuul.NamedKey{
+			Name:       "pk",
+			Account:    0,
+			Child:      0,
+			HD:         true,
+			PrivateKey: ek,
+		}
+
+		expectedPriv, err := ek.ECPrivKey()
+		if err != nil {
+			return nil, err
+		}
+
+		ki := keyInfo{
+			ek:   ek,
+			addr: &addr,
+			priv: expectedPriv,
+			nk:   &nk,
+		}
+
+		keyInfoList = append(keyInfoList, ki)
+	}
+
+	return keyInfoList, nil
+}
+
+func TestMemoryZuul(t *testing.T) {
+	xprivList := []string{
+		"xprv9s21ZrQH143K3ScRXhao5KSyozmph3B3Bop8C1iqnyCgXSpUDE8oYDsz2hDp897fwwqdsTFYKNQVg5jn5nLH2QkZWeF9MZeMwkbkN8uAafy",
+		"xprv9s21ZrQH143K2pxg5xps4opEVnydz9MexEvEQMGCdVpaYyVxMsfSLHwh4QRgxZQTh6TkdhZvi1339vKUoDZz5XinoqKxrVKhmrjVMdAnChT",
+		"xprv9s21ZrQH143K44uicYsxgM8kSYF96MykdxgTm66MVTChY7epoVBEfdDMzZwUo6WcyzvvkuautC5gRN2LkQEqpME1uVH1unXoYQiMao4734N",
+		"xprv9s21ZrQH143K2MreeuJfJ2aV4PgzZZ4jNq4czYdXTzZvhfkHoBdetWq7mtMiM8WSKqxf8AKKr16mXvfLjLZxbrShfiE51n4DqCDGHKezcYC",
+	}
+
+	type kiCmd struct {
+		cmd      string   // type of 'put' or 'purge'
+		privKeys []string // list of privkeys to run the command with
+		fail     bool     // expected to fail
+	}
+
+	type testTableItem struct {
+		name        string
+		cmds        []kiCmd  // commands to run during test
+		expectedIn  []string // expected to be in zuul at end of test
+		expectedOut []string // expected to NOT be in zuul at end of test
+	}
+
+	testTable := []testTableItem{
+		{
+			name:        "testEmpty",
+			expectedOut: xprivList,
+		},
+		{
+			name:        "testInsert",
+			cmds:        []kiCmd{{cmd: "put", privKeys: xprivList}},
+			expectedIn:  xprivList,
+			expectedOut: nil,
+		},
+		{
+			name: "testInsertDup",
+			cmds: []kiCmd{
+				{cmd: "put", privKeys: xprivList},
+				{cmd: "put", privKeys: xprivList, fail: true},
+			},
+			expectedIn: xprivList,
+		},
+		{
+			name: "testPurge",
+			cmds: []kiCmd{
+				{cmd: "put", privKeys: xprivList},
+				{cmd: "purge", privKeys: xprivList},
+			},
+			expectedOut: xprivList,
+		},
+		{
+			name:        "testPurgeInvalid",
+			cmds:        []kiCmd{{cmd: "purge", privKeys: xprivList, fail: true}},
+			expectedOut: xprivList,
+		},
+		{
+			name:        "testMixedInsert",
+			cmds:        []kiCmd{{cmd: "put", privKeys: xprivList[:2]}},
+			expectedOut: xprivList[2:],
+			expectedIn:  xprivList[:2],
+		},
+		{
+			name: "testMixedPurge",
+			cmds: []kiCmd{
+				{cmd: "put", privKeys: xprivList},
+				{cmd: "purge", privKeys: xprivList[:2]},
+			},
+			expectedOut: xprivList[:2],
+			expectedIn:  xprivList[2:],
+		},
+	}
+
+	for _, tti := range testTable {
+		t.Run(tti.name, func(t *testing.T) {
+			m, err := New(&chaincfg.TestNet3Params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// run each of the commands
+			for _, command := range tti.cmds {
+				switch command.cmd {
+				case "put":
+					privKeys, err := keyInfoFromXprevs(command.privKeys)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, ki := range privKeys {
+						err = m.PutKey(ki.nk)
+						if !command.fail {
+							if err != nil {
+								t.Fatal(err)
+							}
+						} else {
+							if err == nil || !errors.Is(err, zuul.ErrKeyExists) {
+								t.Fatalf("expected '%v' error, got '%v'", zuul.ErrKeyExists, err)
+							}
+						}
+					}
+				case "purge":
+
+					privKeys, err := keyInfoFromXprevs(command.privKeys)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, ki := range privKeys {
+						err = m.PurgeKey(*(ki.addr))
+						if !command.fail {
+							if err != nil {
+								t.Fatal(err)
+							}
+						} else {
+							if err == nil || !errors.Is(err, zuul.ErrKeyDoesntExist) {
+								t.Fatalf("expected '%v' error, got '%v'", zuul.ErrKeyDoesntExist, err)
+							}
+						}
+					}
+				default:
+					t.Fatalf("unknown command...")
+				}
+			}
+
+			// check if keys in expectedIn are in zuul
+			expectedIn, err := keyInfoFromXprevs(tti.expectedIn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, ki := range expectedIn {
+				nk, err := m.GetKey(*ki.addr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if diff := deep.Equal(ki.nk, nk); len(diff) > 0 {
+					t.Fatalf("unexpected error diff: %s", diff)
+				}
+
+				priv, ok, err := m.LookupKeyByAddr(*ki.addr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !ok {
+					t.Fatalf("Expected %v on lookup, got %v", true, ok)
+				}
+				if diff := deep.Equal(ki.priv, priv); len(diff) > 0 {
+					t.Fatalf("unexpected error diff: %s", diff)
+				}
+			}
+
+			// check if keys in expectedOut are NOT in zuul
+			expectedOut, err := keyInfoFromXprevs(tti.expectedOut)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, ki := range expectedOut {
+				_, err = m.GetKey(*ki.addr)
+				if err == nil || !errors.Is(err, zuul.ErrKeyDoesntExist) {
+					t.Fatalf("expected '%v' error, got '%v'", zuul.ErrKeyDoesntExist, err)
+				}
+				_, _, err = m.LookupKeyByAddr(*ki.addr)
+				if err == nil || !errors.Is(err, zuul.ErrKeyDoesntExist) {
+					t.Fatalf("expected '%v' error, got '%v'", zuul.ErrKeyDoesntExist, err)
+				}
+			}
+		})
+	}
+}

--- a/bitcoin/wallet/zuul/zuul.go
+++ b/bitcoin/wallet/zuul/zuul.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+// Package zuul provides an interface for handling the storage of secret
+// material.
+//
+// Zuul, a minion of the god known as Gozer, was worshiped as a demigod by the
+// Sumerians, Mesopotamians and Hittites in 6000 BC.
+package zuul
+
+import (
+	"errors"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+)
+
+var (
+	ErrKeyExists      = errors.New("key exists")
+	ErrKeyDoesntExist = errors.New("key does not exist")
+)
+
+// NamedKey contains a private key with metadata.
+type NamedKey struct {
+	Name string // User defined name
+
+	// Derivation path
+	Account uint
+	Child   uint
+	HD      bool
+
+	PrivateKey *hdkeychain.ExtendedKey
+}
+
+// Zuul is an interface for storing secret material.
+type Zuul interface {
+	PutKey(nk *NamedKey) error
+	GetKey(addr btcutil.Address) (*NamedKey, error)
+	PurgeKey(addr btcutil.Address) error
+	LookupKeyByAddr(addr btcutil.Address) (*btcec.PrivateKey, bool, error) // signing lookup
+}

--- a/cmd/btctool/blockstream/blockstream.go
+++ b/cmd/btctool/blockstream/blockstream.go
@@ -54,7 +54,7 @@ func Tip(ctx context.Context) (int, error) {
 	}
 	height, err := strconv.ParseInt(string(b), 10, 0)
 	if err != nil {
-		return 0, fmt.Errorf("parse uint: %w", err)
+		return 0, fmt.Errorf("parse int: %w", err)
 	}
 	if height < 0 {
 		return 0, fmt.Errorf("parse uint: unexpected negative value")

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -261,12 +261,12 @@ func httpCall(ctx context.Context, method, url string, requestBody io.Reader) (i
 	c := http.DefaultClient
 	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
 	if err != nil {
-		return nil, fmt.Errorf("request: %v", err)
+		return nil, fmt.Errorf("request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	reply, err := c.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("http.do: %v", err)
+		return nil, fmt.Errorf("http.do: %w", err)
 	}
 	switch reply.StatusCode {
 	case http.StatusOK:
@@ -342,7 +342,7 @@ func hproxyctl(pctx context.Context, flags []string) error {
 		}
 		req, err := json.Marshal(r)
 		if err != nil {
-			return fmt.Errorf("request: %v", err)
+			return fmt.Errorf("request: %w", err)
 		}
 		request := bytes.NewReader(req)
 		body, err := httpCall(ctx, http.MethodGet, "http://"+hp+hproxy.RouteControlAdd, request)
@@ -354,7 +354,7 @@ func hproxyctl(pctx context.Context, flags []string) error {
 		var jr []map[string]interface{}
 		err = json.NewDecoder(body).Decode(&jr)
 		if err != nil {
-			return fmt.Errorf("decode: %v", err)
+			return fmt.Errorf("decode: %w", err)
 		}
 		for _, v := range jr {
 			fmt.Printf("node: %v error: %v\n", v["node_url"], v["error"])
@@ -374,7 +374,7 @@ func hproxyctl(pctx context.Context, flags []string) error {
 		var jr []map[string]interface{}
 		err = json.NewDecoder(body).Decode(&jr)
 		if err != nil {
-			return fmt.Errorf("decode: %v", err)
+			return fmt.Errorf("decode: %w", err)
 		}
 		for _, v := range jr {
 			fmt.Printf("node: %v status: %v connections: %v\n",
@@ -398,7 +398,7 @@ func hproxyctl(pctx context.Context, flags []string) error {
 		}
 		req, err := json.Marshal(r)
 		if err != nil {
-			return fmt.Errorf("request: %v", err)
+			return fmt.Errorf("request: %w", err)
 		}
 		request := bytes.NewReader(req)
 		body, err := httpCall(ctx, http.MethodGet, "http://"+hp+hproxy.RouteControlRemove, request)
@@ -410,7 +410,7 @@ func hproxyctl(pctx context.Context, flags []string) error {
 		var jr []map[string]interface{}
 		err = json.NewDecoder(body).Decode(&jr)
 		if err != nil {
-			return fmt.Errorf("decode: %v", err)
+			return fmt.Errorf("decode: %w", err)
 		}
 		for _, v := range jr {
 			fmt.Printf("node: %v error: %v\n", v["node_url"], v["error"])
@@ -1522,7 +1522,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\tp2p\t\tp2p commands\n")
 	fmt.Fprintf(os.Stderr, "\ttbcdb\t\tdatabase open (tbcd must not be running)\n")
 	fmt.Fprintf(os.Stderr, "\tlevel\t\tdb manipulation\n\n")
-	fmt.Fprintf(os.Stderr, "\thproxy\t\thproxy controller\n\n")
+	fmt.Fprintf(os.Stderr, "\thproxy\t\tcontroller\n\n")
 	fmt.Fprintf(os.Stderr, "ENVIRONMENT:\n")
 	config.Help(os.Stderr, cm)
 	fmt.Fprintf(os.Stderr, "\nuse 'hemictl <command> -h' or 'hemictl <command> -help' to"+

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -73,6 +73,12 @@ var (
 			Help:         "address and port hproxy pprof listens on (open <address>/debug/pprof to see available profiles)",
 			Print:        config.PrintAll,
 		},
+		"HPROXY_POLL_FREQUENCY": config.Config{
+			Value:        &cfg.PollFrequency,
+			DefaultValue: hproxy.DefaultPollFrequency,
+			Help:         "frequency that hproxy pokes nodes for health information",
+			Print:        config.PrintAll,
+		},
 		"HPROXY_REQUEST_TIMEOUT": config.Config{
 			Value:        &cfg.RequestTimeout,
 			DefaultValue: cfg.RequestTimeout,

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -31,6 +31,12 @@ var (
 
 	cfg = hproxy.NewDefaultConfig()
 	cm  = config.CfgMap{
+		"HPROXY_CLIENT_IDLE_TIMEOUT": config.Config{
+			Value:        &cfg.ClientIdleTimeout,
+			DefaultValue: hproxy.DefaultClientIdleTimeout,
+			Help:         "max idle time to persists hvm reuse per client",
+			Print:        config.PrintAll,
+		},
 		"HPROXY_HVM_URLS": config.Config{
 			Value:        &cfg.HVMURLs,
 			DefaultValue: cfg.HVMURLs,

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -31,26 +31,23 @@ var (
 
 	cfg = hproxy.NewDefaultConfig()
 	cm  = config.CfgMap{
-		"HPROXY_LOG_LEVEL": config.Config{
-			Value:        &cfg.LogLevel,
-			DefaultValue: defaultLogLevel,
-			Help:         "loglevel for various packages; INFO, DEBUG and TRACE",
-			Print:        config.PrintAll,
-		},
 		"HPROXY_HVM_URLS": config.Config{
 			Value:        &cfg.HVMURLs,
 			DefaultValue: cfg.HVMURLs,
 			Help:         "comma separated HVM URLs",
 			Print:        config.PrintAll,
 		},
-		"HPROXY_REQUEST_TIMEOUT": config.Config{
-			Value:        &cfg.RequestTimeout,
-			DefaultValue: cfg.RequestTimeout,
-			Help:         "HVM request timeout",
+		"HPROXY_LOG_LEVEL": config.Config{
+			Value:        &cfg.LogLevel,
+			DefaultValue: defaultLogLevel,
+			Help:         "loglevel for various packages; INFO, DEBUG and TRACE",
 			Print:        config.PrintAll,
-			Parse: func(envValue string) (any, error) {
-				return time.ParseDuration(envValue)
-			},
+		},
+		"HPROXY_LISTEN_ADDRESS": config.Config{
+			Value:        &cfg.ListenAddress,
+			DefaultValue: hproxy.DefaultListenAddress,
+			Help:         "listen address for incomming connections",
+			Print:        config.PrintAll,
 		},
 		"HPROXY_NETWORK": config.Config{
 			Value:        &cfg.Network,
@@ -65,10 +62,19 @@ var (
 			Print:        config.PrintAll,
 		},
 		"HPROXY_PPROF_ADDRESS": config.Config{
-			Value:        &cfg.PrometheusListenAddress,
+			Value:        &cfg.PprofListenAddress,
 			DefaultValue: "",
 			Help:         "address and port hproxy pprof listens on (open <address>/debug/pprof to see available profiles)",
 			Print:        config.PrintAll,
+		},
+		"HPROXY_REQUEST_TIMEOUT": config.Config{
+			Value:        &cfg.RequestTimeout,
+			DefaultValue: cfg.RequestTimeout,
+			Help:         "HVM request timeout",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
 		},
 	}
 )
@@ -113,7 +119,7 @@ func _main() error {
 		log.Infof("hproxy service received signal: %s", s)
 	})
 
-	hp, err := hproxy.NewHProxy(cfg)
+	hp, err := hproxy.NewServer(cfg)
 	if err != nil {
 		return fmt.Errorf("create hproxy: %w", err)
 	}

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/juju/loggo"
+
+	"github.com/hemilabs/heminetwork/config"
+	"github.com/hemilabs/heminetwork/service/hproxy"
+	"github.com/hemilabs/heminetwork/version"
+)
+
+const (
+	daemonName      = "hproxyd"
+	defaultLogLevel = daemonName + "=INFO;hproxy=INFO"
+)
+
+var (
+	log     = loggo.GetLogger(daemonName)
+	welcome string
+
+	cfg = hproxy.NewDefaultConfig()
+	cm  = config.CfgMap{
+		"HPROXY_LOG_LEVEL": config.Config{
+			Value:        &cfg.LogLevel,
+			DefaultValue: defaultLogLevel,
+			Help:         "loglevel for various packages; INFO, DEBUG and TRACE",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_HVM_URLS": config.Config{
+			Value:        &cfg.HVMURLs,
+			DefaultValue: cfg.HVMURLs,
+			Help:         "comma separated HVM URLs",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_REQUEST_TIMEOUT": config.Config{
+			Value:        &cfg.RequestTimeout,
+			DefaultValue: cfg.RequestTimeout,
+			Help:         "HVM request timeout",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
+		},
+		"HPROXY_NETWORK": config.Config{
+			Value:        &cfg.Network,
+			DefaultValue: "sepolia", // XXX
+			Help:         "ethereum network (ex. \"mainnet\", \"sepolia\")",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_PROMETHEUS_ADDRESS": config.Config{
+			Value:        &cfg.PrometheusListenAddress,
+			DefaultValue: "",
+			Help:         "address and port hproxy prometheus listens on",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_PPROF_ADDRESS": config.Config{
+			Value:        &cfg.PrometheusListenAddress,
+			DefaultValue: "",
+			Help:         "address and port hproxy pprof listens on (open <address>/debug/pprof to see available profiles)",
+			Print:        config.PrintAll,
+		},
+	}
+)
+
+func handleSignals(ctx context.Context, cancel context.CancelFunc, callback func(os.Signal)) {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+	defer func() {
+		signal.Stop(signalChan)
+		cancel()
+	}()
+
+	select {
+	case <-ctx.Done():
+	case s := <-signalChan: // First signal, cancel context.
+		if callback != nil {
+			callback(s) // Do whatever caller wants first.
+			cancel()
+		}
+	}
+	<-signalChan // Second signal, hard exit.
+	os.Exit(2)
+}
+
+func _main() error {
+	if err := config.Parse(cm); err != nil {
+		return err
+	}
+
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		return err
+	}
+	log.Infof("%v", welcome)
+
+	pc := config.PrintableConfig(cm)
+	for k := range pc {
+		log.Infof("%v", pc[k])
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go handleSignals(ctx, cancel, func(s os.Signal) {
+		log.Infof("hproxy service received signal: %s", s)
+	})
+
+	hp, err := hproxy.NewHProxy(cfg)
+	if err != nil {
+		return fmt.Errorf("create hproxy: %w", err)
+	}
+	if err := hp.Run(ctx); !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("hproxy service terminated: %w", err)
+	}
+
+	return nil
+}
+
+func init() {
+	version.Component = "hproxyd"
+	welcome = "Hemi Proxy" + version.BuildInfo()
+}
+
+func main() {
+	if len(os.Args) != 1 {
+		fmt.Fprintf(os.Stderr, "%v\n", welcome)
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "\thelp (this help)\n")
+		fmt.Fprintf(os.Stderr, "Environment:\n")
+		config.Help(os.Stderr, cm)
+		os.Exit(1)
+	}
+
+	if err := _main(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -43,6 +43,12 @@ var (
 			Help:         "loglevel for various packages; INFO, DEBUG and TRACE",
 			Print:        config.PrintAll,
 		},
+		"HPROXY_CONTROL_ADDRESS": config.Config{
+			Value:        &cfg.ControlAddress,
+			DefaultValue: hproxy.DefaultControlAddress,
+			Help:         "control address for incomming commands",
+			Print:        config.PrintAll,
+		},
 		"HPROXY_LISTEN_ADDRESS": config.Config{
 			Value:        &cfg.ListenAddress,
 			DefaultValue: hproxy.DefaultListenAddress,

--- a/cmd/keygen/keygen.go
+++ b/cmd/keygen/keygen.go
@@ -106,7 +106,6 @@ func main() {
 		fmt.Printf("v%v\n", version.String())
 		os.Exit(0)
 	}
-	flag.Parse()
 
 	if err := _main(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -270,6 +270,8 @@ services:
       ADMIN_PRIVATE_KEY: "${ADMIN_PRIVATE_KEY}"
       OP_GETH_L1_RPC: "http://geth-l1:8545"
       HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
+      # yamllint disable-line rule:line-length
+      GETH_NODEKEYHEX: "76e3e48b25c512e1036069538041df813b759fc67d4756b80ace2586b123e913"
     working_dir: "/tmp"
     command:
       - "sh"
@@ -289,6 +291,7 @@ services:
       - 8546:8546
     networks:
       e2e:
+        ipv4_address: 192.169.199.8
 
   op-node:
     build:
@@ -326,8 +329,6 @@ services:
       - "--p2p.no-discovery"
       - "--p2p.priv.path=/tmp/op-node-priv-key.txt"
       - "--p2p.sequencer.key=${ADMIN_PRIVATE_KEY}"
-      - "--p2p.static=/ip4/192.169.198.7/tcp/9222/p2p/16Uiu2HAkx8gegEci9Jk2GDJ92S7HuF7odZCgg9mbos18qiqNEpFz"
-      - "--p2p.static=/ip4/192.169.197.7/tcp/9222/p2p/16Uiu2HAmVqqZGwbuWDffuQo2jCLBSULod13CZuoACZQS8WTKEL2X"
       - "--log.level=debug"
       - "--log.format=terminal"
       - "--override.ecotone=1725868497"
@@ -346,6 +347,92 @@ services:
     networks:
       e2e:
         ipv4_address: 192.169.199.7
+    ports:
+      - "8547:8547"
+
+  op-node-non-sequencing:
+    build:
+      dockerfile: "optimism-stack.Dockerfile"
+      context: "."
+    depends_on:
+      op-node:
+        condition: "service_started"
+    healthcheck:
+      start_period: 180s
+    environment:
+      OP_NODE_BSS_WS: "http://bssd:8081/v1/ws"
+    command:
+      - "op-node/bin/op-node"
+      - "--l2=ws://op-geth-l2-non-sequencing:8551"
+      - "--l2.jwt-secret=/tmp/jwt.hex"
+      - "--verifier.l1-confs=0"
+      - "--rollup.config=/l2configs/rollup.json"
+      - "--rpc.addr=0.0.0.0"
+      - "--rpc.port=8547"
+      - "--rpc.enable-admin"
+      - "--l1=http://geth-l1:8545"
+      - "--l1.rpckind=standard"
+      - "--l1.trustrpc"
+      - "--log.level=info"
+      - "--l1.trustrpc=true"
+      - "--l1.http-poll-interval=1s"
+      - "--p2p.priv.path=/tmp/op-node-priv-key.txt"
+      - "--p2p.sequencer.key=${ADMIN_PRIVATE_KEY}"
+      - "--p2p.static=/ip4/192.169.199.7/tcp/9222/p2p/16Uiu2HAmGCJv5C97ZcdMr6pCCQFqdNXvwE8k6RgTd7vWu4WtVUmr"
+      - "--log.level=debug"
+      - "--log.format=terminal"
+      - "--override.ecotone=1725868497"
+      - "--override.canyon=1725868497"
+      - "--override.delta=1725868497"
+      - "--override.pectrablobschedule=1744238662"
+      - "--override.isthmus=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.holocene=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.granite=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.fjord=${HVM_PHASE0_TIMESTAMP}"
+      - "--l1.beacon.ignore=true"
+    volumes:
+      - "l2configs:/l2configs"
+      - "./jwt.hex:/tmp/jwt.hex"
+    networks:
+      e2e:
+    ports:
+      - "18547:8547"
+
+  op-geth-l2-non-sequencing:
+    build:
+      dockerfile: "optimism-stack.Dockerfile"
+      context: "."
+    depends_on:
+      op-geth-l2:
+        condition: "service_started"
+    healthcheck:
+      test: ["CMD-SHELL", "ls /tmp/datadir/geth.ipc"]
+      interval: 5s
+      retries: 300
+      start_period: 30s
+    environment:
+      ADMIN_PRIVATE_KEY: "${ADMIN_PRIVATE_KEY}"
+      OP_GETH_L1_RPC: "http://geth-l1:8545"
+      HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
+    working_dir: "/tmp"
+    command:
+      - "sh"
+      - "/tmp/entrypointl2.sh"
+    volumes:
+      - "./e2e/keystore:/tmp/keystore:ro"
+      - "./e2e/passwords.txt:/tmp/passwords.txt:ro"
+      - "./jwt.hex:/tmp/jwt.hex:ro"
+      - "./entrypointl2.sh:/tmp/entrypointl2.sh"
+      - "./genesisl2.sh:/tmp/genesisl2.sh"
+      - "./output:/tmp/output"
+      - "l2configs:/l2configs"
+      - "./deploy-config.json:/git/optimism/packages/contracts-bedrock/deploy-config/devnetL1.json"
+      - "./prestate-proof.json:/git/optimism/op-program/bin/prestate-proof.json"
+      - {type: "tmpfs", target: "/tmp"}
+    networks:
+      e2e:
+    ports:
+      - "18546:8546"
 
   op-batcher:
     build:

--- a/e2e/monitor/go.mod
+++ b/e2e/monitor/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/ethereum-optimism/optimism v0.0.0-00010101000000-000000000000
 	github.com/ethereum/go-ethereum v1.15.9
+	github.com/go-test/deep v1.1.1
 	github.com/gosuri/uilive v0.0.4
 	github.com/hemilabs/heminetwork v1.0.0
 	github.com/jedib0t/go-pretty/v6 v6.5.8

--- a/e2e/monitor/main.go
+++ b/e2e/monitor/main.go
@@ -38,6 +38,9 @@ type state struct {
 	lastBatcherPublicationHash  string
 	batcherPublicationCount     int
 	popMinerBalance             string // very large number
+	tipDiff                     int
+	tipHash                     string
+	tipHashNonSequencing        string
 }
 
 type jsonOutput struct {
@@ -47,6 +50,8 @@ type jsonOutput struct {
 	LastBatcherPublicationHash  string `json:"last_batcher_publication_hash"`
 	BatcherPublicationCount     uint64 `json:"batcher_publication_count"`
 	PopMinerHemiBalance         string `json:"pop_miner_hemi_balance"`
+	TipHash                     string `json:"tip_hash"`
+	TipHashNonSequencing        string `json:"tip_hash_non_sequencing"`
 }
 
 func main() {
@@ -113,6 +118,12 @@ func render(ctx context.Context, s *state, w table.Writer, mtx *sync.Mutex) {
 		w.AppendRow(table.Row{"batcher publication count", fmt.Sprintf("%d", s.batcherPublicationCount)})
 
 		w.AppendRow(table.Row{"pop miner $HEMI balance", fmt.Sprintf("%s", s.popMinerBalance)})
+
+		w.AppendRow(table.Row{"sequencer vs non-sequencer tip diff", fmt.Sprintf("%d", s.tipDiff)})
+
+		w.AppendRow(table.Row{"sequencer tip", fmt.Sprintf("%s", s.tipHash)})
+
+		w.AppendRow(table.Row{"non-sequencer tip", fmt.Sprintf("%s", s.tipHashNonSequencing)})
 
 		for _, c := range s.containersRunning {
 			w.AppendRow(table.Row{fmt.Sprintf("container %s", c), "running"})
@@ -294,6 +305,14 @@ func monitorRolledUpTxs(ctx context.Context, s *state, mtx *sync.Mutex) {
 		console.log(Number.parseInt(hexValue, 16));
 	`
 
+	tipJs := `
+		console.log(eth.blockNumber)
+	`
+
+	tipHashJs := `
+		console.log(eth.getBlock(eth.blockNumber).hash)
+	`
+
 	runJs := func(jsi string, layer string, ipcPath string, replica string) string {
 		prefix := "op-"
 		if layer == "l1" {
@@ -319,17 +338,45 @@ func monitorRolledUpTxs(ctx context.Context, s *state, mtx *sync.Mutex) {
 		return strings.Split(string(output), "\n")[0]
 	}
 
+	runJsToInt := func(jsi string, layer string, ipcPath string, replica string) int {
+		val := runJs(jsi, layer, ipcPath, replica)
+		intVal, err := strconv.Atoi(val)
+		if err != nil {
+			panic(fmt.Sprintf("error converting to int: %s", err))
+		}
+
+		return intVal
+	}
+
 	for {
 		first := runJs(firstBatcherTxBlockJs, "l1", "geth.ipc", "1")
 		last := runJs(lastBatcherTxBlockJs, "l1", "geth.ipc", "1")
 		count := runJs(batcherPublicationCountJs, "l1", "geth.ipc", "1")
-		popMinerBalance := runJs(popMinerBalanceJs, "l2", "datadir/geth.ipc", "1")
+
+		popMinerBalance := runJsToInt(popMinerBalanceJs, "l2", "datadir/geth.ipc", "1")
+		popMinerBalanceNonSequencing := runJsToInt(popMinerBalanceJs, "l2-non-sequencing", "datadir/geth.ipc", "1")
+
+		tip := runJsToInt(tipJs, "l2", "datadir/geth.ipc", "1")
+		tipNonSequencing := runJsToInt(tipJs, "l2-non-sequencing", "datadir/geth.ipc", "1")
+
+		tipHash := runJs(tipHashJs, "l2", "datadir/geth.ipc", "1")
+		tipHashNonSequencing := runJs(tipHashJs, "l2-non-sequencing", "datadir/geth.ipc", "1")
+
+		// choose the min of these values; the values should be going up.  if
+		// one node is not keeping up, it will have a (noticeably) lower balance
+		if popMinerBalanceNonSequencing < popMinerBalance {
+			popMinerBalance = popMinerBalanceNonSequencing
+		}
+
+		tipDiff := tip - tipNonSequencing
 
 		mtx.Lock()
 		s.firstBatcherPublicationHash = first
 		s.lastBatcherPublicationHash = last
-
-		s.popMinerBalance = popMinerBalance
+		s.tipDiff = tipDiff
+		s.popMinerBalance = fmt.Sprintf("%d", popMinerBalance)
+		s.tipHash = tipHash
+		s.tipHashNonSequencing = tipHashNonSequencing
 		var err error
 		s.batcherPublicationCount, err = strconv.Atoi(count)
 		if err != nil {
@@ -371,6 +418,8 @@ func dumpJson(mtx *sync.Mutex, s *state) string {
 		LastBatcherPublicationHash:  s.lastBatcherPublicationHash,
 		BatcherPublicationCount:     uint64(s.batcherPublicationCount),
 		PopMinerHemiBalance:         s.popMinerBalance,
+		TipHash:                     s.tipHash,
+		TipHashNonSequencing:        s.tipHashNonSequencing,
 	}
 	mtx.Unlock()
 

--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -5,11 +5,15 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io"
 	"math/big"
+	"net/http"
 	"slices"
 	"testing"
 	"time"
@@ -30,6 +34,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/go-test/deep"
 
 	mybindings "github.com/hemilabs/heminetwork/e2e/monitor/bindings"
 	"github.com/hemilabs/heminetwork/hemi"
@@ -99,10 +105,15 @@ func TestMonitor(t *testing.T) {
 			t.Fatalf("could not parse balance from %s", jo.PopMinerHemiBalance)
 		}
 
-		t.Logf("expecting actual balance %d to be greater than %d", balance, expectedPayoutBalance)
+		t.Logf("expecting actual balance %v to be greater than %v", balance, expectedPayoutBalance)
 
 		if expectedPayoutBalance.Cmp(balance) > 0 {
-			t.Logf("pop miner payout balance received %d, want at least %d", balance, expectedPayoutBalance)
+			t.Logf("pop miner payout balance received %v, want at least %v", balance, expectedPayoutBalance)
+			continue
+		}
+
+		if jo.TipHash != jo.TipHashNonSequencing {
+			t.Logf("tip mismatch: %s != %s", jo.TipHash, jo.TipHashNonSequencing)
 			continue
 		}
 
@@ -112,41 +123,66 @@ func TestMonitor(t *testing.T) {
 }
 
 func TestL1L2Comms(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Minute)
-	defer cancel()
+	for _, sequencing := range []bool{true, false} {
+		var name string
+		if sequencing {
+			name = "testing sequencing client"
+		} else {
+			name = "testing non-sequencing client"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+			defer cancel()
 
-	l1Client, err := ethclient.Dial("http://localhost:8545")
-	if err != nil {
-		t.Fatalf("could not dial eth l1 %s", err)
+			l1Client, err := ethclient.Dial("http://localhost:8545")
+			if err != nil {
+				t.Fatalf("could not dial eth l1 %s", err)
+			}
+
+			l2Client, err := ethclient.Dial("http://localhost:8546")
+			if err != nil {
+				t.Fatalf("could not dial eth l1 %s", err)
+			}
+
+			l2ClientNonSequencing, err := ethclient.Dial("http://localhost:18546")
+			if err != nil {
+				t.Fatalf("could not dial eth l1 %s", err)
+			}
+
+			privateKey, err := crypto.HexToECDSA(localnetPrivateKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			l2ClientToUse := l2Client
+			if !sequencing {
+				l2ClientToUse = l2ClientNonSequencing
+			}
+
+			l1Address := deployL1TestToken(t, ctx, l1Client, privateKey)
+
+			t.Logf("the l1 address is %s", l1Address.Hex())
+
+			bridgeEthL1ToL2(t, ctx, l1Client, l2ClientToUse, privateKey)
+
+			l2Address := deployL2TestToken(t, ctx, l1Address, l2ClientToUse, privateKey)
+			t.Logf("the l2 address is %s", l2Address.Hex())
+
+			bridgeERC20FromL1ToL2(t, ctx, l1Address, l2Address, privateKey, l1Client, l2ClientToUse)
+
+			bridgeERC20FromL2ToL1(t, ctx, l1Address, l2Address, privateKey, l1Client, l2ClientToUse)
+
+			bridgeEthL2ToL1(t, ctx, l1Client, l2ClientToUse, privateKey)
+
+			hvmTipNearBtcTip(t, ctx, l2Client, l2ClientNonSequencing, privateKey)
+			hvmBtcBalance(t, ctx, l2ClientToUse, privateKey)
+
+			opNodeSequencingEndpoint := "http://localhost:8547"
+			opNodeNonSequencingEndpoint := "http://localhost:18547"
+			assertOutputRootsAreTheSame(t, ctx, l2ClientToUse, opNodeSequencingEndpoint, opNodeNonSequencingEndpoint)
+			assertSafeAndFinalBlocksAreProgressing(t, ctx, l2ClientToUse)
+		})
 	}
-
-	l2Client, err := ethclient.Dial("http://localhost:8546")
-	if err != nil {
-		t.Fatalf("could not dial eth l1 %s", err)
-	}
-
-	privateKey, err := crypto.HexToECDSA(localnetPrivateKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	l1Address := deployL1TestToken(t, ctx, l1Client, privateKey)
-
-	t.Logf("the l1 address is %s", l1Address.Hex())
-
-	bridgeEthL1ToL2(t, ctx, l1Client, l2Client, privateKey)
-
-	l2Address := deployL2TestToken(t, ctx, l1Address, l2Client, privateKey)
-	t.Logf("the l2 address is %s", l2Address.Hex())
-
-	bridgeERC20FromL1ToL2(t, ctx, l1Address, l2Address, privateKey, l1Client, l2Client)
-
-	bridgeERC20FromL2ToL1(t, ctx, l1Address, l2Address, privateKey, l1Client, l2Client)
-
-	bridgeEthL2ToL1(t, ctx, l1Client, l2Client, privateKey)
-
-	hvmTipNearBtcTip(t, ctx, l2Client, privateKey)
-	hvmBtcBalance(t, ctx, l2Client, privateKey)
 }
 
 func TestOperatorFeeVaultIsPresent(t *testing.T) {
@@ -170,7 +206,7 @@ func TestOperatorFeeVaultIsPresent(t *testing.T) {
 	}
 }
 
-func hvmTipNearBtcTip(t *testing.T, ctx context.Context, l2Client *ethclient.Client, privateKey *ecdsa.PrivateKey) {
+func hvmTipNearBtcTip(t *testing.T, ctx context.Context, l2Client *ethclient.Client, l2ClientNonSequencing *ethclient.Client, privateKey *ecdsa.PrivateKey) {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
@@ -198,7 +234,7 @@ func hvmTipNearBtcTip(t *testing.T, ctx context.Context, l2Client *ethclient.Cli
 	auth.GasLimit = uint64(3000000) // in units
 	auth.GasPrice = gasPrice
 
-	_, tx, l2ReadBalances, err := mybindings.DeployL2ReadBalances(auth, l2Client)
+	contractAddress, tx, l2ReadBalances, err := mybindings.DeployL2ReadBalances(auth, l2Client)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,6 +244,20 @@ func hvmTipNearBtcTip(t *testing.T, ctx context.Context, l2Client *ethclient.Cli
 	res, err := l2ReadBalances.L2ReadBalancesCaller.GetBitcoinLastHeader(nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	l2ReadBalancesNonSequencing, err := mybindings.NewL2ReadBalances(contractAddress, l2ClientNonSequencing)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resNonSequencing, err := l2ReadBalancesNonSequencing.L2ReadBalancesCaller.GetBitcoinLastHeader(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(res, resNonSequencing) {
+		t.Fatalf("bitcoin header mismatch between sequencer and non-sequencer: %x != %x", res, resNonSequencing)
 	}
 
 	config := client.ConnConfig{
@@ -537,7 +587,15 @@ func bridgeEthL2ToL1(t *testing.T, ctx context.Context, l1Client *ethclient.Clie
 
 	t.Logf("assuming L2OutputOracle is at %s", ooproxy)
 
-	blockNumber, err := wait.ForOutputRootPublished(ctx, l1Client, ooproxy, receipt.BlockNumber)
+	var blockNumber uint64
+
+	for range 5 {
+		blockNumber, err = wait.ForOutputRootPublished(ctx, l1Client, ooproxy, receipt.BlockNumber)
+		if err == nil {
+			break
+		}
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -627,8 +685,14 @@ func bridgeEthL2ToL1(t *testing.T, ctx context.Context, l1Client *ethclient.Clie
 		break
 	}
 
-	t.Logf("waiting for the finalization period")
-	if err := wait.ForFinalizationPeriod(ctx, l1Client, receipt.BlockNumber, ooproxy); err != nil {
+	for range 5 {
+		t.Logf("waiting for the finalization period")
+		if err := wait.ForFinalizationPeriod(ctx, l1Client, receipt.BlockNumber, ooproxy); err == nil {
+			break
+		}
+	}
+
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -953,7 +1017,14 @@ func bridgeERC20FromL2ToL1(t *testing.T, ctx context.Context, l1Address common.A
 
 	t.Logf("assuming L2OutputOracle is at %s", ooproxy)
 
-	blockNumber, err := wait.ForOutputRootPublished(ctx, l1Client, ooproxy, receipt.BlockNumber)
+	var blockNumber uint64
+
+	for range 5 {
+		blockNumber, err = wait.ForOutputRootPublished(ctx, l1Client, ooproxy, receipt.BlockNumber)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1043,8 +1114,14 @@ func bridgeERC20FromL2ToL1(t *testing.T, ctx context.Context, l1Address common.A
 		break
 	}
 
-	t.Logf("waiting for the finalization period")
-	if err := wait.ForFinalizationPeriod(ctx, l1Client, receipt.BlockNumber, ooproxy); err != nil {
+	for range 5 {
+		t.Logf("waiting for the finalization period")
+		if err = wait.ForFinalizationPeriod(ctx, l1Client, receipt.BlockNumber, ooproxy); err == nil {
+			break
+		}
+	}
+
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1120,7 +1197,7 @@ func bridgeERC20FromL2ToL1(t *testing.T, ctx context.Context, l1Address common.A
 
 func waitForTxReceipt(t *testing.T, ctx context.Context, client *ethclient.Client, tx *types.Transaction) *types.Receipt {
 	t.Logf("will wait for receipt of tx %s", tx.Hash())
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	receipt, err := client.TransactionReceipt(ctx, tx.Hash())
 	if err != nil {
 		t.Logf("error getting tx receipt, will retry: %s", err)
@@ -1130,5 +1207,146 @@ func waitForTxReceipt(t *testing.T, ctx context.Context, client *ethclient.Clien
 	}
 }
 
+func assertSafeAndFinalBlocksAreProgressing(t *testing.T, ctx context.Context, l2Client *ethclient.Client) {
+	block, err := l2Client.BlockByNumber(ctx, big.NewInt(int64(rpc.SafeBlockNumber)))
+	if err != nil {
+		t.Fatalf("error getting safe block: %s", err)
+	}
+
+	if block.NumberU64() <= 0 {
+		t.Fatalf("safe block number should be greater than 0, received %d", block.NumberU64())
+	}
+
+	block, err = l2Client.BlockByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
+	if err != nil {
+		t.Fatalf("error getting finalized block: %s", err)
+	}
+
+	if block.NumberU64() <= 0 {
+		t.Fatalf("finalized block number should be greater than 0, received %d", block.NumberU64())
+	}
+}
+
+func assertOutputRootsAreTheSame(t *testing.T, ctx context.Context, l2Client *ethclient.Client, opNodeSequencingEndpoint string, opNodeNonSequencingEndpoint string) {
+	bigTip, err := l2Client.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("error getting l2 tip: %s", err)
+	}
+
+	tip := bigTip.Number.Uint64()
+
+	tip -= 5
+
+	t.Logf("checking output roots from tip %d", tip)
+
+	type outputAtBlock struct {
+		ID      int      `json:"id"`
+		Method  string   `json:"method"`
+		Params  []string `json:"params"`
+		JsonRpc string   `json:"jsonrpc"`
+	}
+
+	for tip != 0 {
+		hexTip := fmt.Sprintf("%#x", tip)
+		requestBody := outputAtBlock{
+			ID:      1,
+			Method:  "optimism_outputAtBlock",
+			Params:  []string{hexTip},
+			JsonRpc: "2.0",
+		}
+
+		jsonbody, err := json.Marshal(requestBody)
+		if err != nil {
+			t.Fatalf("error marshalling request body: %s", err)
+		}
+
+		t.Logf("sending request json body: %s", string(jsonbody))
+
+		client := &http.Client{}
+
+		res, err := client.Post(opNodeSequencingEndpoint, "application/json", bytes.NewBuffer(jsonbody))
+		if err != nil {
+			t.Fatalf("error making request to sequencer endpoint: %s", err)
+		}
+
+		res2, err := client.Post(opNodeNonSequencingEndpoint, "application/json", bytes.NewBuffer(jsonbody))
+		if err != nil {
+			t.Fatalf("error making request to sequencer endpoint: %s", err)
+		}
+
+		resBody, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("error reading response body from sequencer: %s", err)
+		}
+
+		resBody2, err := io.ReadAll(res2.Body)
+		if err != nil {
+			t.Fatalf("error reading response body from non-sequencer: %s", err)
+		}
+
+		res.Body.Close()
+		res2.Body.Close()
+
+		assertResultNotError := func(body *outputAtBlockResponse) error {
+			if body.Error != nil {
+				return fmt.Errorf("error in response body: %v", body)
+			}
+
+			return nil
+		}
+
+		var outputAtBlockResponseOne outputAtBlockResponse
+		var outputAtBlockResponseTwo outputAtBlockResponse
+
+		if err := json.Unmarshal(resBody, &outputAtBlockResponseOne); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := json.Unmarshal(resBody2, &outputAtBlockResponseTwo); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := assertResultNotError(&outputAtBlockResponseOne); err != nil {
+			t.Fatalf("error in response: %v", outputAtBlockResponseOne.Error)
+		}
+
+		if err := assertResultNotError(&outputAtBlockResponseTwo); err != nil {
+			t.Fatalf("error in response: %v", outputAtBlockResponseTwo.Error)
+		}
+
+		assertResultNotError(&outputAtBlockResponseOne)
+		assertResultNotError(&outputAtBlockResponseTwo)
+
+		if diff := deep.Equal(outputAtBlockResponseOne, outputAtBlockResponseTwo); len(diff) > 0 {
+			t.Fatalf("output roots are not the same: %s", diff)
+		}
+
+		tip--
+	}
+}
+
 // put here for readability
 const operatorFeeVaultCode = "60806040526004361061005e5760003560e01c80635c60da1b116100435780635c60da1b146100be5780638f283970146100f8578063f851a440146101185761006d565b80633659cfe6146100755780634f1ef286146100955761006d565b3661006d5761006b61012d565b005b61006b61012d565b34801561008157600080fd5b5061006b6100903660046106dd565b610224565b6100a86100a33660046106f8565b610296565b6040516100b5919061077b565b60405180910390f35b3480156100ca57600080fd5b506100d3610419565b60405173ffffffffffffffffffffffffffffffffffffffff90911681526020016100b5565b34801561010457600080fd5b5061006b6101133660046106dd565b6104b0565b34801561012457600080fd5b506100d3610517565b60006101577f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5490565b905073ffffffffffffffffffffffffffffffffffffffff8116610201576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602560248201527f50726f78793a20696d706c656d656e746174696f6e206e6f7420696e6974696160448201527f6c697a656400000000000000000000000000000000000000000000000000000060648201526084015b60405180910390fd5b3660008037600080366000845af43d6000803e8061021e573d6000fd5b503d6000f35b7fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035473ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16148061027d575033155b1561028e5761028b816105a3565b50565b61028b61012d565b60606102c07fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614806102f7575033155b1561040a57610305846105a3565b6000808573ffffffffffffffffffffffffffffffffffffffff16858560405161032f9291906107ee565b600060405180830381855af49150503d806000811461036a576040519150601f19603f3d011682016040523d82523d6000602084013e61036f565b606091505b509150915081610401576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152603960248201527f50726f78793a2064656c656761746563616c6c20746f206e657720696d706c6560448201527f6d656e746174696f6e20636f6e7472616374206661696c65640000000000000060648201526084016101f8565b91506104129050565b61041261012d565b9392505050565b60006104437fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16148061047a575033155b156104a557507f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5490565b6104ad61012d565b90565b7fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035473ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161480610509575033155b1561028e5761028b8161060c565b60006105417fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b73ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161480610578575033155b156104a557507fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc81815560405173ffffffffffffffffffffffffffffffffffffffff8316907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b90600090a25050565b60006106367fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035490565b7fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61038381556040805173ffffffffffffffffffffffffffffffffffffffff80851682528616602082015292935090917f7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f910160405180910390a1505050565b803573ffffffffffffffffffffffffffffffffffffffff811681146106d857600080fd5b919050565b6000602082840312156106ef57600080fd5b610412826106b4565b60008060006040848603121561070d57600080fd5b610716846106b4565b9250602084013567ffffffffffffffff8082111561073357600080fd5b818601915086601f83011261074757600080fd5b81358181111561075657600080fd5b87602082850101111561076857600080fd5b6020830194508093505050509250925092565b600060208083528351808285015260005b818110156107a85785810183015185820160400152820161078c565b818111156107ba576000604083870101525b50601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe016929092016040019392505050565b818382376000910190815291905056fea164736f6c634300080f000a"
+
+type outputAtBlockResponse struct {
+	Jsonrpc string       `json:"jsonrpc"`
+	ID      int          `json:"id"`
+	Error   *interface{} `json:"error,omitempty"`
+	Result  struct {
+		Version    string `json:"version"`
+		OutputRoot string `json:"outputRoot"`
+		BlockRef   struct {
+			Hash       string `json:"hash"`
+			Number     int    `json:"number"`
+			ParentHash string `json:"parentHash"`
+			Timestamp  int    `json:"timestamp"`
+			L1Origin   struct {
+				Hash   string `json:"hash"`
+				Number int    `json:"number"`
+			} `json:"l1origin"`
+			SequenceNumber int `json:"sequenceNumber"`
+		} `json:"blockRef"`
+		WithdrawalStorageRoot string `json:"withdrawalStorageRoot"`
+		StateRoot             string `json:"stateRoot"`
+	} `json:"result"`
+}

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -28,7 +28,7 @@ COPY --from=build_1 /git/op-geth /git/op-geth
 WORKDIR /git
 RUN git clone https://github.com/hemilabs/optimism
 WORKDIR /git/optimism
-RUN git checkout bde08fd3e335c235455b4cee6a6f8dbf88446201
+RUN git checkout ea9fe7b4f2e10f2573934957f4808d8494cfeb9f
 
 WORKDIR /git/optimism
 RUN go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
+	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.5
 	github.com/coder/websocket v1.8.12
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
@@ -29,6 +30,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.3
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/testcontainers/testcontainers-go v0.32.0
+	github.com/tyler-smith/go-bip39 v1.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcwallet/wallet/txsizes v1.2.5 h1:93o5Xz9dYepBP4RMFUc9RGIFXwqP2volSWRkYJFrNtI=
+github.com/btcsuite/btcwallet/wallet/txsizes v1.2.5/go.mod h1:lQ+e9HxZ85QP7r3kdxItkiMSloSLg1PEGis5o5CXUQw=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
@@ -236,6 +238,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
+github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=

--- a/localnode/docker-compose.yml
+++ b/localnode/docker-compose.yml
@@ -237,7 +237,7 @@ services:
   # Hemi op-node
   op-node:
     # yamllint disable-line rule:line-length
-    image: "ghcr.io/hemilabs/op-node:bde08fd@sha256:4b366d60a140b096c94d071a03ec3338820dacbbec60a3e857ad2561c4e8bb39"
+    image: "ghcr.io/hemilabs/op-node:ea9fe7b@sha256:7110e3c4c61e495ea0a6621d7ec211ceb7e948e25c648b05bd51fcc557ad06bc"
     platform: linux/amd64
     profiles: ["hemi", "hemi-min", "full"]
     depends_on:

--- a/localnode/docker-compose_mainnet.yml
+++ b/localnode/docker-compose_mainnet.yml
@@ -235,7 +235,7 @@ services:
   # Hemi op-node
   op-node:
     # yamllint disable-line rule:line-length
-    image: "ghcr.io/hemilabs/op-node:a356ee2@sha256:6a47b7ac380f76565d3b554484e12b6976bda7aef4938098f2bebff5813eb8e5"
+    image: "ghcr.io/hemilabs/op-node:ea9fe7b@sha256:7110e3c4c61e495ea0a6621d7ec211ceb7e948e25c648b05bd51fcc557ad06bc"
     platform: linux/amd64
     profiles: ["hemi", "hemi-min", "full"]
     depends_on:

--- a/service/hproxy/ethereum.go
+++ b/service/hproxy/ethereum.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
 package hproxy
 
 import (
@@ -39,7 +43,7 @@ func ethID() uint64 {
 	return binary.LittleEndian.Uint64(buf)
 }
 
-func CallEthereum(c *http.Client, url, method string, params []any) ([]byte, error) {
+func CallEthereum(ctx context.Context, c *http.Client, url, method string, params []any) ([]byte, error) {
 	ec := EthereumCall{
 		Method:  method,
 		Params:  params,
@@ -50,7 +54,13 @@ func CallEthereum(c *http.Client, url, method string, params []any) ([]byte, err
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(url, "application/json", bytes.NewBuffer(jec))
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(jec))
+	// resp, err := c.Post(url, "application/json", bytes.NewBuffer(jec))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := c.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/service/hproxy/ethereum.go
+++ b/service/hproxy/ethereum.go
@@ -55,7 +55,6 @@ func CallEthereum(ctx context.Context, c *http.Client, url, method string, param
 		return nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(jec))
-	// resp, err := c.Post(url, "application/json", bytes.NewBuffer(jec))
 	if err != nil {
 		return nil, err
 	}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -396,6 +396,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 		// Only call same host when healthy
 		if s.hvmHandlers[v].state == StateHealthy {
 			id = v
+			// XXX reset timer for reuse here
 		} else {
 			// hvm died, remove persistence
 			delete(s.clients, r.RemoteAddr)
@@ -417,6 +418,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 			// Add connection to candidate
 			s.clients[r.RemoteAddr] = id
 			s.hvmHandlers[id].connections++
+			// XXX set timer for reuse here
 		}
 	}
 	s.mtx.Unlock()

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -182,10 +182,21 @@ func (s *Server) health(ctx context.Context) (bool, any, error) {
 	return s.isHealthy(ctx), health{Healthy: true, Remove: "FIXME"}, nil // XXX
 }
 
+type HVMState int
+
+const (
+	StateInvalid   HVMState = 0
+	StateHealthy            = 1
+	StateUnhealthy          = 2
+	StateRemoved            = 3
+)
+
 type HVMHandler struct {
 	id int // server id
 	rp *httputil.ReverseProxy
 	u  *url.URL // XXX remove?
+
+	state HVMState
 }
 
 func lowest(x []int) int {

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -166,6 +166,22 @@ func (s *Server) promRunning() float64 {
 	return 0
 }
 
+func (s *Server) isHealthy(_ context.Context) bool {
+	return true // XXX
+}
+
+func (s *Server) health(ctx context.Context) (bool, any, error) {
+	log.Tracef("health")
+	defer log.Tracef("health exit")
+
+	type health struct {
+		Healthy bool   `json:"health"`
+		Remove  string `json:"remove"`
+	}
+
+	return s.isHealthy(ctx), health{Healthy: true, Remove: "FIXME"}, nil // XXX
+}
+
 type HVMHandler struct {
 	id int // server id
 	rp *httputil.ReverseProxy
@@ -295,7 +311,7 @@ func (s *Server) Run(pctx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			if err := d.Run(ctx, s.Collectors(), nil); !errors.Is(err, context.Canceled) {
+			if err := d.Run(ctx, s.Collectors(), s.health); !errors.Is(err, context.Canceled) {
 				log.Errorf("prometheus terminated with error: %v", err)
 				return
 			}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package hproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/hemilabs/heminetwork/service/deucalion"
+	"github.com/hemilabs/heminetwork/service/pprof"
+)
+
+const (
+	logLevel = "INFO"
+
+	promSubsystem = "hproxy_service" // Prometheus
+
+)
+
+var log = loggo.GetLogger("hproxy")
+
+func init() {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
+		panic(err)
+	}
+}
+
+type Config struct {
+	HVMURLs                 []string
+	Network                 string
+	RequestTimeout          time.Duration
+	LogLevel                string
+	PrometheusListenAddress string
+	PprofListenAddress      string
+}
+
+const DefaultRequestTimeout = 9 * time.Second // Smaller than 12s
+
+func NewDefaultConfig() *Config {
+	return &Config{
+		Network:        "mainnet",
+		RequestTimeout: DefaultRequestTimeout,
+	}
+}
+
+type HProxy struct {
+	mtx sync.RWMutex
+	wg  sync.WaitGroup
+
+	cfg *Config
+
+	// Prometheus
+	isRunning bool
+}
+
+func NewHProxy(cfg *Config) (*HProxy, error) {
+	if cfg == nil {
+		cfg = NewDefaultConfig()
+	}
+	if cfg.RequestTimeout <= 0 {
+		cfg.RequestTimeout = DefaultRequestTimeout
+	}
+
+	hp := &HProxy{
+		cfg: cfg,
+	}
+
+	switch strings.ToLower(cfg.Network) {
+	case "mainnet":
+	case "sepolia":
+	default:
+		return nil, fmt.Errorf("unknown network %q", cfg.Network)
+	}
+
+	return hp, nil
+}
+
+func (h *HProxy) handlePrometheus(ctx context.Context) error {
+	d, err := deucalion.New(&deucalion.Config{
+		ListenAddress: h.cfg.PrometheusListenAddress,
+	})
+	if err != nil {
+		return fmt.Errorf("create server: %w", err)
+	}
+	cs := []prometheus.Collector{
+		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Subsystem: promSubsystem,
+			Name:      "running",
+			Help:      "Is hproxy service running.",
+		}, h.promRunning),
+	}
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		if err := d.Run(ctx, cs, nil); !errors.Is(err, context.Canceled) {
+			log.Errorf("prometheus terminated with error: %v", err)
+			return
+		}
+		log.Infof("prometheus clean shutdown")
+	}()
+
+	return nil
+}
+
+func (h *HProxy) running() bool {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+	return h.isRunning
+}
+
+func (h *HProxy) testAndSetRunning(b bool) bool {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+	old := h.isRunning
+	h.isRunning = b
+	return old != h.isRunning
+}
+
+func (h *HProxy) promRunning() float64 {
+	r := h.running()
+	if r {
+		return 1
+	}
+	return 0
+}
+
+type ProxyHandler struct {
+	p      *httputil.ReverseProxy
+	remote *url.URL
+}
+
+func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Infof("ServeHTTP %v", r.URL)
+	w.Header().Set("X-Cow", "Moo")
+	r.Host = p.remote.Host
+	p.p.ServeHTTP(w, r)
+}
+
+func (h *HProxy) Run(pctx context.Context) error {
+	if !h.testAndSetRunning(true) {
+		return errors.New("hproxy already running")
+	}
+	defer h.testAndSetRunning(false)
+
+	// Validate urls
+	if len(h.cfg.HVMURLs) == 0 {
+		return errors.New("must provide hvm url(s)")
+	}
+	for k := range h.cfg.HVMURLs {
+		u, err := url.Parse(h.cfg.HVMURLs[k])
+		if err != nil {
+			return fmt.Errorf("invalid url %v: %v", h.cfg.HVMURLs[k], err)
+		}
+		switch u.Scheme {
+		case "http", "https":
+		default:
+			return fmt.Errorf("unsuported scheme [%v]: %v", k, u.Scheme)
+		}
+
+		proxy := httputil.NewSingleHostReverseProxy(u)
+		// use http.Handle instead of http.HandleFunc when your struct implements http.Handler interface
+		http.Handle("/", &ProxyHandler{p: proxy, remote: u})
+		err = http.ListenAndServe(":8080", nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(pctx)
+	defer cancel()
+
+	// Prometheus
+	if h.cfg.PrometheusListenAddress != "" {
+		if err := h.handlePrometheus(ctx); err != nil {
+			return fmt.Errorf("handlePrometheus: %w", err)
+		}
+	}
+
+	// pprof
+	if h.cfg.PprofListenAddress != "" {
+		p, err := pprof.NewServer(&pprof.Config{
+			ListenAddress: h.cfg.PprofListenAddress,
+		})
+		if err != nil {
+			return fmt.Errorf("create pprof server: %w", err)
+		}
+		h.wg.Add(1)
+		go func() {
+			defer h.wg.Done()
+			if err := p.Run(ctx); !errors.Is(err, context.Canceled) {
+				log.Errorf("pprof server terminated with error: %v", err)
+				return
+			}
+			log.Infof("pprof server clean shutdown")
+		}()
+	}
+
+	log.Infof("Starting hproxy")
+
+	var err error
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+	cancel()
+
+	log.Infof("hproxy shutting down...")
+
+	h.wg.Wait()
+	log.Infof("hproxy shutdown cleanly")
+
+	return err
+}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -176,6 +176,8 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 	// Select host to call
 	hvm := s.hvmHandlers[0]
 
+	// XXX handle aggressive timeputs for ServeHTTP
+
 	// Throw call over the fence
 	hvm.rp.ServeHTTP(w, r)
 

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/juju/loggo"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -194,6 +193,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Hproxy", "Moo") // return to caller
 
 	// Select host to call
+	// XXX expire client connections at some point
 	s.mtx.Lock()
 	var (
 		id int
@@ -204,7 +204,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 		for _, v := range s.clients {
 			connections[v]++
 		}
-		spew.Dump(connections)
+		// spew.Dump(connections)
 		id = lowest(connections)
 		s.clients[r.RemoteAddr] = id
 	}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -110,6 +110,7 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		ControlAddress:      DefaultControlAddress,
 		ListenAddress:       DefaultListenAddress,
+		PollFrequency:       DefaultPollFrequency,
 		Network:             "mainnet",
 		PrometheusNamespace: appName,
 		RequestTimeout:      DefaultRequestTimeout,
@@ -434,6 +435,8 @@ func (s *Server) nodeAdd(node string) error {
 				DialContext:           dialer,
 				TLSHandshakeTimeout:   5 * time.Second,
 				ResponseHeaderTimeout: s.cfg.RequestTimeout,
+				MaxIdleConnsPerHost:   1,
+				MaxConnsPerHost:       1,
 			},
 			FlushInterval:  0,
 			ErrorLog:       nil, // XXX wrap in loggo

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -314,6 +314,9 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 		// Only call same host when healthy
 		if s.hvmHandlers[v].state == StateHealthy {
 			id = v
+		} else {
+			// hvm died, remove persistence
+			delete(s.clients, r.RemoteAddr)
 		}
 	}
 

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -341,11 +341,14 @@ func (s *Server) isHealthy(_ context.Context) bool {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	for k := range s.hvmHandlers {
-		if s.hvmHandlers[k].state == StateHealthy {
-			return true
+		// If we see a single hvm unhealthy bail with unhealthy status.
+		// XXX i think this is technically correct but we do return
+		// 503 to the caller here.
+		if s.hvmHandlers[k].state == StateUnhealthy {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func (s *Server) health(ctx context.Context) (bool, any, error) {

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -210,6 +210,8 @@ func (s *Server) Run(pctx context.Context) error {
 					r.SetURL(u)
 					// r.Out.Host = r.In.Host // XXX yes/no?
 				},
+				ErrorLog:     nil, // XXX wrap in loggo
+				ErrorHandler: nil, // XXX add this to deal with errors
 			},
 			u: u, // XXX do we need this?
 		})

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -47,8 +47,6 @@ const (
 
 	logLevel = "INFO"
 
-	promSubsystem = "hproxy_service" // Prometheus
-
 	// XXX think about these durations
 	DefaultRequestTimeout = 9 * time.Second  // Smaller than 12s
 	DefaultPollFrequency  = 11 * time.Second // Smaller than 12s
@@ -385,20 +383,6 @@ type HVMHandler struct {
 	state  HVMState // Do NOT directly set, use utility functions!
 }
 
-func (s *Server) lowest(x []int) int {
-	if len(x) == 0 {
-		return -1
-	}
-
-	minIndex := 0
-	for i := 1; i < len(x); i++ {
-		if x[i] < x[minIndex] {
-			minIndex = i
-		}
-	}
-	return minIndex
-}
-
 func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("handleProxyRequest: %v", r.RemoteAddr)
 	defer log.Tracef("handleProxyRequest exit: %v", r.RemoteAddr)
@@ -548,7 +532,7 @@ func (s *Server) nodeAdd(node string) error {
 	// For now, everything is ethereum but we can use the poker function to
 	// handle different types health checks.
 	hvmHandler.poker = NewEthereumProxy(func(ctx context.Context) error {
-		resp, err := CallEthereum(hvmHandler.c, hvmHandler.u.String(),
+		resp, err := CallEthereum(ctx, hvmHandler.c, hvmHandler.u.String(),
 			"eth_blockNumber", nil)
 		if err != nil {
 			return err

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -57,9 +57,9 @@ const (
 	expectedClients = 1000
 
 	routeControl       = "/v1/control"
-	routeControlAdd    = routeControl + "/add"
-	routeControlRemove = routeControl + "/remove"
-	routeControlList   = routeControl + "/list"
+	RouteControlAdd    = routeControl + "/add"
+	RouteControlRemove = routeControl + "/remove"
+	RouteControlList   = routeControl + "/list"
 )
 
 var log = loggo.GetLogger(appName)
@@ -740,7 +740,7 @@ func (s *Server) handleControlAddRequest(w http.ResponseWriter, r *http.Request)
 	err := json.NewDecoder(r.Body).Decode(&ns)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		log.Errorf("%v %v: %v", routeControlAdd, r.RemoteAddr, err) // too loud?
+		log.Errorf("%v %v: %v", RouteControlAdd, r.RemoteAddr, err) // too loud?
 		return
 	}
 
@@ -756,7 +756,7 @@ func (s *Server) handleControlAddRequest(w http.ResponseWriter, r *http.Request)
 	err = json.NewEncoder(w).Encode(nes)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Errorf("%v %v: %v", routeControlAdd, r.RemoteAddr, err) // too loud?
+		log.Errorf("%v %v: %v", RouteControlAdd, r.RemoteAddr, err) // too loud?
 		return
 	}
 }
@@ -769,7 +769,7 @@ func (s *Server) handleControlRemoveRequest(w http.ResponseWriter, r *http.Reque
 	err := json.NewDecoder(r.Body).Decode(&ns)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		log.Errorf("%v %v: %v", routeControlRemove, r.RemoteAddr, err) // too loud?
+		log.Errorf("%v %v: %v", RouteControlRemove, r.RemoteAddr, err) // too loud?
 		return
 	}
 
@@ -785,7 +785,7 @@ func (s *Server) handleControlRemoveRequest(w http.ResponseWriter, r *http.Reque
 	err = json.NewEncoder(w).Encode(nes)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Errorf("%v %v: %v", routeControlRemove, r.RemoteAddr, err) // too loud?
+		log.Errorf("%v %v: %v", RouteControlRemove, r.RemoteAddr, err) // too loud?
 		return
 	}
 }
@@ -869,9 +869,9 @@ func (s *Server) Run(pctx context.Context) error {
 	ctrlHttpErrCh := make(chan error)
 	if s.cfg.ControlAddress != "" {
 		cmux := http.NewServeMux()
-		handle("Control", cmux, routeControlAdd, s.handleControlAddRequest)
-		handle("Control", cmux, routeControlRemove, s.handleControlRemoveRequest)
-		handle("Control", cmux, routeControlList, s.handleControlListRequest)
+		handle("Control", cmux, RouteControlAdd, s.handleControlAddRequest)
+		handle("Control", cmux, RouteControlRemove, s.handleControlRemoveRequest)
+		handle("Control", cmux, RouteControlList, s.handleControlListRequest)
 
 		ctrlHttpServer := &http.Server{
 			Addr:        s.cfg.ControlAddress,

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -374,8 +374,8 @@ func TestFanout(t *testing.T) {
 	wg.Wait()
 	cancel()
 
-	// Allow 20% variance
-	acceptable := (clientCount / serverCount) / (100 / 20)
+	// Allow 30% variance
+	acceptable := (clientCount / serverCount) / (100 / 30)
 	upperBound := (clientCount / serverCount) + acceptable
 	lowerBound := (clientCount / serverCount) - acceptable
 	total := 0

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -65,6 +65,7 @@ func newHproxy(t *testing.T, servers []string) (*Server, *Config) {
 	hpCfg.HVMURLs = servers
 	hpCfg.LogLevel = "hproxy=TRACE" // XXX figure out why this isn't working
 	hpCfg.RequestTimeout = time.Second
+	hpCfg.PollFrequency = time.Second
 	hp, err := NewServer(hpCfg)
 	if err != nil {
 		t.Fatal(err)
@@ -193,7 +194,7 @@ func TestFanout(t *testing.T) {
 
 	// Setup hproxy
 	_, hpCfg := newHproxy(t, servers)
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond) // Let proxies be marked healthy
 
 	// clients
 	var (

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+
+	"github.com/hemilabs/heminetwork/testutil"
 )
 
 type serverReply struct {
@@ -72,6 +74,8 @@ func newHproxy(t *testing.T, servers []string) (*Server, *Config) {
 	hpCfg.LogLevel = "hproxy=TRACE" // XXX figure out why this isn't working
 	hpCfg.RequestTimeout = time.Second
 	hpCfg.PollFrequency = time.Second
+	hpCfg.ListenAddress = "127.0.0.1:" + testutil.FreePort()
+	hpCfg.ControlAddress = "127.0.0.1:" + testutil.FreePort()
 	hp, err := NewServer(hpCfg)
 	if err != nil {
 		t.Fatal(err)

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -332,7 +332,7 @@ func TestProxyPersistence(t *testing.T) {
 		}
 		// Discard so that we can reuse connection
 		if _, err := io.Copy(ioutil.Discard, reply.Body); err != nil {
-			// t.Fatal(err)
+			t.Fatal(err)
 		}
 
 		am.Lock()

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -1,0 +1,105 @@
+package hproxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+type serverReply struct {
+	ID    int   `json:"id"`
+	Error error `json:"error,omitempty"`
+}
+
+func newServer(x int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := serverReply{ID: x}
+		err := json.NewEncoder(w).Encode(id)
+		if err != nil {
+			panic(err)
+		}
+	}))
+}
+
+func TestFanout(t *testing.T) {
+	serverCount := 5
+
+	servers := make([]string, 0, serverCount)
+	for i := 0; i < serverCount; i++ {
+		s := newServer(i)
+		defer s.Close()
+
+		// Verify url
+		_, err := url.Parse(s.URL)
+		if err != nil {
+			t.Fatalf("server %v: %v", i, err)
+		}
+		servers = append(servers, s.URL)
+	}
+
+	testDuration := 5 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	defer cancel()
+
+	// Setup hproxy
+	hpCfg := NewDefaultConfig()
+	hpCfg.HVMURLs = servers
+	hpCfg.LogLevel = "TRACE"
+	hp, err := NewServer(hpCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		err = hp.Run(ctx)
+		if err != nil && err != context.Canceled {
+			panic(err)
+		}
+	}()
+	time.Sleep(250 * time.Millisecond)
+
+	// clients
+	var (
+		wg sync.WaitGroup
+		am sync.Mutex
+	)
+	clientCount := serverCount * 10
+	answers := make([]int, serverCount)
+	for i := 0; i < clientCount; i++ {
+		wg.Add(1)
+		go func(x int) {
+			defer wg.Done()
+			reply, err := http.Get("http://" + hpCfg.ListenAddress)
+			if err != nil {
+				t.Fatalf("get %v: %v", x, err)
+			}
+			defer reply.Body.Close()
+			var jr serverReply
+			err = json.NewDecoder(reply.Body).Decode(&jr)
+			if err != nil {
+				t.Fatalf("decode %v: %v", x, err)
+			}
+			am.Lock()
+			answers[jr.ID]++
+			am.Unlock()
+		}(i)
+	}
+
+	wg.Wait()
+	cancel()
+
+	// Allow 10% variance
+	acceptable := (clientCount / serverCount) / (100 / 10)
+	upperBound := (clientCount / serverCount) + acceptable
+	lowerBound := (clientCount / serverCount) - acceptable
+	for k, v := range answers {
+		if v < lowerBound || v > upperBound {
+			t.Fatalf("%v out of bounds lower %v upper %v got %v",
+				k, lowerBound, upperBound, v)
+		}
+	}
+}

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -171,7 +171,7 @@ func TestProxy(t *testing.T) {
 
 	// Setup hproxy
 	_, hpCfg := newHproxy(t, servers)
-	time.Sleep(250 * time.Millisecond) // XXX
+	time.Sleep(250 * time.Millisecond)
 
 	// Send command
 	err := request(serverID, hpCfg)
@@ -273,7 +273,7 @@ func TestFanout(t *testing.T) {
 	}
 }
 
-func TestProxyPersistence(t *testing.T) {
+func TestPersistence(t *testing.T) {
 	serverCount := 5
 
 	servers := make([]string, 0, serverCount)


### PR DESCRIPTION
**Summary**
proxyd tried to solve all problems and per the laws of physics, it made everything worse.

hproxy is a dead simple replacement that throws opgeth commands over the fence and maintains a list of concurrent nodes.

**Changes**
No changes, all greenfield.
