### PR TITLE
hproxy: a much simpler proxyd replacement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ cmds = \
 	bssd	\
 	extool	\
 	hemictl	\
+	hproxyd	\
 	keygen	\
 	popmd	\
 	tbcd

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -14,6 +14,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"os/user"
@@ -47,6 +48,7 @@ import (
 	"github.com/hemilabs/heminetwork/database/tbcd"
 	"github.com/hemilabs/heminetwork/database/tbcd/level"
 	"github.com/hemilabs/heminetwork/hemi/pop"
+	"github.com/hemilabs/heminetwork/service/hproxy"
 	"github.com/hemilabs/heminetwork/service/tbc"
 	"github.com/hemilabs/heminetwork/service/tbc/peer"
 	"github.com/hemilabs/heminetwork/version"
@@ -248,6 +250,172 @@ func directLevel(pctx context.Context, flags []string) error {
 		if err != nil {
 			return fmt.Errorf("leveldb close: %w", err)
 		}
+	default:
+		return fmt.Errorf("invalid action: %v", action)
+	}
+
+	return nil
+}
+
+func httpCall(ctx context.Context, method, url string, requestBody io.Reader) (io.ReadCloser, error) {
+	c := http.DefaultClient
+	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	reply, err := c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http.do: %w", err)
+	}
+	switch reply.StatusCode {
+	case http.StatusOK:
+	default:
+		return nil, fmt.Errorf("status %v", reply.StatusCode)
+	}
+	return reply.Body, nil
+}
+
+func hproxyctl(pctx context.Context, flags []string) error {
+	flagSet := flag.NewFlagSet("hproxy commands", flag.ExitOnError)
+	var (
+		helpFlag     = flagSet.Bool("h", false, "displays help information")
+		helpLongFlag = flagSet.Bool("help", false, "displays help information")
+	)
+
+	flagSet.Usage = func() {
+		fmt.Fprintf(os.Stderr, "%v\n", welcome)
+		fmt.Fprintf(os.Stderr, "Usage: %v hproxy [OPTION]... [ACTION] [<args>]\n\n", os.Args[0])
+		fmt.Println("COMMAND OVERVIEW:")
+		fmt.Println("\tThe 'hproxy' command allows you to issues commands to hproxy .")
+		fmt.Println("")
+		fmt.Println("OPTIONS:")
+		fmt.Println("\t-h, -help\tDisplay help information")
+		fmt.Println("\t-debug   \tEnable debug mode (required for certain actions)")
+		fmt.Println("")
+		fmt.Println("ACTIONS:")
+		fmt.Println("\tadd [hproxy=hproxy_address] <hvm=url,...>")
+		fmt.Println("\tlist [hproxy=hproxy_address]")
+		fmt.Println("\tremove [hproxy=hproxy_address] <hvm=url,...>")
+		fmt.Println("")
+		fmt.Println("ARGUMENTS:")
+		fmt.Println("\tThe action arguments are expected to be passed in as a key/value pair.")
+		fmt.Println("\tNote that the hvm parameter is comma separated.")
+		fmt.Fprintf(os.Stderr, "\tExample: '%v hproxy add hvm=\"http://1.2.3.4\"'\n", os.Args[0])
+	}
+
+	err := flagSet.Parse(flags)
+	if err != nil {
+		return err
+	}
+
+	if len(flags) < 1 || *helpFlag || *helpLongFlag {
+		flagSet.Usage()
+		return nil
+	}
+
+	action, args, err := parseArgs(flagSet.Args())
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(pctx)
+	defer cancel()
+
+	// commands
+	switch action {
+	// utility
+	case "add":
+		hp := args["hproxy"]
+		if hp == "" {
+			hp = hproxy.DefaultControlAddress
+		}
+		hvm := args["hvm"]
+		if hvm == "" {
+			return fmt.Errorf("hvm must be set")
+		}
+		hvms := strings.Split(hvm, ",")
+		r := make([]map[string]any, len(hvms))
+		for k := range hvms {
+			r[k] = make(map[string]any)
+			r[k]["node_url"] = hvms[k]
+		}
+		req, err := json.Marshal(r)
+		if err != nil {
+			return fmt.Errorf("request: %w", err)
+		}
+		request := bytes.NewReader(req)
+		body, err := httpCall(ctx, http.MethodGet, "http://"+hp+hproxy.RouteControlAdd, request)
+		if err != nil {
+			return err
+		}
+		defer body.Close()
+
+		var jr []map[string]interface{}
+		err = json.NewDecoder(body).Decode(&jr)
+		if err != nil {
+			return fmt.Errorf("decode: %w", err)
+		}
+		for _, v := range jr {
+			fmt.Printf("node: %v error: %v\n", v["node_url"], v["error"])
+		}
+
+	case "list":
+		hp := args["hproxy"]
+		if hp == "" {
+			hp = hproxy.DefaultControlAddress
+		}
+		body, err := httpCall(ctx, http.MethodGet, "http://"+hp+hproxy.RouteControlList, nil)
+		if err != nil {
+			return err
+		}
+		defer body.Close()
+
+		var jr []map[string]interface{}
+		err = json.NewDecoder(body).Decode(&jr)
+		if err != nil {
+			return fmt.Errorf("decode: %w", err)
+		}
+		for _, v := range jr {
+			fmt.Printf("node: %v status: %v connections: %v\n",
+				v["node_url"], v["status"], v["connections"])
+		}
+
+	case "remove":
+		hp := args["hproxy"]
+		if hp == "" {
+			hp = hproxy.DefaultControlAddress
+		}
+		hvm := args["hvm"]
+		if hvm == "" {
+			return fmt.Errorf("hvm must be set")
+		}
+		hvms := strings.Split(hvm, ",")
+		r := make([]map[string]any, len(hvms))
+		for k := range hvms {
+			r[k] = make(map[string]any)
+			r[k]["node_url"] = hvms[k]
+		}
+		req, err := json.Marshal(r)
+		if err != nil {
+			return fmt.Errorf("request: %w", err)
+		}
+		request := bytes.NewReader(req)
+		body, err := httpCall(ctx, http.MethodGet, "http://"+hp+hproxy.RouteControlRemove, request)
+		if err != nil {
+			return err
+		}
+		defer body.Close()
+
+		var jr []map[string]interface{}
+		err = json.NewDecoder(body).Decode(&jr)
+		if err != nil {
+			return fmt.Errorf("decode: %w", err)
+		}
+		for _, v := range jr {
+			fmt.Printf("node: %v error: %v\n", v["node_url"], v["error"])
+		}
+
 	default:
 		return fmt.Errorf("invalid action: %v", action)
 	}
@@ -1354,6 +1522,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\tp2p\t\tp2p commands\n")
 	fmt.Fprintf(os.Stderr, "\ttbcdb\t\tdatabase open (tbcd must not be running)\n")
 	fmt.Fprintf(os.Stderr, "\tlevel\t\tdb manipulation\n\n")
+	fmt.Fprintf(os.Stderr, "\thproxy\t\tcontroller\n\n")
 	fmt.Fprintf(os.Stderr, "ENVIRONMENT:\n")
 	config.Help(os.Stderr, cm)
 	fmt.Fprintf(os.Stderr, "\nuse 'hemictl <command> -h' or 'hemictl <command> -help' to"+
@@ -1597,6 +1766,8 @@ func _main(args []string) error {
 		return client("bss")
 	case "p2p":
 		return p2p(args[1:])
+	case "hproxy":
+		return hproxyctl(ctx, args[1:])
 	default:
 		return fmt.Errorf("unknown action: %v", cmd)
 	}

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/juju/loggo"
+
+	"github.com/hemilabs/heminetwork/config"
+	"github.com/hemilabs/heminetwork/service/hproxy"
+	"github.com/hemilabs/heminetwork/version"
+)
+
+const (
+	daemonName      = "hproxyd"
+	defaultLogLevel = daemonName + "=INFO;hproxy=INFO"
+)
+
+var (
+	log     = loggo.GetLogger(daemonName)
+	welcome string
+
+	cfg = hproxy.NewDefaultConfig()
+	cm  = config.CfgMap{
+		"HPROXY_CLIENT_IDLE_TIMEOUT": config.Config{
+			Value:        &cfg.ClientIdleTimeout,
+			DefaultValue: hproxy.DefaultClientIdleTimeout,
+			Help:         "max idle time to persists hvm reuse per client",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_HVM_URLS": config.Config{
+			Value:        &cfg.HVMURLs,
+			DefaultValue: cfg.HVMURLs,
+			Help:         "comma separated HVM URLs",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_LOG_LEVEL": config.Config{
+			Value:        &cfg.LogLevel,
+			DefaultValue: defaultLogLevel,
+			Help:         "loglevel for various packages; INFO, DEBUG and TRACE",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_CONTROL_ADDRESS": config.Config{
+			Value:        &cfg.ControlAddress,
+			DefaultValue: hproxy.DefaultControlAddress,
+			Help:         "control address for incomming commands",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_LISTEN_ADDRESS": config.Config{
+			Value:        &cfg.ListenAddress,
+			DefaultValue: hproxy.DefaultListenAddress,
+			Help:         "listen address for incomming connections",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_NETWORK": config.Config{
+			Value:        &cfg.Network,
+			DefaultValue: "sepolia", // XXX
+			Help:         "ethereum network (ex. \"mainnet\", \"sepolia\")",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_PROMETHEUS_ADDRESS": config.Config{
+			Value:        &cfg.PrometheusListenAddress,
+			DefaultValue: "",
+			Help:         "address and port hproxy prometheus listens on",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_PPROF_ADDRESS": config.Config{
+			Value:        &cfg.PprofListenAddress,
+			DefaultValue: "",
+			Help:         "address and port hproxy pprof listens on (open <address>/debug/pprof to see available profiles)",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_POLL_FREQUENCY": config.Config{
+			Value:        &cfg.PollFrequency,
+			DefaultValue: hproxy.DefaultPollFrequency,
+			Help:         "frequency that hproxy pokes nodes for health information",
+			Print:        config.PrintAll,
+		},
+		"HPROXY_REQUEST_TIMEOUT": config.Config{
+			Value:        &cfg.RequestTimeout,
+			DefaultValue: cfg.RequestTimeout,
+			Help:         "HVM request timeout",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
+		},
+	}
+)
+
+func handleSignals(ctx context.Context, cancel context.CancelFunc, callback func(os.Signal)) {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+	defer func() {
+		signal.Stop(signalChan)
+		cancel()
+	}()
+
+	select {
+	case <-ctx.Done():
+	case s := <-signalChan: // First signal, cancel context.
+		if callback != nil {
+			callback(s) // Do whatever caller wants first.
+			cancel()
+		}
+	}
+	<-signalChan // Second signal, hard exit.
+	os.Exit(2)
+}
+
+func _main() error {
+	if err := config.Parse(cm); err != nil {
+		return err
+	}
+
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		return err
+	}
+	log.Infof("%v", welcome)
+
+	pc := config.PrintableConfig(cm)
+	for k := range pc {
+		log.Infof("%v", pc[k])
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go handleSignals(ctx, cancel, func(s os.Signal) {
+		log.Infof("hproxy service received signal: %s", s)
+	})
+
+	hp, err := hproxy.NewServer(cfg)
+	if err != nil {
+		return fmt.Errorf("create hproxy: %w", err)
+	}
+	if err := hp.Run(ctx); !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("hproxy service terminated: %w", err)
+	}
+
+	return nil
+}
+
+func init() {
+	version.Component = "hproxyd"
+	welcome = "Hemi Proxy" + version.BuildInfo()
+}
+
+func main() {
+	if len(os.Args) != 1 {
+		fmt.Fprintf(os.Stderr, "%v\n", welcome)
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "\thelp (this help)\n")
+		fmt.Fprintf(os.Stderr, "Environment:\n")
+		config.Help(os.Stderr, cm)
+		os.Exit(1)
+	}
+
+	if err := _main(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/service/hproxy/ethereum.go
+++ b/service/hproxy/ethereum.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package hproxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+)
+
+type Proxy interface {
+	Poke(ctx context.Context) error
+}
+
+type EthereumProxy struct {
+	f func(ctx context.Context) error
+}
+
+var _ Proxy = EthereumProxy{}
+
+const EthereumVersion = "2.0"
+
+type EthereumCall struct {
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+	ID      uint64 `json:"id"`
+	Version string `json:"jsonrpc"`
+}
+
+func ethID() uint64 {
+	buf := make([]byte, 8)
+	_, err := rand.Read(buf)
+	if err != nil {
+		panic(err)
+	}
+	return binary.LittleEndian.Uint64(buf)
+}
+
+func CallEthereum(ctx context.Context, c *http.Client, url, method string, params []any) ([]byte, error) {
+	ec := EthereumCall{
+		Method:  method,
+		Params:  params,
+		ID:      ethID(),
+		Version: EthereumVersion,
+	}
+	jec, err := json.Marshal(ec)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(jec))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	default:
+		return nil, errors.New(http.StatusText(resp.StatusCode))
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+func (e EthereumProxy) Poke(ctx context.Context) error {
+	return e.f(ctx)
+}
+
+func NewEthereumProxy(f func(ctx context.Context) error) Proxy {
+	return &EthereumProxy{f: f}
+}

