### PR TITLE
popm, bfg: more test fixes

### DIFF
--- a/service/bfg/bfg_test.go
+++ b/service/bfg/bfg_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -72,30 +71,11 @@ func TestBFG(t *testing.T) {
 		}
 	}()
 
-	// messages we expect to receive
-	expectedMsg := map[string]int{
-		"kss_getKeystone":                      wantedKeystones,
-		tbcapi.CmdBlocksByL2AbrevHashesRequest: wantedKeystones,
-	}
-
 	for !s.Connected() {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	var wg sync.WaitGroup
-	// send finality requests to bfg, which should return super finality
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		sendFinalityRequests(ctx, kssList, bfgCfg.ListenAddress, 9, 10000)
-	}()
-
-	// receive messages and errors from opgeth and tbc
-	if err = messageListener(t, expectedMsg, errCh, msgCh); err != nil {
-		t.Fatal(err)
-	}
-
-	wg.Wait()
+	sendFinalityRequests(ctx, kssList, bfgCfg.ListenAddress, 9, 10000)
 }
 
 func TestKeystoneFinalityInheritance(t *testing.T) {
@@ -152,30 +132,11 @@ func TestKeystoneFinalityInheritance(t *testing.T) {
 		}
 	}()
 
-	// messages we expect to receive
-	expectedMsg := map[string]int{
-		"kss_getKeystone":                      wantedKeystones,
-		tbcapi.CmdBlocksByL2AbrevHashesRequest: wantedKeystones,
-	}
-
 	for !s.Connected() {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	var wg sync.WaitGroup
-	// send finality requests to bfg, which should return super finality
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		sendFinalityRequests(ctx, kssList, bfgCfg.ListenAddress, 9, 10000)
-	}()
-
-	// receive messages and errors from opgeth and tbc
-	if err = messageListener(t, expectedMsg, errCh, msgCh); err != nil {
-		t.Fatal(err)
-	}
-
-	wg.Wait()
+	sendFinalityRequests(ctx, kssList, bfgCfg.ListenAddress, 9, 10000)
 }
 
 func TestFullMockIntegration(t *testing.T) {
@@ -204,7 +165,7 @@ func TestFullMockIntegration(t *testing.T) {
 	bfgCfg.BitcoinURL = "ws" + strings.TrimPrefix(mtbc.URL(), "http")
 	bfgCfg.OpgethURL = "ws" + strings.TrimPrefix(opgeth.URL(), "http")
 	bfgCfg.ListenAddress = createAddress()
-	// bfgCfg.LogLevel = "bfg=Info; mock=Trace; popm=TRACE"
+	bfgCfg.LogLevel = "bfg=Info; mock=Trace; popm=TRACE"
 
 	if err := loggo.ConfigureLoggers(bfgCfg.LogLevel); err != nil {
 		t.Fatal(err)
@@ -234,7 +195,7 @@ func TestFullMockIntegration(t *testing.T) {
 	popCfg.BitcoinURL = "ws" + strings.TrimPrefix(mtbc.URL(), "http")
 	popCfg.OpgethURL = "ws" + strings.TrimPrefix(opgeth.URL(), "http")
 	popCfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
-	// popCfg.LogLevel = "popm=TRACE"
+	popCfg.LogLevel = "popm=TRACE"
 
 	// Create pop miner
 	popm, err := popm.NewServer(popCfg)

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -82,12 +82,15 @@ type Config struct {
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		Network:              "mainnet",
-		PrometheusNamespace:  appName,
-		OpgethURL:            defaultOpgethURL,
-		BitcoinConfirmations: defaultBitcoinConfirmations,
-		BitcoinSource:        bitcoinSourceTBC,
-		BitcoinURL:           tbcgozer.DefaultURL,
+		Network:                "mainnet",
+		PrometheusNamespace:    appName,
+		OpgethURL:              defaultOpgethURL,
+		BitcoinConfirmations:   defaultBitcoinConfirmations,
+		BitcoinSource:          bitcoinSourceTBC,
+		BitcoinURL:             tbcgozer.DefaultURL,
+		opgethReconnectTimeout: defaultOpgethReconnectTimeout,
+		l2KeystoneMaxAge:       defaultL2KeystoneMaxAge,
+		l2KeystonePollTimeout:  defaultL2KeystonePollTimeout,
 	}
 }
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -316,7 +316,7 @@ func TestDisconnectedOpgeth(t *testing.T) {
 	}
 
 	// close current popm connection to opgeth
-	if err = opgeth.CloseConnections(); err != nil && !errors.Is(err, net.ErrClosed) {
+	if err = opgeth.CloseConnections(false); err != nil && !errors.Is(err, net.ErrClosed) {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
**Summary**
Fixes a few more tests.

**Changes**
For some reason, some important settings were not being set in `popm`, which broke the tests (correctly). This has been fixed. 
Also changed the `close` behavior on the websocket connections of the mock servers.
