### PR TITLE
tbcgozer: fix fragile tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -121,7 +121,7 @@ jobs:
         env:
           PGTESTURI: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
           HEMI_DOCKER_TESTS: "0"
-        run: GOCACHE="$(go env GOCACHE)" go test -v -test.timeout=20m -count 10 ./...
+        run: GOCACHE="$(go env GOCACHE)" go test -v -test.timeout=20m -count 20 ./...
 
   test-race:
     name: "Test (race)"
@@ -142,4 +142,4 @@ jobs:
         run: make GOCACHE="$(go env GOCACHE)" go-deps
 
       - name: "make race"
-        run: GOCACHE="$(go env GOCACHE)" go test -v -race -count 10 ./...
+        run: GOCACHE="$(go env GOCACHE)" go test -v -race -count 20 ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,8 +120,8 @@ jobs:
       - name: "make test (with E2E tests)"
         env:
           PGTESTURI: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
-          HEMI_DOCKER_TESTS: "1"
-        run: make GOCACHE="$(go env GOCACHE)" test
+          HEMI_DOCKER_TESTS: "0"
+        run: GOCACHE="$(go env GOCACHE)" go test -v -test.timeout=20m -count 10 ./...
 
   test-race:
     name: "Test (race)"
@@ -142,4 +142,4 @@ jobs:
         run: make GOCACHE="$(go env GOCACHE)" go-deps
 
       - name: "make race"
-        run: make GOCACHE="$(go env GOCACHE)" race
+        run: GOCACHE="$(go env GOCACHE)" go test -v -race -count 10 ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,8 +120,8 @@ jobs:
       - name: "make test (with E2E tests)"
         env:
           PGTESTURI: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
-          HEMI_DOCKER_TESTS: "0"
-        run: GOCACHE="$(go env GOCACHE)" go test -v -test.timeout=20m -count 20 ./...
+          HEMI_DOCKER_TESTS: "1"
+        run: make GOCACHE="$(go env GOCACHE)" test
 
   test-race:
     name: "Test (race)"
@@ -142,4 +142,4 @@ jobs:
         run: make GOCACHE="$(go env GOCACHE)" go-deps
 
       - name: "make race"
-        run: GOCACHE="$(go env GOCACHE)" go test -v -race -count 20 ./...
+        run: make GOCACHE="$(go env GOCACHE)" race

--- a/api/auth/secp256k1.go
+++ b/api/auth/secp256k1.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -30,11 +30,13 @@ const (
 
 	DefaultURL = "ws://localhost:8082/v1/ws"
 
-	DefaultRequestTimeout    = 5 * time.Second
 	DefaultCommandQueueDepth = 10
 )
 
-var log = loggo.GetLogger("tbcgozer")
+var (
+	log                   = loggo.GetLogger("tbcgozer")
+	DefaultRequestTimeout = 5 * time.Second
+)
 
 func init() {
 	if err := loggo.ConfigureLoggers(logLevel); err != nil {
@@ -310,6 +312,7 @@ func (t *tbcGozer) handleTBCWebsocketCall(pctx context.Context, conn *protocol.C
 
 				_, _, payload, err := tbcapi.Call(ctx, conn, bc.msg)
 				if err != nil {
+					// XXX very loud
 					log.Errorf("handleTBCWebsocketCall %T: %v",
 						bc.msg, err)
 					select {

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -269,6 +269,8 @@ func (t *tbcGozer) callTBC(pctx context.Context, timeout time.Duration, msg any)
 		return nil, errors.New("tbc command queue full")
 	}
 
+	log.Tracef("request sent: %T", msg)
+
 	// Wait for response
 	select {
 	case <-ctx.Done():
@@ -300,17 +302,14 @@ func (t *tbcGozer) handleTBCWebsocketCall(ctx context.Context, conn *protocol.Co
 				if err != nil {
 					log.Errorf("handleTBCWebsocketCall %T: %v",
 						bc.msg, err)
-					select {
-					case bc.ch <- err:
-					default:
-					}
+					bc.ch <- err
+					return
 				}
-				select {
-				case bc.ch <- payload:
-					log.Tracef("handleTBCWebsocketCall returned: %v",
-						spew.Sdump(payload))
-				default:
-				}
+
+				bc.ch <- payload
+				log.Tracef("handleTBCWebsocketCall returned: %v",
+					spew.Sdump(payload))
+
 			}(c)
 		}
 	}

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -132,6 +132,7 @@ func TestTBCGozerCalls(t *testing.T) {
 	mtbc := mock.NewMockTBC(ctx, nil, nil, kssMap, btcTip, 100)
 	defer mtbc.Shutdown()
 
+	DefaultRequestTimeout = 10 * time.Second // CI is slow as balls
 	b := New("ws" + strings.TrimPrefix(mtbc.URL(), "http"))
 	if err = b.Run(ctx, nil); err != nil {
 		t.Fatal(err)

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -36,7 +36,7 @@ func TestTBCGozerConnection(t *testing.T) {
 		BlockheaderCacheSize:    "1mb",
 		BlockSanity:             false,
 		LevelDBHome:             t.TempDir(),
-		LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
+		LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG:tbcgozer=TRACE",
 		MaxCachedTxs:            1000, // XXX
 		Network:                 "localnet",
 		PrometheusListenAddress: "",

--- a/cmd/btctool/btctool/btctool.go
+++ b/cmd/btctool/btctool/btctool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/database/tbcd/database_test.go
+++ b/database/tbcd/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/hemi/electrs/electrs.go
+++ b/hemi/electrs/electrs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/hemi/pop/pop_test.go
+++ b/hemi/pop/pop_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/version/useragent.go
+++ b/version/useragent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Hemi Labs, Inc.
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 


### PR DESCRIPTION
**Summary**
Fixes #637
Additionally, fixes a fragility found in `TestTBCGozerCalls` found while making this PR, and probably all other tests dependent on `tbcGozer`

To ensure that this was indeed the error, the go.yml file was temporarily changed to run `go test`and `go test -race` with `count=20` and was run multiple times. 

**Changes**
Remove `default` from sending the result of `handleTBCWebsocketCall` back to the caller, as that would sometimes race and the caller would not be listening for the channel. Instead, sending the result will be tied to a context with timeout that matches the timeout on the caller side, ensuring neither side becomes stuck.
