### PR TITLE
popm: add static fee override

### DIFF
--- a/bitcoin/wallet/wallet.go
+++ b/bitcoin/wallet/wallet.go
@@ -57,7 +57,7 @@ func UtxoPickerSingle(amount, fee btcutil.Amount, utxos []*tbcapi.UTXO) (*tbcapi
 	return nil, errors.New("no suitable utxo found")
 }
 
-func TransactionCreate(locktime uint32, amount, satsPerByte btcutil.Amount, address btcutil.Address, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, map[string][]byte, error) {
+func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerByte float64, address btcutil.Address, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, map[string][]byte, error) {
 	// Create TxOut
 	payToScript, err := txscript.PayToAddrScript(address)
 	if err != nil {
@@ -70,7 +70,7 @@ func TransactionCreate(locktime uint32, amount, satsPerByte btcutil.Amount, addr
 
 	// Calculate fee for worst case input number and assume there is change
 	txSize := txsizes.EstimateSerializeSize(len(utxos), []*wire.TxOut{txOut}, true)
-	fee := btcutil.Amount(txSize) * satsPerByte
+	fee := btcutil.Amount(float64(txSize) * satsPerByte)
 
 	// Find utxo list that is big enough for entire transaction
 	utxoList, err := UtxoPickerMultiple(amount, fee, utxos)
@@ -80,7 +80,7 @@ func TransactionCreate(locktime uint32, amount, satsPerByte btcutil.Amount, addr
 
 	// Calculate fee for real input number and assume there is change
 	txSize = txsizes.EstimateSerializeSize(len(utxoList), []*wire.TxOut{txOut}, true)
-	fee = btcutil.Amount(txSize) * satsPerByte
+	fee = btcutil.Amount(float64(txSize) * satsPerByte)
 
 	// Assemble transaction
 	tx := wire.NewMsgTx(2) // Latest supported version
@@ -104,7 +104,7 @@ func TransactionCreate(locktime uint32, amount, satsPerByte btcutil.Amount, addr
 	return tx, prevOuts, nil
 }
 
-func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerByte btcutil.Amount, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, map[string][]byte, error) {
+func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerByte float64, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, map[string][]byte, error) {
 	// Create OP_RETURN
 	aks := hemi.L2KeystoneAbbreviate(*l2keystone)
 	popTx := pop.TransactionL2{L2Keystone: aks}
@@ -116,7 +116,7 @@ func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerB
 
 	// Calculate fee for 1 input and assume there is change
 	txSize := txsizes.EstimateSerializeSize(1, []*wire.TxOut{popTxOut}, true)
-	fee := btcutil.Amount(txSize) * satsPerByte
+	fee := btcutil.Amount(float64(txSize) * satsPerByte)
 
 	// Find utxo that is big enough for entire transaction
 	utxo, err := UtxoPickerSingle(0, fee, utxos) // no amount, just fees

--- a/bitcoin/wallet/wallet_test.go
+++ b/bitcoin/wallet/wallet_test.go
@@ -181,7 +181,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	tx, prevOut, err := TransactionCreate(uint32(time.Now().Unix()),
-		btcutil.Amount(550), btcutil.Amount(feeEstimateForTx.SatsPerByte), addr, utxos, pkscript)
+		btcutil.Amount(550), feeEstimateForTx.SatsPerByte, addr, utxos, pkscript)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	popTx, prevOut, err := PoPTransactionCreate(keystone, uint32(time.Now().Unix()),
-		btcutil.Amount(feeEstimateForPop.SatsPerByte+0.5), utxos, pkscript)
+		feeEstimateForPop.SatsPerByte+0.5, utxos, pkscript)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -79,6 +79,18 @@ var (
 			Help:         "the bitcoin url to connect to; it's either a tbc or blockstream url",
 			Print:        config.PrintAll,
 		},
+		"POPM_FEE_OVERRIDE": config.Config{
+			Value:        &cfg.StaticFee,
+			DefaultValue: false,
+			Help:         "if popm should override fee estimation and use a static fee",
+			Print:        config.PrintAll,
+		},
+		"POPM_FEE_AMOUNT": config.Config{
+			Value:        &cfg.StaticFeeAmount,
+			DefaultValue: uint(1),
+			Help:         "static fee amount in sats/byte (requires POPM_FEE_OVERRIDE=true)",
+			Print:        config.PrintAll,
+		},
 	}
 )
 

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -81,8 +81,8 @@ var (
 		},
 		"POPM_STATIC_FEE": config.Config{
 			Value:        &cfg.StaticFee,
-			DefaultValue: uint(0),
-			Help:         "static fee amount in sats/byte; overrides fee estimation if greater than 0",
+			DefaultValue: float64(0),
+			Help:         "static fee amount in sats/byte; overrides fee estimation if greater than 0. Can be decimal (ex. 1.5 sats/byte)",
 			Print:        config.PrintAll,
 		},
 	}

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -79,16 +79,10 @@ var (
 			Help:         "the bitcoin url to connect to; it's either a tbc or blockstream url",
 			Print:        config.PrintAll,
 		},