--- a/service/hproxy/ethereum.go
+++ b/service/hproxy/ethereum.go
@@ -54,7 +54,8 @@ func CallEthereum(ctx context.Context, c *http.Client, url, method string, param
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(jec))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url,
+		bytes.NewBuffer(jec))
 	if err != nil {
 		return nil, err
 	}

--- a/service/hproxy/ethereum.go
+++ b/service/hproxy/ethereum.go
@@ -41,7 +41,7 @@ type EthereumRequest struct {
 type EthereumResponse struct {
 	Version string          `json:"jsonrpc"`
 	Result  json.RawMessage `json:"result"`
-	Error   any             `json:"error"`
+	Error   json.RawMessage `json:"error,omitempty"`
 	ID      any             `json:"id"`
 }
 

--- a/service/hproxy/ethereum.go
+++ b/service/hproxy/ethereum.go
@@ -43,7 +43,7 @@ func ethID() uint64 {
 	return binary.LittleEndian.Uint64(buf)
 }
 
-func CallEthereum(ctx context.Context, c *http.Client, url, method string, params []any) ([]byte, error) {
+func CallEthereum(ctx context.Context, c *http.Client, url, method string, params []any) (io.ReadCloser, error) {
 	ec := EthereumCall{
 		Method:  method,
 		Params:  params,
@@ -63,7 +63,6 @@ func CallEthereum(ctx context.Context, c *http.Client, url, method string, param
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -71,7 +70,7 @@ func CallEthereum(ctx context.Context, c *http.Client, url, method string, param
 		return nil, errors.New(http.StatusText(resp.StatusCode))
 	}
 
-	return io.ReadAll(resp.Body)
+	return resp.Body, nil
 }
 
 func (e EthereumProxy) Poke(ctx context.Context) error {

--- a/service/hproxy/ethereum.go
+++ b/service/hproxy/ethereum.go
@@ -50,12 +50,11 @@ func CallEthereum(ctx context.Context, c *http.Client, url, method string, param
 		ID:      ethID(),
 		Version: EthereumVersion,
 	}
-	jec, err := json.Marshal(ec)
-	if err != nil {
+	b := new(bytes.Buffer)
+	if err := json.NewEncoder(b).Encode(ec); err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url,
-		bytes.NewBuffer(jec))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, b)
 	if err != nil {
 		return nil, err
 	}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -669,13 +669,14 @@ func (s *Server) nodeHealthy(id int) {
 	s.mtx.Unlock()
 }
 
-func (s *Server) nodeUnhealthy(id int) {
+func (s *Server) nodeUnhealthy(id int, err error) {
 	s.mtx.Lock()
 	if s.hvmHandlers[id].state != StateUnhealthy {
 		s.hvmHandlers[id].connections = 0 // reset connections
 		s.hvmHandlers[id].state = StateUnhealthy
 		s._nodeReap(id)
-		log.Infof("Marking hvm unhealthy %v: %v", id, s.hvmHandlers[id].u)
+		log.Infof("Marking hvm unhealthy %v: %v reason: %v",
+			id, s.hvmHandlers[id].u, err)
 	}
 	s.mtx.Unlock()
 }
@@ -700,7 +701,7 @@ func (s *Server) poke(ctx context.Context, id int) {
 
 	err := poker.Poke(ctx)
 	if err != nil {
-		s.nodeUnhealthy(id)
+		s.nodeUnhealthy(id, err)
 	} else {
 		s.nodeHealthy(id)
 	}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -434,7 +434,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 			// We need global context here, not request context
 			// since that one goes away prior the client idle
 			// timeout.
-			s.clients[r.RemoteAddr] = newClient(s.gctx, id,
+			s.clients[r.RemoteAddr] = newClient(s.BaseContext, id,
 				s.cfg.ClientIdleTimeout, func() {
 					s.clientRemove(r.RemoteAddr)
 				})
@@ -513,7 +513,7 @@ func (s *Server) nodeAdd(node string) error {
 	switch u.Scheme {
 	case "http", "https":
 	default:
-		return fmt.Errorf("unsuported scheme: %v", u.Scheme)
+		return fmt.Errorf("unsupported scheme: %v", u.Scheme)
 	}
 
 	s.mtx.Lock()
@@ -598,7 +598,7 @@ func (s *Server) nodeRemove(node string) error {
 	switch u.Scheme {
 	case "http", "https":
 	default:
-		return fmt.Errorf("unsuported scheme: %v", u.Scheme)
+		return fmt.Errorf("unsupported scheme: %v", u.Scheme)
 	}
 
 	s.mtx.Lock()

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -565,7 +565,7 @@ func (s *Server) nodeAdd(node string) error {
 		},
 	}
 
-	// For now, everything is ethereum but we can use the poker function to
+	// For now, everything is ethereum, but we can use the poker function to
 	// handle different types health checks.
 	hvmHandler.poker = NewEthereumProxy(func(ctx context.Context) error {
 		body, err := CallEthereum(ctx, hvmHandler.c, hvmHandler.u.String(), "eth_blockNumber", nil)
@@ -617,7 +617,7 @@ func (s *Server) nodeRemove(node string) error {
 	return errors.New("not found")
 }
 
-// _countNode must be called with the mutext held.
+// _countNode must be called with the mutex held.
 func (s *Server) _nodeCount(id int) int {
 	var count int
 	for _, v := range s.clients {
@@ -628,7 +628,7 @@ func (s *Server) _nodeCount(id int) int {
 	return count
 }
 
-// _nodeReap must be called with the mutext held.
+// _nodeReap must be called with the mutex held.
 func (s *Server) _nodeReap(id int) {
 	for k, v := range s.clients {
 		if v.node == id {

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -567,8 +567,7 @@ func (s *Server) nodeAdd(node string) error {
 	// For now, everything is ethereum but we can use the poker function to
 	// handle different types health checks.
 	hvmHandler.poker = NewEthereumProxy(func(ctx context.Context) error {
-		resp, err := CallEthereum(ctx, hvmHandler.c, hvmHandler.u.String(),
-			"eth_blockNumber", nil)
+		resp, err := CallEthereum(ctx, hvmHandler.c, hvmHandler.u.String(), "eth_blockNumber", nil)
 		if err != nil {
 			return err
 		}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -1,0 +1,960 @@
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package hproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juju/loggo"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/hemilabs/heminetwork/service/deucalion"
+	"github.com/hemilabs/heminetwork/service/pprof"
+)
+
+type Node struct {
+	NodeURL string `json:"node_url"`
+}
+
+type NodeError struct {
+	NodeURL string `json:"node_url"`
+	Error   string `json:"error"`
+}
+
+type NodeHealth struct {
+	NodeURL     string `json:"node_url"`
+	Status      string `json:"status"`
+	Connections int    `json:"connections"`
+}
+
+const (
+	appName = "hproxy" // Prometheus
+
+	logLevel = "INFO"
+
+	// XXX think about these durations
+	DefaultClientIdleTimeout = 5 * time.Minute  // Reap timer for client persistence
+	DefaultRequestTimeout    = 9 * time.Second  // Smaller than 12s
+	DefaultPollFrequency     = 11 * time.Second // Smaller than 12s
+	DefaultListenAddress     = "localhost:8545" // Default geth port
+	DefaultControlAddress    = "localhost:1337" // Default control port
+
+	expectedClients = 1000
+
+	routeControl       = "/v1/control"
+	RouteControlAdd    = routeControl + "/add"
+	RouteControlRemove = routeControl + "/remove"
+	RouteControlList   = routeControl + "/list"
+)
+
+var log = loggo.GetLogger(appName)
+
+func init() {
+	if err := loggo.ConfigureLoggers(logLevel); err != nil {
+		panic(err)
+	}
+}
+
+func handle(service string, mux *http.ServeMux, pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	mux.HandleFunc(pattern, handler)
+	log.Infof("handle (%v): %v", service, pattern)
+}
+
+func dialer(pctx context.Context, network, addr string) (net.Conn, error) {
+	log.Tracef("handleProxyDial: %v %v", network, addr)
+	defer log.Tracef("handleProxyDial exit: %v %v", network, addr)
+
+	defaultDialTimeout := 5 * time.Second
+	d := &net.Dialer{
+		KeepAliveConfig: net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     7 * time.Second,
+			Interval: 7 * time.Second,
+			Count:    2,
+		},
+	}
+	ctx, cancel := context.WithTimeout(pctx, defaultDialTimeout)
+	defer cancel()
+	return d.DialContext(ctx, network, addr)
+}
+
+// client structure handles persistence and client timeouts. We can't use TTL
+// here because we need to be able to reset the timer.
+type client struct {
+	node   int // persistent node
+	ticker *time.Ticker
+}
+
+func newClient(ctx context.Context, node int, duration time.Duration, timeout func()) *client {
+	c := &client{
+		node:   node,
+		ticker: time.NewTicker(duration),
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			c.ticker.Stop()
+		case <-c.ticker.C:
+			timeout()
+		}
+	}()
+	return c
+}
+
+func (c *client) reset(duration time.Duration) {
+	c.ticker.Reset(duration)
+}
+
+func (c *client) abort() {
+	c.ticker.Stop()
+}
+
+type Config struct {
+	ClientIdleTimeout       time.Duration
+	ControlAddress          string
+	HVMURLs                 []string
+	ListenAddress           string
+	LogLevel                string
+	Network                 string
+	PollFrequency           time.Duration
+	PrometheusListenAddress string
+	PrometheusNamespace     string
+	PprofListenAddress      string
+	RequestTimeout          time.Duration
+}
+
+func NewDefaultConfig() *Config {
+	return &Config{
+		ClientIdleTimeout:   DefaultClientIdleTimeout,
+		ControlAddress:      DefaultControlAddress,
+		ListenAddress:       DefaultListenAddress,
+		PollFrequency:       DefaultPollFrequency,
+		Network:             "mainnet",
+		PrometheusNamespace: appName,
+		RequestTimeout:      DefaultRequestTimeout,
+	}
+}
+
+type Server struct {
+	mtx  sync.RWMutex
+	wg   sync.WaitGroup
+	gctx context.Context // We need the global context in client requests
+
+	cfg *Config
+
+	hvmHandlers []HVMHandler       // hvm nodes
+	clients     map[string]*client // [ip_address]server_id
+
+	// Prometheus
+	promCollectors        []prometheus.Collector
+	promPollVerbose       bool // set to true to print stats during poll
+	isRunning             bool
+	cmdsProcessed         prometheus.Counter
+	promHealth            health
+	persistentConnections uint64
+}
+
+func NewServer(cfg *Config) (*Server, error) {
+	if cfg == nil {
+		cfg = NewDefaultConfig()
+	}
+	if cfg.RequestTimeout <= 0 {
+		cfg.RequestTimeout = DefaultRequestTimeout
+	}
+
+	s := &Server{
+		cfg:     cfg,
+		clients: make(map[string]*client, expectedClients),
+		cmdsProcessed: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: cfg.PrometheusNamespace,
+			Name:      "proxy_calls",
+			Help:      "The total number of successful proxy calls",
+		}),
+	}
+
+	switch strings.ToLower(cfg.Network) {
+	case "mainnet":
+	case "sepolia":
+	default:
+		return nil, fmt.Errorf("unknown network %q", cfg.Network)
+	}
+
+	return s, nil
+}
+
+func (s *Server) promHVMNew() float64 {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return deucalion.IntToFloat(s.promHealth.NewNodes)
+}
+
+func (s *Server) promHVMHealthy() float64 {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return deucalion.IntToFloat(s.promHealth.HealthyNodes)
+}
+
+func (s *Server) promHVMUnhealthy() float64 {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return deucalion.IntToFloat(s.promHealth.UnhealthyNodes)
+}
+
+func (s *Server) promHVMRemoved() float64 {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return deucalion.IntToFloat(s.promHealth.RemovedNodes)
+}
+
+func (s *Server) promConnections() float64 {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return deucalion.Uint64ToFloat(s.persistentConnections)
+}
+
+// Collectors returns the Prometheus collectors available for the server.
+func (s *Server) Collectors() []prometheus.Collector {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.promCollectors == nil {
+		// Naming: https://prometheus.io/docs/practices/naming/
+		s.promCollectors = []prometheus.Collector{
+			s.cmdsProcessed,
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "running",
+				Help:      "Whether the hproxy service is running",
+			}, s.promRunning),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "hvm_new",
+				Help:      "Number of new HVMs",
+			}, s.promHVMNew),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "hvm_healthy",
+				Help:      "Number of healthy HVMs",
+			}, s.promHVMHealthy),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "hvm_unhealthy",
+				Help:      "Number of unhealthy HVMs",
+			}, s.promHVMUnhealthy),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "hvm_removed",
+				Help:      "Number of removed HVMs",
+			}, s.promHVMRemoved),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "connections",
+				Help:      "Number of active client connections",
+			}, s.promConnections),
+		}
+	}
+	return s.promCollectors
+}
+
+func (s *Server) promPoll(ctx context.Context) error {
+	promPollFrequency := 5 * time.Second
+	ticker := time.NewTicker(promPollFrequency)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+
+		var (
+			h           health
+			connections uint64
+		)
+		s.mtx.Lock()
+		for k := range s.hvmHandlers {
+			switch s.hvmHandlers[k].state {
+			case StateNew:
+				h.NewNodes++
+			case StateHealthy:
+				h.HealthyNodes++
+				connections += uint64(s.hvmHandlers[k].connections)
+			case StateUnhealthy:
+				h.UnhealthyNodes++
+			case StateRemoved:
+				h.RemovedNodes++
+			}
+		}
+		s.promHealth = h
+		s.persistentConnections = connections
+		s.mtx.Unlock()
+
+		if s.promPollVerbose {
+			log.Infof("new: %v healthy: %v unhealthy: %v removed: %v "+
+				"persistent connections: %v", h.NewNodes,
+				h.HealthyNodes, h.UnhealthyNodes, h.RemovedNodes,
+				connections)
+		}
+		ticker.Reset(promPollFrequency)
+	}
+}
+
+func (s *Server) running() bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.isRunning
+}
+
+func (s *Server) testAndSetRunning(b bool) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	old := s.isRunning
+	s.isRunning = b
+	return old != s.isRunning
+}
+
+func (s *Server) promRunning() float64 {
+	r := s.running()
+	if r {
+		return 1
+	}
+	return 0
+}
+
+func (s *Server) isHealthy(_ context.Context) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for k := range s.hvmHandlers {
+		// If we see a single hvm unhealthy bail with unhealthy status.
+		// XXX i think this is technically correct but we do return
+		// 503 to the caller here.
+		if s.hvmHandlers[k].state == StateUnhealthy {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Server) health(ctx context.Context) (bool, any, error) {
+	log.Tracef("health")
+	defer log.Tracef("health exit")
+
+	s.mtx.RLock()
+	h := s.promHealth
+	s.mtx.RUnlock()
+
+	return s.isHealthy(ctx), h, nil
+}
+
+type HVMState int
+
+type health struct {
+	NewNodes       int `json:"new_nodes"`
+	HealthyNodes   int `json:"healthy_nodes"`
+	UnhealthyNodes int `json:"unhealthy_nodes"`
+	RemovedNodes   int `json:"removed_nodes"`
+}
+
+const (
+	StateNew       HVMState = 0
+	StateHealthy   HVMState = 1
+	StateUnhealthy HVMState = 2
+	StateRemoved   HVMState = 3
+)
+
+var stateString = map[HVMState]string{
+	StateNew:       "new",
+	StateHealthy:   "healthy",
+	StateUnhealthy: "unhealthy",
+	StateRemoved:   "removed",
+}
+
+type HVMHandler struct {
+	id int // node id
+
+	rp *httputil.ReverseProxy
+	u  *url.URL     // Connection URL for HVM
+	c  *http.Client // In here to reuse connection
+
+	connections uint // Open connections
+
+	poking bool // true when getting health
+	poker  Proxy
+	state  HVMState // Do NOT directly set, use utility functions!
+}
+
+func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleProxyRequest: %v", r.RemoteAddr)
+	defer log.Tracef("handleProxyRequest exit: %v", r.RemoteAddr)
+
+	// Select host to call
+	s.mtx.Lock()
+	id := -1
+	if v, ok := s.clients[r.RemoteAddr]; ok {
+		// Only call same host when healthy
+		if s.hvmHandlers[v.node].state == StateHealthy {
+			id = v.node
+			v.reset(s.cfg.ClientIdleTimeout) // reset timer for reuse here
+		} else {
+			// hvm died, remove persisted client
+			s._clientRemove(r.RemoteAddr)
+		}
+	}
+
+	// Find suitable candidate
+	if id == -1 {
+		var leastConnections uint = math.MaxUint
+		for k := range s.hvmHandlers {
+			if s.hvmHandlers[k].state == StateHealthy {
+				if s.hvmHandlers[k].connections < leastConnections {
+					leastConnections = s.hvmHandlers[k].connections
+					id = k
+				}
+			}
+		}
+		if id >= 0 {
+			// Add connection to candidate.
+			//
+			// We need global context here, not request context
+			// since that one goes away prior the client idle
+			// timeout.
+			s.clients[r.RemoteAddr] = newClient(s.gctx, id,
+				s.cfg.ClientIdleTimeout, func() {
+					s.clientRemove(r.RemoteAddr)
+				})
+			s.hvmHandlers[id].connections++
+		}
+	}
+	s.mtx.Unlock()
+
+	// If no candidate was found return error
+	if id == -1 {
+		// No candidates, exit with error
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	log.Debugf("handleProxyRequest: remote %v url '%v' -> node %v",
+		r.RemoteAddr, r.URL, id)
+
+	// Throw call over the fence
+	w.Header().Set("X-Hproxy", strconv.Itoa(id))
+	s.hvmHandlers[id].rp.ServeHTTP(w, r)
+
+	s.cmdsProcessed.Inc()
+}
+
+//func (s *Server) handleProxyError(w http.ResponseWriter, r *http.Request, e error) {
+//	log.Tracef("handleProxyError: %v", r.RemoteAddr)
+//	defer log.Tracef("handleProxyError exit: %v", r.RemoteAddr)
+//
+//	// XXX only called when ModifyResponse is used.
+//
+//	//cs := spew.ConfigState{
+//	//	DisableMethods:        true,
+//	//	DisablePointerMethods: true,
+//	//	ContinueOnMethod:      true,
+//	//}
+//
+//	// log.Errorf("proxy error: %T", e)
+//	// log.Errorf("proxy error: %v", cs.Sdump(e))
+//
+//	// connection errors
+//	// XXX or is this all ohio?
+//	var netErr net.Error
+//	switch {
+//	case errors.As(e, &netErr) && netErr.Timeout():
+//		w.WriteHeader(http.StatusBadGateway)
+//	case errors.Is(e, net.ErrClosed):
+//		w.WriteHeader(http.StatusBadGateway)
+//	case errors.Is(e, net.ErrWriteToConnected):
+//		w.WriteHeader(http.StatusBadGateway)
+//	case errors.Is(e, syscall.ECONNREFUSED):
+//		w.WriteHeader(http.StatusBadGateway)
+//	default:
+//		panic(e)
+//	}
+//}
+
+func (s *Server) _clientRemove(remoteAddr string) {
+	if v, ok := s.clients[remoteAddr]; ok {
+		v.abort()
+		delete(s.clients, remoteAddr)
+	}
+}
+
+func (s *Server) clientRemove(remoteAddr string) {
+	s.mtx.Lock()
+	s._clientRemove(remoteAddr)
+	s.mtx.Unlock()
+}
+
+func (s *Server) nodeAdd(node string) error {
+	u, err := url.Parse(node)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("unsuported scheme: %v", u.Scheme)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// make sure it isn't a dupe
+	for k := range s.hvmHandlers {
+		if s.hvmHandlers[k].u.String() == u.String() {
+			if s.hvmHandlers[k].state == StateRemoved {
+				s._nodeNew(k) // add it back
+				return nil
+			}
+			return errors.New("duplicate")
+		}
+	}
+
+	hvmHandler := HVMHandler{
+		id:    len(s.hvmHandlers),
+		state: StateNew,
+		u:     u,
+		c: &http.Client{
+			Transport: &http.Transport{
+				DialContext:           dialer,
+				TLSHandshakeTimeout:   5 * time.Second,
+				ResponseHeaderTimeout: s.cfg.RequestTimeout,
+			},
+		},
+		// Ethereum only needs what is set. If we want to make this
+		// generic we may have to fart with this a bit.
+		rp: &httputil.ReverseProxy{
+			Rewrite: func(r *httputil.ProxyRequest) {
+				r.SetURL(u)
+				r.SetXForwarded()
+			},
+			Director: nil, // not needed
+			Transport: &http.Transport{
+				DialContext:           dialer,
+				TLSHandshakeTimeout:   5 * time.Second,
+				ResponseHeaderTimeout: s.cfg.RequestTimeout,
+				MaxIdleConnsPerHost:   1,
+				MaxConnsPerHost:       1,
+			},
+			FlushInterval:  0,
+			ErrorLog:       nil, // XXX wrap in loggo
+			BufferPool:     nil, // not useful for different sized calls
+			ModifyResponse: nil, // not needed
+			ErrorHandler:   nil, // s.handleProxyError, ModifyResponse only
+		},
+	}
+
+	// For now, everything is ethereum but we can use the poker function to
+	// handle different types health checks.
+	hvmHandler.poker = NewEthereumProxy(func(ctx context.Context) error {
+		resp, err := CallEthereum(ctx, hvmHandler.c, hvmHandler.u.String(),
+			"eth_blockNumber", nil)
+		if err != nil {
+			return err
+		}
+
+		j := make(map[string]any)
+		err = json.Unmarshal(resp, &j)
+		if err != nil {
+			return err
+		}
+
+		// Make sure we have "result"
+		if _, ok := j["result"]; !ok {
+			return errors.New("no result")
+		}
+		return nil
+	})
+
+	s.hvmHandlers = append(s.hvmHandlers, hvmHandler)
+
+	return nil
+}
+
+func (s *Server) nodeRemove(node string) error {
+	u, err := url.Parse(node)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return fmt.Errorf("unsuported scheme: %v", u.Scheme)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// make sure it isn't a dupe
+	for k := range s.hvmHandlers {
+		if s.hvmHandlers[k].u.String() == u.String() {
+			if s.hvmHandlers[k].state != StateRemoved {
+				s._nodeRemoved(k)
+				return nil
+			}
+			return errors.New("already removed")
+		}
+	}
+	return errors.New("not found")
+}
+
+// _countNode must be called with the mutext held.
+func (s *Server) _nodeCount(id int) int {
+	var count int
+	for _, v := range s.clients {
+		if v.node == id {
+			count++
+		}
+	}
+	return count
+}
+
+// _nodeReap must be called with the mutext held.
+func (s *Server) _nodeReap(id int) {
+	for k, v := range s.clients {
+		if v.node == id {
+			delete(s.clients, k)
+		}
+	}
+}
+
+// _nodeNew must be called with lock held.
+func (s *Server) _nodeNew(id int) {
+	if s.hvmHandlers[id].state != StateNew {
+		s.hvmHandlers[id].connections = 0 // reset connections
+		s.hvmHandlers[id].state = StateNew
+		s._nodeReap(id)
+		log.Infof("Marking hvm new %v: %v", id, s.hvmHandlers[id].u)
+	}
+}
+
+// _nodeRemoved must be called with lock held.
+func (s *Server) _nodeRemoved(id int) {
+	if s.hvmHandlers[id].state != StateRemoved {
+		s.hvmHandlers[id].connections = 0 // reset connections
+		s.hvmHandlers[id].state = StateRemoved
+		s._nodeReap(id)
+		log.Infof("Marking hvm removed %v: %v", id, s.hvmHandlers[id].u)
+	}
+}
+
+func (s *Server) nodeHealthy(id int) {
+	s.mtx.Lock()
+	if s.hvmHandlers[id].state != StateHealthy {
+		s.hvmHandlers[id].connections = 0 // reset connections
+		s.hvmHandlers[id].state = StateHealthy
+		s._nodeReap(id)
+		log.Infof("Marking hvm healthy %v: %v", id, s.hvmHandlers[id].u)
+	}
+	s.mtx.Unlock()
+}
+
+func (s *Server) nodeUnhealthy(id int) {
+	s.mtx.Lock()
+	if s.hvmHandlers[id].state != StateUnhealthy {
+		s.hvmHandlers[id].connections = 0 // reset connections
+		s.hvmHandlers[id].state = StateUnhealthy
+		s._nodeReap(id)
+		log.Infof("Marking hvm unhealthy %v: %v", id, s.hvmHandlers[id].u)
+	}
+	s.mtx.Unlock()
+}
+
+func (s *Server) poke(ctx context.Context, id int) {
+	log.Tracef("poke: %v", id)
+	defer log.Tracef("poke exit: %v", id)
+
+	s.mtx.Lock()
+	if s.hvmHandlers[id].poking {
+		s.mtx.Unlock()
+		return
+	}
+	s.hvmHandlers[id].poking = true
+	poker := s.hvmHandlers[id].poker
+	s.mtx.Unlock()
+	defer func() {
+		s.mtx.Lock()
+		s.hvmHandlers[id].poking = false
+		s.mtx.Unlock()
+	}()
+
+	err := poker.Poke(ctx)
+	if err != nil {
+		s.nodeUnhealthy(id)
+	} else {
+		s.nodeHealthy(id)
+	}
+}
+
+func (s *Server) monitor(ctx context.Context) {
+	log.Tracef("monitor")
+	defer log.Tracef("monitor exit")
+	defer s.wg.Done()
+
+	ticker := time.NewTicker(s.cfg.PollFrequency)
+	defer ticker.Stop()
+	for {
+		// Poke hvms
+		s.mtx.Lock()
+		for k := range s.hvmHandlers {
+			if s.hvmHandlers[k].state != StateRemoved {
+				go s.poke(ctx, k)
+			}
+		}
+		s.mtx.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		ticker.Reset(s.cfg.PollFrequency)
+	}
+}
+
+func (s *Server) handleControlAddRequest(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleControlAddRequest: %v", r.RemoteAddr)
+	defer log.Tracef("handleControlAddRequest exit: %v", r.RemoteAddr)
+
+	ns := make([]Node, 0, 16)
+	err := json.NewDecoder(r.Body).Decode(&ns)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Errorf("%v %v: %v", RouteControlAdd, r.RemoteAddr, err) // too loud?
+		return
+	}
+
+	nes := make([]NodeError, len(ns))
+	for k := range ns {
+		nes[k].NodeURL = ns[k].NodeURL
+		err = s.nodeAdd(ns[k].NodeURL)
+		if err != nil {
+			nes[k].Error = err.Error()
+			continue
+		}
+	}
+	err = json.NewEncoder(w).Encode(nes)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Errorf("%v %v: %v", RouteControlAdd, r.RemoteAddr, err) // too loud?
+		return
+	}
+}
+
+func (s *Server) handleControlRemoveRequest(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleControlRemoveRequest: %v", r.RemoteAddr)
+	defer log.Tracef("handleControlRemoveRequest exit: %v", r.RemoteAddr)
+
+	ns := make([]Node, 0, 16)
+	err := json.NewDecoder(r.Body).Decode(&ns)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Errorf("%v %v: %v", RouteControlRemove, r.RemoteAddr, err) // too loud?
+		return
+	}
+
+	nes := make([]NodeError, len(ns))
+	for k := range ns {
+		nes[k].NodeURL = ns[k].NodeURL
+		err = s.nodeRemove(ns[k].NodeURL)
+		if err != nil {
+			nes[k].Error = err.Error()
+			continue
+		}
+	}
+	err = json.NewEncoder(w).Encode(nes)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Errorf("%v %v: %v", RouteControlRemove, r.RemoteAddr, err) // too loud?
+		return
+	}
+}
+
+func (s *Server) handleControlListRequest(w http.ResponseWriter, r *http.Request) {
+	log.Tracef("handleControlListRequest: %v", r.RemoteAddr)
+	defer log.Tracef("handleControlListRequest exit: %v", r.RemoteAddr)
+
+	s.mtx.Lock()
+	nhs := make([]NodeHealth, 0, len(s.hvmHandlers))
+	for k := range s.hvmHandlers {
+		nhs = append(nhs, NodeHealth{
+			NodeURL:     s.hvmHandlers[k].u.String(),
+			Status:      stateString[s.hvmHandlers[k].state],
+			Connections: s._nodeCount(k),
+		})
+	}
+	s.mtx.Unlock()
+
+	err := json.NewEncoder(w).Encode(nhs)
+	if err != nil {
+		log.Errorf("encode %v: %v", r.RemoteAddr, err)
+		return
+	}
+}
+
+func (s *Server) Run(pctx context.Context) error {
+	if !s.testAndSetRunning(true) {
+		return errors.New("hproxy already running")
+	}
+	defer s.testAndSetRunning(false)
+
+	// Validate urls
+	if len(s.cfg.HVMURLs) == 0 {
+		return errors.New("must provide hvm url(s)")
+	}
+	s.hvmHandlers = make([]HVMHandler, 0, len(s.cfg.HVMURLs))
+	for k := range s.cfg.HVMURLs {
+		err := s.nodeAdd(s.cfg.HVMURLs[k])
+		if err != nil {
+			return fmt.Errorf("node add: %w", err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(pctx)
+	defer cancel()
+
+	// Set global context for client timeouts during requests
+	s.gctx = ctx
+
+	// Launch hvm monitor
+	s.wg.Add(1)
+	go s.monitor(ctx)
+
+	// HTTP server
+	httpErrCh := make(chan error)
+	if s.cfg.ListenAddress == "" {
+		return errors.New("must provide listen address")
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleProxyRequest)
+
+	httpServer := &http.Server{
+		Addr:        s.cfg.ListenAddress,
+		Handler:     mux,
+		BaseContext: func(_ net.Listener) context.Context { return ctx },
+	}
+	go func() {
+		log.Infof("Listening: %s", s.cfg.ListenAddress)
+		httpErrCh <- httpServer.ListenAndServe()
+	}()
+	defer func() {
+		if err := httpServer.Shutdown(ctx); err != nil {
+			log.Errorf("http server exit: %v", err)
+			return
+		}
+		log.Infof("web server shutdown cleanly")
+	}()
+
+	// Control HTTP server
+	ctrlHttpErrCh := make(chan error)
+	if s.cfg.ControlAddress != "" {
+		cmux := http.NewServeMux()
+		handle("Control", cmux, RouteControlAdd, s.handleControlAddRequest)
+		handle("Control", cmux, RouteControlRemove, s.handleControlRemoveRequest)
+		handle("Control", cmux, RouteControlList, s.handleControlListRequest)
+
+		ctrlHttpServer := &http.Server{
+			Addr:        s.cfg.ControlAddress,
+			Handler:     cmux,
+			BaseContext: func(_ net.Listener) context.Context { return ctx },
+		}
+		go func() {
+			log.Infof("Control listening: %s", s.cfg.ControlAddress)
+			ctrlHttpErrCh <- ctrlHttpServer.ListenAndServe()
+		}()
+		defer func() {
+			if err := ctrlHttpServer.Shutdown(ctx); err != nil {
+				log.Errorf("control http server exit: %v", err)
+				return
+			}
+			log.Infof("control web server shutdown cleanly")
+		}()
+	}
+
+	// Prometheus
+	if s.cfg.PrometheusListenAddress != "" {
+		d, err := deucalion.New(&deucalion.Config{
+			ListenAddress: s.cfg.PrometheusListenAddress,
+		})
+		if err != nil {
+			return fmt.Errorf("create server: %w", err)
+		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			if err := d.Run(ctx, s.Collectors(), s.health); !errors.Is(err, context.Canceled) {
+				log.Errorf("prometheus terminated with error: %v", err)
+				return
+			}
+			log.Infof("prometheus clean shutdown")
+		}()
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			err := s.promPoll(ctx)
+			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					log.Errorf("prometheus poll terminated with error: %v", err)
+				}
+				return
+			}
+		}()
+	}
+
+	// pprof
+	if s.cfg.PprofListenAddress != "" {
+		p, err := pprof.NewServer(&pprof.Config{
+			ListenAddress: s.cfg.PprofListenAddress,
+		})
+		if err != nil {
+			return fmt.Errorf("create pprof server: %w", err)
+		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			if err := p.Run(ctx); !errors.Is(err, context.Canceled) {
+				log.Errorf("pprof server terminated with error: %v", err)
+				return
+			}
+			log.Infof("pprof server clean shutdown")
+		}()
+	}
+
+	runtime.Gosched() // just for pretty print
+	log.Infof("Starting hproxy")
+
+	var err error
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+	case err = <-httpErrCh:
+	case err = <-ctrlHttpErrCh:
+	}
+	cancel()
+
+	log.Infof("hproxy shutting down...")
+	s.wg.Wait()
+	log.Infof("hproxy shutdown cleanly")
+
+	return err
+}

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -434,7 +434,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 			// We need global context here, not request context
 			// since that one goes away prior the client idle
 			// timeout.
