### PR TITLE
leveldb: fix dataraces in db packages

### DIFF
--- a/database/level/level.go
+++ b/database/level/level.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -106,14 +107,18 @@ func (l *Database) DB() Pool {
 	log.Tracef("DB")
 	defer log.Tracef("DB exit")
 
-	return l.pool
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
+	return maps.Clone(l.pool)
 }
 
 func (l *Database) RawDB() RawPool {
 	log.Tracef("RawDB")
 	defer log.Tracef("RawDB exit")
 
-	return l.rawPool
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
+	return maps.Clone(l.rawPool)
 }
 
 func (l *Database) RegisterNotification(ctx context.Context, n database.NotificationName, f database.NotificationCallback, payload any) error {


### PR DESCRIPTION
**Summary**
There are some races when people touch the same map in different locations.

This clones the map or otherwise tries to not have multiple "accessors" at the same time.

**Changes**
<!-- A list of changes made by this pull request. -->
