### PR TITLE
re-added sql files needed to set up localnode

### DIFF
--- a/database/bfgd/scripts/0001.sql
+++ b/database/bfgd/scripts/0001.sql
@@ -1,0 +1,68 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+-- Create database version
+CREATE TABLE version (version INTEGER UNIQUE NOT NULL);
+
+-- Populate version
+INSERT INTO version (version) VALUES (1);
+
+-- Create L2 keystone table
+CREATE TABLE l2_keystones(
+	l2_keystone_abrev_hash	BYTEA PRIMARY KEY NOT NULL,
+	version			INTEGER NOT NULL,
+	l1_block_number		BIGINT NOT NULL,
+	l2_block_number		BIGINT NOT NULL,
+	parent_ep_hash		BYTEA NOT NULL,
+	prev_keystone_ep_hash	BYTEA NOT NULL,
+	state_root		BYTEA NOT NULL,
+	ep_hash			BYTEA NOT NULL,
+	created_at		TIMESTAMP NOT NULL DEFAULT NOW(),
+	updated_at		TIMESTAMP,
+
+	CONSTRAINT l2_keystone_abrev_hash_length CHECK (octet_length(l2_keystone_abrev_hash) = 32),
+	CONSTRAINT parent_ep_hash_length CHECK (octet_length(parent_ep_hash) = 32),
+	CONSTRAINT prev_keystone_ep_hash_length CHECK (octet_length( prev_keystone_ep_hash) = 32),
+	CONSTRAINT state_root_length CHECK (octet_length(state_root) = 32),
+	CONSTRAINT ep_hash_length CHECK (octet_length(ep_hash) = 32)
+);
+
+-- Create btc blocks table
+CREATE TABLE btc_blocks(
+	hash		BYTEA PRIMARY KEY UNIQUE NOT NULL,
+	header		BYTEA NOT NULL,
+	height		BIGINT NOT NULL,
+	created_at	TIMESTAMP NOT NULL DEFAULT NOW(),
+	updated_at	TIMESTAMP,
+
+	CONSTRAINT btc_blocks_hash UNIQUE (hash, header),
+	CONSTRAINT hash_length CHECK (octet_length(hash) = 32),
+	CONSTRAINT header_length CHECK (octet_length(header) = 80)
+);
+
+-- Create pop data table
+CREATE TABLE pop_basis(
+	id			BIGSERIAL PRIMARY KEY NOT NULL,
+        btc_txid                BYTEA NOT NULL,
+        btc_raw_tx              BYTEA NOT NULL,
+        btc_block_hash          BYTEA REFERENCES btc_blocks(hash) DEFAULT NULL,
+        btc_tx_index            BIGINT DEFAULT NULL,
+        btc_merkle_path         JSON DEFAULT NULL,
+        pop_txid                BYTEA DEFAULT NULL,
+        l2_keystone_abrev_hash  BYTEA NOT NULL,
+        pop_miner_public_key    BYTEA NOT NULL,
+        created_at              TIMESTAMP NOT NULL DEFAULT NOW(),
+        updated_at              TIMESTAMP,
+
+        UNIQUE (btc_txid, btc_raw_tx, btc_block_hash, btc_tx_index),
+
+        CONSTRAINT btc_txid_length CHECK (octet_length(btc_txid) = 32),
+        CONSTRAINT pop_txid_length CHECK (pop_txid IS NOT NULL OR octet_length(pop_txid) = 32)
+);
+
+CREATE UNIQUE INDEX btc_txid_unconfirmed ON pop_basis (btc_txid) WHERE (btc_block_hash IS NULL);
+
+COMMIT;

