### PR TITLE
ci, goreleaser: add supply chain attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,6 @@ concurrency:
 
 env:
   GO_VERSION: "1.24.x"
-  PNPM_VERSION: "9.4.x"
-  GO_LDFLAGS: >-
-    -X 'github.com/hemilabs/heminetwork/v2/version.Brand=Hemi Labs'
-    -X github.com/hemilabs/heminetwork/v2/version.PreRelease=
 
 jobs:
   # Build and test
@@ -40,6 +36,8 @@ jobs:
       id-token: write
       # Required to publish to GitHub Container Registry.
       packages: write
+      # Required to create attestations.
+      attestations: write
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -86,3 +84,19 @@ jobs:
           args: "release --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Get version"
+        id: version
+        run: |
+          VERSION=$(cat './dist/metadata.json' | jq -r '.version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: "Attest release artifacts"
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-checksums: "./dist/heminetwork_v{{ steps.version.outputs.version }}_checksums.txt"
+
+      - name: "Attest checksums file"
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "./dist/heminetwork_v{{ steps.version.outputs.version }}_checksums.txt"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -179,13 +179,13 @@ builds:
     goarch: ["amd64", "arm64"]
 
 archives:
-  - format: "tar.gz"
+  - formats: ["tar.gz"]
     name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
     allow_different_binary_count: true
     format_overrides:
       - goos: "windows"
-        format: "zip"
+        formats: ["zip"]
     files:
       - "README*"
       - "LICENSE*"
@@ -241,6 +241,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # bfgd arm64
   - id: "bfgd-arm64"
@@ -256,6 +258,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # popmd amd64
   - id: "popmd-amd64"
@@ -271,6 +275,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # popmd arm64
   - id: "popmd-arm64"
@@ -286,6 +292,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # popmd armv7
   - id: "popmd-armv7"
@@ -302,6 +310,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # tbcd amd64
   - id: "tbcd-amd64"
@@ -317,6 +327,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # tbcd arm64
   - id: "tbcd-arm64"
@@ -332,6 +344,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # hproxyd amd64
   - id: "hproxyd-amd64"
@@ -347,6 +361,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
   # hproxyd arm64
   - id: "hproxyd-arm64"
@@ -362,6 +378,8 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
+      - "--sbom=true"
+      - "--provenance=mode=max"
 
 # Creates Docker manifests for each image containing the images for each
 # architecture.


### PR DESCRIPTION
**Summary**
Update release workflow to create supply chain attestations for release assets and Docker images.

Supply chain attestations provide verifiable, cryptographically signed statements that provide evidence of an artifact's origin, security posture, and build process.

**Changes**
- Use `actions/attest-build-provenance` for release artifacts in the `release.yml` workflow.
- Update GoReleaser config to create SBOMs and provenance when building Docker images.
- Remove unused environment variables from `release.yml` workflow.
- Fix GoReleaser deprecation warnings (`archives.format` -> `archives.formats`, `archives.format_overrides.format` -> `archives.format_overrides.formats`)
