### PR TITLE
tbc: fix unused variable

### DIFF
--- a/service/tbc/peer/peer_test.go
+++ b/service/tbc/peer/peer_test.go
@@ -55,7 +55,7 @@ func TestPeer(t *testing.T) {
 
 	// Get unknown block
 	blockUnknown := &chainhash.Hash{}
-	h, err = p.GetHeaders(ctx, []*chainhash.Hash{blockUnknown}, nil)
+	_, err = p.GetHeaders(ctx, []*chainhash.Hash{blockUnknown}, nil)
 	if !errors.Is(err, ErrUnknown) {
 		t.Fatalf("expected unknown error, got %v", err)
 	}


### PR DESCRIPTION
**Summary**
fix unused variable caught by linter

**Changes**
see summary