-			s.clients[r.RemoteAddr] = newClient(s.BaseContext, id,
+			s.clients[r.RemoteAddr] = newClient(s.gctx, id,
 				s.cfg.ClientIdleTimeout, func() {
 					s.clientRemove(r.RemoteAddr)
 				})

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -243,12 +243,18 @@ func (s *Server) promConnections() float64 {
 func (s *Server) promAvgClientSetupLatency() float64 {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
+	if s.proxyCalls == 0 {
+		return 0
+	}
 	return math.Round(float64(s.setupDuration) / float64(s.proxyCalls))
 }
 
 func (s *Server) promAvgProxyLatency() float64 {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
+	if s.proxyCalls == 0 {
+		return 0
+	}
 	return math.Round(float64(s.proxyDuration) / float64(s.proxyCalls))
 }
 

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -342,7 +342,9 @@ func (s *Server) isHealthy(_ context.Context) bool {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	for k := range s.hvmHandlers {
-		// If we see a single hvm unhealthy bail with unhealthy status.
+		// If we see a single hvm unhealthy bail with unhealthy
+		// status.
+		//
 		// XXX i think this is technically correct but we do return
 		// 503 to the caller here.
 		if s.hvmHandlers[k].state == StateUnhealthy {
@@ -565,8 +567,8 @@ func (s *Server) nodeAdd(node string) error {
 		},
 	}
 
-	// For now, everything is ethereum, but we can use the poker function to
-	// handle different types health checks.
+	// For now, everything is ethereum, but we can use the poker function
+	// to handle different types health checks.
 	hvmHandler.poker = NewEthereumProxy(newEthereumPoker(hvmHandler.c, hvmHandler.u.String()))
 
 	s.hvmHandlers = append(s.hvmHandlers, hvmHandler)
@@ -574,15 +576,17 @@ func (s *Server) nodeAdd(node string) error {
 	return nil
 }
 
-// newEthereumPoker returns a new poker which checks the health of an Ethereum
-// node. The health of the node is determined by the age of the latest block.
+// newEthereumPoker returns a new poker which checks the health of an
+// Ethereum node. The health of the node is determined by the age of the
+// latest block.
 func newEthereumPoker(client *http.Client, url string) func(ctx context.Context) error {
 	const maxBlockAge = 30 * time.Second // TODO: make this configurable?
 
 	// TODO: Improve health checks.
 
 	return func(ctx context.Context) error {
-		blockRes, err := CallEthereum(ctx, client, url, "eth_getBlockByNumber", "latest")
+		blockRes, err := CallEthereum(ctx, client, url,
+			"eth_getBlockByNumber", "latest")
 		if err != nil {
 			return err
 		}
@@ -600,8 +604,8 @@ func newEthereumPoker(client *http.Client, url string) func(ctx context.Context)
 		}
 
 		if age := time.Since(time.Unix(ts, 0)); age > maxBlockAge {
-			return fmt.Errorf("eth_getBlockByNumber timestamp too old: %v (%v ago)",
-				block.Timestamp, age)
+			return fmt.Errorf("eth_getBlockByNumber timestamp "+
+				"too old: %v (%v ago)", block.Timestamp, age)
 		}
 
 		return nil

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -461,7 +461,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 	s.cmdsProcessed.Inc()
 }
 
-//func (s *Server) handleProxyError(w http.ResponseWriter, r *http.Request, e error) {
+// func (s *Server) handleProxyError(w http.ResponseWriter, r *http.Request, e error) {
 //	log.Tracef("handleProxyError: %v", r.RemoteAddr)
 //	defer log.Tracef("handleProxyError exit: %v", r.RemoteAddr)
 //
@@ -491,7 +491,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 //	default:
 //		panic(e)
 //	}
-//}
+// }
 
 func (s *Server) _clientRemove(remoteAddr string) {
 	if v, ok := s.clients[remoteAddr]; ok {
@@ -568,14 +568,13 @@ func (s *Server) nodeAdd(node string) error {
 	// For now, everything is ethereum but we can use the poker function to
 	// handle different types health checks.
 	hvmHandler.poker = NewEthereumProxy(func(ctx context.Context) error {
-		resp, err := CallEthereum(ctx, hvmHandler.c, hvmHandler.u.String(), "eth_blockNumber", nil)
+		body, err := CallEthereum(ctx, hvmHandler.c, hvmHandler.u.String(), "eth_blockNumber", nil)
 		if err != nil {
 			return err
 		}
 
 		j := make(map[string]any)
-		err = json.Unmarshal(resp, &j)
-		if err != nil {
+		if err := json.NewDecoder(body).Decode(&j); err != nil {
 			return err
 		}
 

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -164,11 +164,11 @@ func TestClientReap(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 				"http://"+hpCfg.ListenAddress, nil)
 			if err != nil {
-				panic(fmt.Errorf("get %v: %v", x, err))
+				panic(fmt.Errorf("get %v: %w", x, err))
 			}
 			reply, err := c.Do(req)
 			if err != nil {
-				panic(fmt.Errorf("do %v: %v", x, err))
+				panic(fmt.Errorf("do %v: %w", x, err))
 			}
 			defer reply.Body.Close()
 			switch reply.StatusCode {
@@ -187,7 +187,7 @@ func TestClientReap(t *testing.T) {
 			var jr serverReply
 			err = json.NewDecoder(reply.Body).Decode(&jr)
 			if err != nil {
-				panic(fmt.Sprintf("decode %v: %v", x, err))
+				panic(fmt.Errorf("decode %v: %w", x, err))
 			}
 
 			// Verify that json id matches header id, a bit silly
@@ -338,17 +338,17 @@ func TestFanout(t *testing.T) {
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
 				"http://"+hpCfg.ListenAddress, nil)
 			if err != nil {
-				panic(fmt.Sprintf("get %v: %v", x, err))
+				panic(fmt.Errorf("get %v: %w", x, err))
 			}
 			reply, err := c.Do(req)
 			if err != nil {
-				panic(fmt.Sprintf("do %v: %v", x, err))
+				panic(fmt.Errorf("do %v: %w", x, err))
 			}
 			defer reply.Body.Close()
 			switch reply.StatusCode {
 			case http.StatusOK:
 			default:
-				panic(fmt.Sprintf("%v replied %v",
+				panic(fmt.Errorf("%v replied %v",
 					hpCfg.ListenAddress, reply.StatusCode))
 			}
 
@@ -361,7 +361,7 @@ func TestFanout(t *testing.T) {
 			var jr serverReply
 			err = json.NewDecoder(reply.Body).Decode(&jr)
 			if err != nil {
-				panic(fmt.Sprintf("decode %v: %v", x, err))
+				panic(fmt.Errorf("decode %v: %w", x, err))
 			}
 			am.Lock()
 			answers[jr.ID]++
@@ -444,7 +444,7 @@ func TestPersistence(t *testing.T) {
 		switch reply.StatusCode {
 		case http.StatusOK:
 		default:
-			panic(fmt.Sprintf("%v replied %v",
+			panic(fmt.Errorf("%v replied %v",
 				hpCfg.ListenAddress, reply.StatusCode))
 		}
 
@@ -540,7 +540,7 @@ func TestFailover(t *testing.T) {
 		switch reply.StatusCode {
 		case http.StatusOK:
 		default:
-			panic(fmt.Sprintf("%v replied %v",
+			panic(fmt.Errorf("%v replied %v",
 				hpCfg.ListenAddress, reply.StatusCode))
 		}
 

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -1,0 +1,589 @@
+// Copyright (c) 2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package hproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"github.com/hemilabs/heminetwork/testutil"
+)
+
+type serverReply struct {
+	ID    int   `json:"id"`
+	Error error `json:"error,omitempty"`
+}
+
+func newServer(x int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Forwarded-Host") == "" ||
+			r.Header.Get("X-Forwarded-For") == "" ||
+			r.Header.Get("X-Forwarded-Proto") == "" {
+			// When we get here we are getting a health
+			// check which does not have headers set. Check
+			// to see if the check is expected and panic if
+			// it isn't.
+			defer r.Body.Close()
+			jr := json.NewDecoder(r.Body)
+			var j map[string]any
+			err := jr.Decode(&j)
+			if err != nil {
+				panic(err)
+			}
+			if x, ok := j["method"]; !ok || x != "eth_blockNumber" {
+				panic("invalid health command")
+			}
+			// return some bs
+			err = json.NewEncoder(w).Encode(
+				map[string]any{
+					"jsonrpc": "2.0",
+					"id":      1,
+					"result":  "0x37af32",
+					"health":  1,
+				})
+			if err != nil {
+				panic(err)
+			}
+			return
+		}
+		id := serverReply{ID: x}
+		err := json.NewEncoder(w).Encode(id)
+		if err != nil {
+			panic(err)
+		}
+	}))
+}
+
+func newHproxy(t *testing.T, servers []string) (*Server, *Config) {
+	hpCfg := NewDefaultConfig()
+	hpCfg.HVMURLs = servers
+	hpCfg.LogLevel = "hproxy=TRACE" // XXX figure out why this isn't working
+	hpCfg.RequestTimeout = time.Second
+	hpCfg.PollFrequency = time.Second
+	hpCfg.ListenAddress = "127.0.0.1:" + testutil.FreePort()
+	hpCfg.ControlAddress = "127.0.0.1:" + testutil.FreePort()
+	hp, err := NewServer(hpCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		err = hp.Run(t.Context())
+		if err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+	return hp, hpCfg
+}
+
+func TestNobodyHome(t *testing.T) {
+	servers := []string{"http://localhost:1"}
+	_, hpCfg := newHproxy(t, servers)
+	time.Sleep(250 * time.Millisecond)
+
+	c := &http.Client{}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"http://"+hpCfg.ListenAddress, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reply, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer reply.Body.Close()
+
+	// Expect 503
+	if reply.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("http error mismatch: got %v wanted %v",
+			reply.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	// Expect EOF
+	var jr serverReply
+	err = json.NewDecoder(reply.Body).Decode(&jr)
+	if !errors.Is(err, io.EOF) {
+		t.Fatal(err)
+	}
+}
+
+// func TestDialTimeout(t *testing.T) {
+// XXX tried to build a test for this but did not succeed. Remove or fix.
+// }
+func TestClientReap(t *testing.T) {
+	s := newServer(0)
+	defer s.Close()
+	servers := []string{s.URL}
+
+	hpCfg := NewDefaultConfig()
+	hpCfg.HVMURLs = servers
+	hpCfg.LogLevel = "hproxy=TRACE"       // XXX figure out why this isn't working
+	hpCfg.ClientIdleTimeout = time.Second // reap clients after 1 second
+	hpCfg.RequestTimeout = time.Second
+	hpCfg.PollFrequency = time.Second
+	hp, err := NewServer(hpCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		err = hp.Run(t.Context())
+		if err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	time.Sleep(250 * time.Millisecond)
+
+	testDuration := 5 * time.Second
+	ctx, cancel := context.WithTimeout(t.Context(), testDuration)
+	defer cancel()
+
+	// Launch 5 clients
+	var wg sync.WaitGroup
+	clientCount := 5
+	for i := 0; i < clientCount; i++ {
+		wg.Add(1)
+		go func(x int) {
+			defer wg.Done()
+			c := &http.Client{Transport: http.DefaultTransport}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+				"http://"+hpCfg.ListenAddress, nil)
+			if err != nil {
+				panic(fmt.Sprintf("get %v: %v", x, err))
+			}
+			reply, err := c.Do(req)
+			if err != nil {
+				panic(fmt.Sprintf("do %v: %v", x, err))
+			}
+			defer reply.Body.Close()
+			switch reply.StatusCode {
+			case http.StatusOK:
+			default:
+				panic(fmt.Sprintf("%v replied %v",
+					hpCfg.ListenAddress, reply.StatusCode))
+			}
+
+			// Require X-Hproxy
+			ids := reply.Header.Get("X-Hproxy")
+			if ids == "" {
+				panic("expected X-Hproxy being set")
+			}
+
+			var jr serverReply
+			err = json.NewDecoder(reply.Body).Decode(&jr)
+			if err != nil {
+				panic(fmt.Sprintf("decode %v: %v", x, err))
+			}
+
+			// Verify that json id matches header id, a bit silly
+			// but keeps us honest.
+			if strconv.Itoa(jr.ID) != ids {
+				panic("id mismatch header: " + ids +
+					" json: " + strconv.Itoa(jr.ID))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if len(hp.clients) != clientCount {
+		t.Fatalf("expected %v clients got %v", len(hp.clients), clientCount)
+	}
+
+	// Wait for reap and check client list
+	time.Sleep(1 * time.Second)
+	if len(hp.clients) != 0 {
+		t.Fatalf("not reaped clients: %v", spew.Sdump(hp.clients))
+	}
+}
+
+func TestRequestTimeout(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wg.Wait() // Stupid test server is stupid
+
+		// exit so that we can complete the test. If we don't exit the
+		// httptest server just sits there.
+	}))
+	defer s.Close()
+
+	servers := []string{s.URL}
+	_, hpCfg := newHproxy(t, servers)
+	time.Sleep(250 * time.Millisecond)
+
+	c := &http.Client{}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"http://"+hpCfg.ListenAddress, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reply, err := c.Do(req)
+	wg.Done()
+	if err != nil {
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("%T", err)
+		}
+	}
+	reply.Body.Close() // shut linter up
+}
+
+func request(ctx context.Context, serverID int, hpCfg *Config) error {
+	c := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"http://"+hpCfg.ListenAddress, nil)
+	if err != nil {
+		return fmt.Errorf("get: %w", err)
+	}
+	reply, err := c.Do(req)
+	if err != nil {
+		return fmt.Errorf("get %v: %w", 0, err)
+	}
+	defer reply.Body.Close()
+	switch reply.StatusCode {
+	case http.StatusOK:
+	default:
+		return fmt.Errorf("%v replied %v", hpCfg.ListenAddress, reply.StatusCode)
+	}
+
+	// Require X-Hproxy
+	ids := reply.Header.Get("X-Hproxy")
+	if ids == "" {
+		return errors.New("expected X-Hproxy being set")
+	}
+
+	// Read body
+	var jr serverReply
+	err = json.NewDecoder(reply.Body).Decode(&jr)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	if jr.ID != serverID {
+		return fmt.Errorf("invalid response got %v, wanted %v", jr.ID, serverID)
+	}
+	return nil
+}
+
+func TestProxy(t *testing.T) {
+	serverID := 1337
+	s := newServer(serverID)
+	defer s.Close()
+	servers := []string{s.URL}
+
+	// Setup hproxy
+	_, hpCfg := newHproxy(t, servers)
+	time.Sleep(250 * time.Millisecond)
+
+	// Send command
+	err := request(t.Context(), serverID, hpCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFanout(t *testing.T) {
+	serverCount := 5
+	servers := make([]string, 0, serverCount)
+	for i := 0; i < serverCount; i++ {
+		s := newServer(i)
+		defer s.Close()
+
+		// Verify url
+		_, err := url.Parse(s.URL)
+		if err != nil {
+			t.Fatalf("server %v: %v", i, err)
+		}
+		servers = append(servers, s.URL)
+	}
+
+	testDuration := 5 * time.Second
+	ctx, cancel := context.WithTimeout(t.Context(), testDuration)
+	_ = ctx
+	defer cancel()
+
+	// Setup hproxy
+	_, hpCfg := newHproxy(t, servers)
+	time.Sleep(500 * time.Millisecond) // Let proxies be marked healthy
+
+	// clients
+	var (
+		wg sync.WaitGroup
+		am sync.Mutex
+	)
+	clientCount := serverCount * 100
+	answers := make([]int, serverCount)
+	for i := 0; i < clientCount; i++ {
+		wg.Add(1)
+		go func(x int) {
+			defer wg.Done()
+			c := &http.Client{}
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+				"http://"+hpCfg.ListenAddress, nil)
+			if err != nil {
+				panic(fmt.Sprintf("get %v: %v", x, err))
+			}
+			reply, err := c.Do(req)
+			if err != nil {
+				panic(fmt.Sprintf("do %v: %v", x, err))
+			}
+			defer reply.Body.Close()
+			switch reply.StatusCode {
+			case http.StatusOK:
+			default:
+				panic(fmt.Sprintf("%v replied %v",
+					hpCfg.ListenAddress, reply.StatusCode))
+			}
+
+			// Require X-Hproxy
+			ids := reply.Header.Get("X-Hproxy")
+			if ids == "" {
+				panic("expected X-Hproxy being set")
+			}
+
+			var jr serverReply
+			err = json.NewDecoder(reply.Body).Decode(&jr)
+			if err != nil {
+				panic(fmt.Sprintf("decode %v: %v", x, err))
+			}
+			am.Lock()
+			answers[jr.ID]++
+			am.Unlock()
+
+			// Verify that json id matches header id, a bit silly
+			// but keeps us honest.
+			if strconv.Itoa(jr.ID) != ids {
+				panic("id mismatch header: " + ids +
+					" json: " + strconv.Itoa(jr.ID))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	cancel()
+
+	// Allow 30% variance
+	acceptable := (clientCount / serverCount) / (100 / 30)
+	upperBound := (clientCount / serverCount) + acceptable
+	lowerBound := (clientCount / serverCount) - acceptable
+	total := 0
+	for k, v := range answers {
+		if v < lowerBound || v > upperBound {
+			t.Fatalf("%v out of bounds lower %v upper %v got %v",
+				k, lowerBound, upperBound, v)
+		}
+		t.Logf("node %v: %v", k, v)
+		total += v
+	}
+	if total != clientCount {
+		t.Fatalf("expected %v connections, got %v", clientCount, total)
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	serverCount := 5
+
+	servers := make([]string, 0, serverCount)
+	for i := 0; i < serverCount; i++ {
+		s := newServer(i)
+		defer s.Close()
+
+		// Verify url
+		_, err := url.Parse(s.URL)
+		if err != nil {
+			t.Fatalf("server %v: %v", i, err)
+		}
+		servers = append(servers, s.URL)
+	}
+
+	testDuration := 5 * time.Second
+	ctx, cancel := context.WithTimeout(t.Context(), testDuration)
+	_ = ctx
+	defer cancel()
+
+	// Setup hproxy
+	_, hpCfg := newHproxy(t, servers)
+	time.Sleep(500 * time.Millisecond) // Let proxies be marked healthy
+
+	// single client
+	var am sync.Mutex
+	clientCount := serverCount * 100
+	answers := make([]int, serverCount)
+	c := &http.Client{
+		Transport: http.DefaultTransport,
+	}
+	for i := 0; i < clientCount; i++ {
+		x := i
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			"http://"+hpCfg.ListenAddress, nil)
+		if err != nil {
+			t.Fatalf("get %v: %v", x, err)
+		}
+		reply, err := c.Do(req)
+		if err != nil {
+			t.Fatalf("do %v: %v", x, err)
+		}
+		defer reply.Body.Close()
+		switch reply.StatusCode {
+		case http.StatusOK:
+		default:
+			panic(fmt.Sprintf("%v replied %v",
+				hpCfg.ListenAddress, reply.StatusCode))
+		}
+
+		// Require X-Hproxy
+		ids := reply.Header.Get("X-Hproxy")
+		if ids == "" {
+			panic("expected X-Hproxy being set")
+		}
+
+		var jr serverReply
+		err = json.NewDecoder(reply.Body).Decode(&jr)
+		if err != nil {
+			t.Fatalf("decode %v: %v", x, err)
+		}
+		// Discard so that we can reuse connection
+		if _, err := io.Copy(io.Discard, reply.Body); err != nil {
+			t.Fatal(err)
+		}
+
+		am.Lock()
+		answers[jr.ID]++
+		am.Unlock()
+
+		// Verify that json id matches header id, a bit silly
+		// but keeps us honest.
+		if strconv.Itoa(jr.ID) != ids {
+			panic("id mismatch header: " + ids +
+				" json: " + strconv.Itoa(jr.ID))
+		}
+	}
+
+	cancel()
+
+	total := 0
+	for k, v := range answers {
+		t.Logf("node %v: %v", k, v)
+		total += v
+		if k != 0 && v != 0 {
+			t.Fatalf("connection was not persisted, node %v was used", k)
+		}
+	}
+	if total != clientCount {
+		t.Fatalf("expected %v connections, got %v", clientCount, total)
+	}
+}
+
+func TestFailover(t *testing.T) {
+	serverCount := 5
+
+	servers := make([]string, 0, serverCount)
+	for i := 0; i < serverCount; i++ {
+		s := newServer(i)
+		defer s.Close()
+
+		// Verify url
+		_, err := url.Parse(s.URL)
+		if err != nil {
+			t.Fatalf("server %v: %v", i, err)
+		}
+		servers = append(servers, s.URL)
+	}
+
+	testDuration := 5 * time.Second
+	ctx, cancel := context.WithTimeout(t.Context(), testDuration)
+	_ = ctx
+	defer cancel()
+
+	// Setup hproxy
+	hp, hpCfg := newHproxy(t, servers)
+	time.Sleep(500 * time.Millisecond) // Let proxies be marked healthy
+
+	// Do 10 command and fail node 0
+
+	// single client
+	var am sync.Mutex
+	clientCount := serverCount * 100
+	answers := make([]int, serverCount)
+	c := &http.Client{
+		Transport: http.DefaultTransport,
+	}
+	for i := 0; i < clientCount; i++ {
+		x := i
+		if i != 0 && i%100 == 0 {
+			t.Logf("marking node unhealthy: %v", i/100-1)
+			hp.nodeUnhealthy(i/100 - 1)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			"http://"+hpCfg.ListenAddress, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reply, err := c.Do(req)
+		if err != nil {
+			t.Fatalf("get %v: %v", x, err)
+		}
+		defer reply.Body.Close()
+		switch reply.StatusCode {
+		case http.StatusOK:
+		default:
+			panic(fmt.Sprintf("%v replied %v",
+				hpCfg.ListenAddress, reply.StatusCode))
+		}
+
+		// Require X-Hproxy
+		ids := reply.Header.Get("X-Hproxy")
+		if ids == "" {
+			panic("expected X-Hproxy being set")
+		}
+
+		var jr serverReply
+		err = json.NewDecoder(reply.Body).Decode(&jr)
+		if err != nil {
+			t.Fatalf("decode %v: %v", x, err)
+		}
+		// Discard so that we can reuse connection
+		if _, err := io.Copy(io.Discard, reply.Body); err != nil {
+			t.Fatal(err)
+		}
+
+		am.Lock()
+		answers[jr.ID]++
+		am.Unlock()
+
+		// Verify that json id matches header id, a bit silly
+		// but keeps us honest.
+		if strconv.Itoa(jr.ID) != ids {
+			panic("id mismatch header: " + ids +
+				" json: " + strconv.Itoa(jr.ID))
+		}
+	}
+
+	cancel()
+
+	total := 0
+	for k, v := range answers {
+		t.Logf("node %v: %v", k, v)
+		if v != 100 {
+			t.Fatalf("unexpected number of calls node %v got %v wanted %v",
+				k, v, 100)
+		}
+		total += v
+	}
+	if total != clientCount {
+		t.Fatalf("expected %v connections, got %v", clientCount, total)
+	}
+}

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -524,7 +524,7 @@ func TestFailover(t *testing.T) {
 		x := i
 		if i != 0 && i%100 == 0 {
 			t.Logf("marking node unhealthy: %v", i/100-1)
-			hp.nodeUnhealthy(i/100 - 1)
+			hp.nodeUnhealthy(i/100-1, errors.New("forced"))
 		}
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet,


### PR DESCRIPTION
**Summary**
proxyd tried to solve all problems and per the laws of physics, it made everything worse.

hproxy is a dead simple replacement that throws opgeth commands over the fence and maintains a list of concurrent nodes.

**Changes**
No changes, all greenfield.