### PR TITLE
goreleaser: enable gomod.proxy for verifiable builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,10 +15,9 @@ before:
     - "go mod download"
     - "go mod verify"
 
-# Re-enable once we no longer need the 'replace' directive in go.mod.
-# gomod:
-#   # Proxy the module from proxy.golang.org, making the builds verifiable.
-#   proxy: true
+gomod:
+  # Proxy the module from proxy.golang.org, making the builds verifiable.
+  proxy: true
 
 builds:
   # Bitcoin Finality Governor Daemon


### PR DESCRIPTION
**Summary**
Re-enable proxying the module through the Go module proxy when building, making builds verifiable.

**Changes**
- Re-enable `gomod.proxy` in the GoReleaser config.