--- a/database/bfgd/scripts/0002.sql
+++ b/database/bfgd/scripts/0002.sql
@@ -1,0 +1,52 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 2;
+
+-- this materialized view represents the canonical btc_blocks as we know it
+CREATE MATERIALIZED VIEW btc_blocks_can AS 
+
+WITH RECURSIVE bb AS (
+			SELECT hash, header, height FROM btc_blocks
+			WHERE height = (
+				SELECT MAX(height) as height
+				FROM __highest
+				WHERE c = 1
+			)
+		
+			UNION 
+		
+			SELECT 
+				btc_blocks.hash, 
+				btc_blocks.header,
+				btc_blocks.height
+			FROM btc_blocks, bb
+			WHERE 
+
+            -- try to find the parent block via header -> parent hash
+			(
+				substr(bb.header, 5, 32) = btc_blocks.hash 
+				AND bb.height > btc_blocks.height
+			)
+			OR
+            -- OR find one of the next highest btc_blocks we know about, 
+            -- we may be missing a block this connects that
+			btc_blocks.hash = (
+				SELECT hash FROM btc_blocks 
+				WHERE height < bb.height ORDER BY height DESC LIMIT 1)
+		), __highest AS (
+			SELECT height, count(*) AS c
+			FROM btc_blocks
+			GROUP BY height
+		)
+SELECT * FROM bb;
+
+CREATE INDEX height_idx on btc_blocks (height DESC);
+CREATE INDEX btc_block_hash_idx on pop_basis (btc_block_hash);
+CREATE INDEX l2_keystone_abrev_hash_idx on pop_basis (l2_keystone_abrev_hash);
+CREATE INDEX l2_keystone_l2_block_number_idx on l2_keystones (l2_block_number);
+
+COMMIT;