-		"POPM_FEE_OVERRIDE": config.Config{
+		"POPM_STATIC_FEE": config.Config{
 			Value:        &cfg.StaticFee,
-			DefaultValue: false,
-			Help:         "if popm should override fee estimation and use a static fee",
-			Print:        config.PrintAll,
-		},
-		"POPM_FEE_AMOUNT": config.Config{
-			Value:        &cfg.StaticFeeAmount,
-			DefaultValue: uint(1),
-			Help:         "static fee amount in sats/byte (requires POPM_FEE_OVERRIDE=true)",
+			DefaultValue: uint(0),
+			Help:         "static fee amount in sats/byte; overrides fee estimation if greater than 0",
 			Print:        config.PrintAll,
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,14 @@ func Parse(c CfgMap) error {
 				}
 				reflect.ValueOf(v.Value).Elem().SetInt(evTyped)
 
+			case reflect.Float32, reflect.Float64:
+				evTyped, err := strconv.ParseFloat(envValue, 64)
+				if err != nil {
+					return fmt.Errorf("invalid float for %v: %w",
+						k, err)
+				}
+				reflect.ValueOf(v.Value).Elem().SetFloat(evTyped)
+
 			case reflect.Uint, reflect.Uint8, reflect.Uint16,
 				reflect.Uint32, reflect.Uint64:
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -344,23 +344,22 @@ func (s *Server) getFee(ctx context.Context) (*tbcapi.FeeEstimate, error) {
 	log.Tracef("getFee")
 	defer log.Tracef("getFee exit")
 
-	var feeAmount *tbcapi.FeeEstimate
 	if s.cfg.StaticFee != 0 {
-		feeAmount = &tbcapi.FeeEstimate{
+		return &tbcapi.FeeEstimate{
 			Blocks:      s.cfg.BitcoinConfirmations,
 			SatsPerByte: float64(s.cfg.StaticFee),
-		}
-	} else {
-		// Estimate BTC fees.
-		feeEstimates, err := s.gozer.FeeEstimates(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("fee estimates: %w", err)
-		}
-		feeAmount, err = gozer.FeeByConfirmations(s.cfg.BitcoinConfirmations, feeEstimates)
-		if err != nil {
-			return nil, fmt.Errorf("fee by confirmations: %w", err)
-		}
+		}, nil
 	}
+	// Estimate BTC fees.
+	feeEstimates, err := s.gozer.FeeEstimates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fee estimates: %w", err)
+	}
+	feeAmount, err := gozer.FeeByConfirmations(s.cfg.BitcoinConfirmations, feeEstimates)
+	if err != nil {
+		return nil, fmt.Errorf("fee by confirmations: %w", err)
+	}
+
 	return feeAmount, nil
 }
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -78,8 +78,7 @@ type Config struct {
 	PrometheusListenAddress string
 	PrometheusNamespace     string
 	RetryMineThreshold      uint
-	StaticFee               bool
-	StaticFeeAmount         uint
+	StaticFee               uint
 
 	// cooked settings, do not export
 	opgethReconnectTimeout time.Duration
@@ -171,9 +170,9 @@ func NewServer(cfg *Config) (*Server, error) {
 		workC:          make(chan struct{}, 2),
 	}
 
-	if cfg.StaticFee && cfg.StaticFeeAmount < minRelayFee {
+	if cfg.StaticFee != 0 && cfg.StaticFee < minRelayFee {
 		return nil, fmt.Errorf("static fee set to %v, minimum is %v",
-			cfg.StaticFeeAmount, minRelayFee)
+			cfg.StaticFee, minRelayFee)
 	}
 
 	switch strings.ToLower(cfg.Network) {
@@ -346,10 +345,10 @@ func (s *Server) getFee(ctx context.Context) (*tbcapi.FeeEstimate, error) {
 	defer log.Tracef("getFee exit")
 
 	var feeAmount *tbcapi.FeeEstimate
-	if s.cfg.StaticFee {
+	if s.cfg.StaticFee != 0 {
 		feeAmount = &tbcapi.FeeEstimate{
 			Blocks:      s.cfg.BitcoinConfirmations,
-			SatsPerByte: float64(s.cfg.StaticFeeAmount),
+			SatsPerByte: float64(s.cfg.StaticFee),
 		}
 	} else {
 		// Estimate BTC fees.

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	btcmempool "github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/juju/loggo"
@@ -54,8 +53,7 @@ const (
 	defaultL2KeystonePollTimeout  = 13 * time.Second
 	defaultL2KeystoneRetryTimeout = 15 * time.Second
 
-	// convert btcd minimum fee from sat/kB to sat/byte
-	minRelayFee = uint(btcmempool.DefaultMinRelayTxFee) / 1000
+	minRelayFee = 1 // sats/vB
 )
 
 var log = loggo.GetLogger("popm")

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -343,21 +343,12 @@ func TestStaticFee(t *testing.T) {
 	cfg.BitcoinSource = "tbc"
 	cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
 	cfg.LogLevel = "popm=TRACE; mock=TRACE;"
-	cfg.StaticFee = true
-	cfg.StaticFeeAmount = 0
+	cfg.StaticFee = 3
 
 	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
 		t.Fatal(err)
 	}
 
-	// shouldn't allow static fee of 0
-	_, err := NewServer(cfg)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-
-	cfg.StaticFeeAmount = 3
-	// should allow static fee of 3
 	s, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -334,6 +334,45 @@ func TestDisconnectedOpgeth(t *testing.T) {
 	}
 }
 
+func TestStaticFee(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	// Setup pop miner
+	cfg := NewDefaultConfig()
+	cfg.BitcoinSource = "tbc"
+	cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
+	cfg.LogLevel = "popm=TRACE; mock=TRACE;"
+	cfg.StaticFee = true
+	cfg.StaticFeeAmount = 0
+
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		t.Fatal(err)
+	}
+
+	// shouldn't allow static fee of 0
+	_, err := NewServer(cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	cfg.StaticFeeAmount = 3
+	// shouldn't allow static fee of 0
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fee, err := s.getFee(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fee.SatsPerByte != 3 {
+		t.Fatalf("expected fee of 3 sats/byte, got %v sats/byte", fee.SatsPerByte)
+	}
+}
+
 func messageListener(t *testing.T, expected map[string]int, errCh chan error, msgCh chan string) error {
 	for {
 		select {

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -343,24 +343,30 @@ func TestStaticFee(t *testing.T) {
 	cfg.BitcoinSource = "tbc"
 	cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
 	cfg.LogLevel = "popm=TRACE; mock=TRACE;"
-	cfg.StaticFee = 3
+	cfg.StaticFee = 0.5
 
 	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
 		t.Fatal(err)
 	}
 
+	_, err := NewServer(cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	cfg.StaticFee = 1.5
 	s, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fee, err := s.getFee(ctx)
+	fee, err := s.estimateFee(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if fee.SatsPerByte != 3 {
-		t.Fatalf("expected fee of 3 sats/byte, got %v sats/byte", fee.SatsPerByte)
+	if fee.SatsPerByte != 1.5 {
+		t.Fatalf("expected fee of 1.5 sats/byte, got %v sats/byte", fee.SatsPerByte)
 	}
 }
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -357,7 +357,7 @@ func TestStaticFee(t *testing.T) {
 	}
 
 	cfg.StaticFeeAmount = 3
-	// shouldn't allow static fee of 0
+	// should allow static fee of 3
 	s, err := NewServer(cfg)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**Summary**
Currently, fee calculation for pop miners is done by the gozer. However, the only functional gozer is TBC, which requires the mempool to be enabled in order for fee estimation to work. This can be both expensive and potentially unreliable. As such, an option to override fee estimation with a static fee was added.

**Changes**
Introduce a way to set a static fee for the pop miner.
Changed the wallet transaction creation methods to allow float sats/byte fees.
Changed config.go to be able to parse float values in env vars. 
