### PR TITLE
ci: restrict token permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
   # Build and test
   test-go:
     name: "Test (Go)"
+    permissions:
+      contents: read
     uses: ./.github/workflows/go.yml
 
   # Create GitHub Release


### PR DESCRIPTION
**Summary**
Restrict token permissions for `test-go` job in release workflow. These token permissions are limited inside the `go.yml` workflow itself, however GitHub flagged this as a risk and it does not hurt to restrict them here as well.

Fixes https://github.com/hemilabs/heminetwork/security/code-scanning/16

**Changes**
- Add `permissions` block to `test-go` job in `release workflow`, limiting the `GITHUB_TOKEN` permissions to reading contents only.