--- a/database/bfgd/scripts/0003.sql
+++ b/database/bfgd/scripts/0003.sql
@@ -1,0 +1,14 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 3;
+
+CREATE TABLE access_public_keys (
+    public_key BYTEA NOT NULL PRIMARY KEY CHECK (LENGTH(public_key) = 33),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+COMMIT;

--- a/database/bfgd/scripts/0004.sql
+++ b/database/bfgd/scripts/0004.sql
@@ -1,0 +1,38 @@
+-- Copyright (c) 2024-2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 4;
+
+-- Notification stored procedure
+CREATE FUNCTION notify_event() RETURNS TRIGGER AS $$
+	DECLARE
+		data_old json;
+		data_new json;
+		notification json;
+
+	BEGIN
+		data_old = row_to_json(OLD);
+		data_new = row_to_json(NEW);
+
+		-- Construct the notification as a JSON string.
+		notification = json_build_object(
+			'table', TG_TABLE_NAME,
+			'action', TG_OP,
+			'data_new', data_new,
+			'data_old', data_old);
+
+		-- Execute pg_notify(channel, notification)
+		PERFORM pg_notify('events', notification::text);
+
+		-- Result is ignored since this is an AFTER trigger
+		RETURN NULL;
+	END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER btc_blocks_event AFTER INSERT OR UPDATE
+	ON btc_blocks FOR EACH ROW EXECUTE PROCEDURE notify_event();
+
+COMMIT;

--- a/database/bfgd/scripts/0005.sql
+++ b/database/bfgd/scripts/0005.sql
@@ -1,0 +1,33 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 5;
+
+CREATE FUNCTION refresh_btc_blocks_can()
+    RETURNS TRIGGER
+    LANGUAGE PLPGSQL
+AS
+$$
+BEGIN
+    REFRESH MATERIALIZED VIEW btc_blocks_can;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER btc_blocks_canonical_refresh_btc_blocks AFTER INSERT OR UPDATE
+	ON btc_blocks FOR EACH STATEMENT EXECUTE PROCEDURE refresh_btc_blocks_can();
+
+CREATE TRIGGER btc_blocks_canonical_refresh_l2_keystones AFTER INSERT OR UPDATE
+	ON l2_keystones FOR EACH STATEMENT EXECUTE PROCEDURE refresh_btc_blocks_can();
+
+CREATE TRIGGER btc_blocks_canonical_refresh_pop_basis AFTER INSERT OR UPDATE
+	ON pop_basis FOR EACH STATEMENT EXECUTE PROCEDURE refresh_btc_blocks_can();
+
+
+CREATE TRIGGER access_public_keys_delete AFTER DELETE
+	ON access_public_keys FOR EACH ROW EXECUTE PROCEDURE notify_event();
+
+COMMIT;

--- a/database/bfgd/scripts/0006.sql
+++ b/database/bfgd/scripts/0006.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 6;
+
+CREATE TRIGGER l2_keystones_changed AFTER INSERT
+	ON l2_keystones FOR EACH STATEMENT EXECUTE PROCEDURE notify_event();
+
+COMMIT;

--- a/database/bfgd/scripts/0007.sql
+++ b/database/bfgd/scripts/0007.sql
@@ -1,0 +1,13 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 7;
+
+DROP TRIGGER btc_blocks_canonical_refresh_l2_keystones ON l2_keystones;
+
+DROP TRIGGER btc_blocks_canonical_refresh_pop_basis ON pop_basis;
+
+COMMIT;

--- a/database/bfgd/scripts/0008.sql
+++ b/database/bfgd/scripts/0008.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 8;
+
+CREATE INDEX btc_blocks_header_prev_hash_idx ON btc_blocks (substr(header, 5, 32));
+
+COMMIT;

--- a/database/bfgd/scripts/0009.sql
+++ b/database/bfgd/scripts/0009.sql
@@ -1,0 +1,27 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 9;
+
+CREATE INDEX btc_blocks_can_hash_idx ON btc_blocks_can (hash);
+CREATE INDEX btc_blocks_can_height_idx ON btc_blocks_can (height);
+
+CREATE TABLE btc_transaction_broadcast_request (
+    tx_id			            TEXT PRIMARY KEY NOT NULL,
+    serialized_tx               BYTEA NOT NULL,
+    broadcast_at                TIMESTAMP,
+    last_broadcast_attempt_at   TIMESTAMP,
+    next_broadcast_attempt_at   TIMESTAMP,
+    created_at                  TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_error TEXT
+);
+
+CREATE INDEX ON btc_transaction_broadcast_request (last_broadcast_attempt_at) WHERE  broadcast_at IS NULL;
+CREATE INDEX btc_transaction_broadcast_request_created_at_new ON btc_transaction_broadcast_request (created_at) WHERE broadcast_at IS NULL AND next_broadcast_attempt_at IS NULL; 
+CREATE INDEX btc_transaction_broadcast_request_created_at_retry ON btc_transaction_broadcast_request (created_at) WHERE broadcast_at IS NULL; 
+
+
+COMMIT;

--- a/database/bfgd/scripts/0010.sql
+++ b/database/bfgd/scripts/0010.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 10;
+
+CREATE INDEX IF NOT EXISTS btc_transaction_broadcast_request_created_at_retry_desc 
+    ON btc_transaction_broadcast_request  (last_broadcast_attempt_at, created_at DESC) WHERE next_broadcast_attempt_at IS NOT NULL AND broadcast_at IS NULL;
+
+COMMIT;

--- a/database/bfgd/scripts/0011.sql
+++ b/database/bfgd/scripts/0011.sql
@@ -1,0 +1,12 @@
+
+-- Copyright (c) 2024 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 11;
+
+CREATE INDEX pop_pasis_published_pop_txs_desc_idx ON pop_basis (l2_keystone_abrev_hash, id ASC) WHERE btc_block_hash IS NOT NULL;
+
+COMMIT;

--- a/database/bfgd/scripts/0012.sql
+++ b/database/bfgd/scripts/0012.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 12;
+
+DROP TABLE access_public_keys;
+
+COMMIT;

--- a/database/bfgd/scripts/0013.sql
+++ b/database/bfgd/scripts/0013.sql
@@ -1,0 +1,18 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 13;
+
+CREATE TABLE l2_keystones_lowest_btc_block (
+    l2_keystone_abrev_hash BYTEA NOT NULL PRIMARY KEY REFERENCES l2_keystones(l2_keystone_abrev_hash),
+    btc_block_hash BYTEA REFERENCES btc_blocks(hash) DEFAULT NULL,
+    btc_block_height BIGINT NULL
+);
+
+CREATE TRIGGER pop_basis_upsert AFTER INSERT OR DELETE OR UPDATE
+	ON pop_basis FOR EACH ROW EXECUTE PROCEDURE notify_event();
+
+COMMIT;

--- a/database/bfgd/scripts/0014.sql
+++ b/database/bfgd/scripts/0014.sql
@@ -1,0 +1,13 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 14;
+
+DROP TABLE l2_keystones_lowest_btc_block;
+
+DROP TRIGGER pop_basis_upsert ON pop_basis;
+
+COMMIT;

--- a/database/bfgd/scripts/0015.sql
+++ b/database/bfgd/scripts/0015.sql
@@ -1,0 +1,26 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 15;
+
+DROP TRIGGER btc_blocks_canonical_refresh_btc_blocks ON btc_blocks;
+
+DROP FUNCTION refresh_btc_blocks_can();
+
+-- no longer have BFG responsible for the canonical chain
+DROP MATERIALIZED VIEW btc_blocks_can;
+
+
+-- we now trust electrs/bitcoind to maintain the best chain, height becomes
+-- unique in this table
+ALTER TABLE btc_blocks ADD UNIQUE (height);
+
+-- when a btc block becomes "invalid" (orphaned), delete it and all pop_bases 
+-- that referenced it
+ALTER TABLE pop_basis DROP CONSTRAINT pop_basis_btc_block_hash_fkey;
+ALTER TABLE pop_basis ADD CONSTRAINT pop_basis_btc_block_hash_fkey FOREIGN KEY (btc_block_hash) REFERENCES btc_blocks (hash) ON DELETE CASCADE;
+
+COMMIT;

--- a/database/bfgd/scripts/0016.sql
+++ b/database/bfgd/scripts/0016.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 16;
+
+ALTER TABLE pop_basis DROP CONSTRAINT pop_basis_btc_block_hash_fkey;
+
+-- upon a re-org, set all references to deleted btc block to NULL, then delete those rows via a trigger
+
+ALTER TABLE pop_basis ADD CONSTRAINT pop_basis_btc_block_hash_fkey FOREIGN KEY (btc_block_hash) REFERENCES btc_blocks (hash) ON UPDATE SET NULL;
+
+CREATE FUNCTION clean_pop_basis() RETURNS TRIGGER AS $clean_pop_basis$
+    BEGIN
+        DELETE FROM pop_basis WHERE btc_block_hash IS NULL;
+        RETURN NULL;
+    END;
+$clean_pop_basis$ LANGUAGE plpgsql;
+
+CREATE TRIGGER btc_blocks_clean AFTER INSERT OR UPDATE OR DELETE 
+	ON btc_blocks EXECUTE FUNCTION clean_pop_basis();
+
+COMMIT;

--- a/database/bfgd/scripts/0017.sql
+++ b/database/bfgd/scripts/0017.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2025 Hemi Labs, Inc.
+-- Use of this source code is governed by the MIT License,
+-- which can be found in the LICENSE file.
+
+BEGIN;
+
+UPDATE version SET version = 17;
+
+DROP INDEX btc_txid_unconfirmed;
+
+COMMIT;
+

--- a/database/bfgd/scripts/createdb.sh
+++ b/database/bfgd/scripts/createdb.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+#
+
+. ./db.sh
+
+createdb

--- a/database/bfgd/scripts/db.sh
+++ b/database/bfgd/scripts/db.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+#
+
+if [ -z ${PSQL} ]; then
+	PSQL=psql
+fi
+
+if [ -z ${DBNAME} ]; then
+	DBNAME=bfgdb
+fi
+
+. ../../scripts/db.sh

--- a/database/bfgd/scripts/dropdb.sh
+++ b/database/bfgd/scripts/dropdb.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+#
+
+. ./db.sh
+
+dropdb

--- a/database/bfgd/scripts/populatedb.sh
+++ b/database/bfgd/scripts/populatedb.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+#
+
+. ./db.sh
+
+populatedb

--- a/database/bfgd/scripts/upgradedb.sh
+++ b/database/bfgd/scripts/upgradedb.sh
@@ -1,0 +1,10 @@
+#/bin/sh
+#
+# Copyright (c) 2024 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+#
+
+. ./db.sh
+
+upgradedb


### PR DESCRIPTION
**Summary**
re-added sql files needed to set up localnode's bfgd-postgres.  these files are used to set up the schema and most were deleted during the rework

fixes #628

**Changes**
see summary

---

re-ran locally to test...

```shell
docker compose -f ./localnode/docker-compose.yml up bfgd-postgres
```

```shell
$ docker compose -f ./localnode/docker-compose.yml exec -it bfgd-postgres psql -U postgres --host localhost
psql (16.3)
Type "help" for help.

postgres=# \c bfg
You are now connected to database "bfg" as user "postgres".
bfg=# \d
                        List of relations
 Schema |               Name                |   Type   |  Owner   
--------+-----------------------------------+----------+----------
 public | btc_blocks                        | table    | postgres
 public | btc_transaction_broadcast_request | table    | postgres
 public | l2_keystones                      | table    | postgres
 public | pop_basis                         | table    | postgres
 public | pop_basis_id_seq                  | sequence | postgres
 public | version                           | table    | postgres
(6 rows)
```
