### PR TITLE
tbcgozer, mock: reader logic & add additional test

### DIFF
--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -149,5 +149,4 @@ func TestTBCGozerCalls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }


### PR DESCRIPTION
**Summary**
The `TestTbcGozer` test seems to timeout at times. This is likely due to using a real TBC instance and making various calls to it. Even if this does not fix the error, I believe it is still good to separate the functionality and connection logic of the test into two.

Also changes how the `mock opgeth` server handles reading messages.

**Changes**
Separate this test into two:
- `TestTBCGozerConnection`: connect to a real TBC instance and make an inexpensive call.
- `TestTBCGozerCalls`: connect to a mock TBC instance and make various calls.

Use `Reader` rather than `Read` to receive messages in the mock opgeth server, as the latter will return EOF if there is no message to be read.