### PR TITLE
popm: add exponential backoff reconnection logic to opgeth

### DIFF
--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -590,8 +590,8 @@ func (s *Server) opgeth(ctx context.Context) {
 			delay = maxDelay
 		}
 
-		jitter := delay / 10
-		delay += time.Duration(mathrand.Int64N(int64(jitter)*2) - int64(jitter))
+		jitter := int64(delay / 10)
+		delay += time.Duration(mathrand.Int64N(jitter*2) - jitter)
 
 		log.Debugf("reconnecting to: %v in %v", s.cfg.OpgethURL, delay)
 


### PR DESCRIPTION
## Changes
- Modified `Server.opgeth()` method to implement exponential backoff instead of fixed timeout
- Uses existing `opgethReconnectTimeout` config as base delay
- Exponential growth: `baseDelay * 2^(attempt-1)` for first 3 attempts
- Maximum delay capped at 15 seconds (as specified in issue)
- Adds jitter (0-10% of delay) 
- Resets attempt counter on successful reconnection
- Maintains infinite retry behavior as well

Fixes #569 