### PR TITLE
tbcapi: update broken SECURITY.md link in readme

### DIFF
--- a/api/tbcapi/README.md
+++ b/api/tbcapi/README.md
@@ -117,7 +117,7 @@ with the `tbcd` daemon. The client provides a command-line interface for all sup
 For developers looking to integrate or extend functionality:
 - View the raw Go types used in TBC's RPC commands: [View `tbcapi.go`](tbcapi.go)
 - Check our [contribution guidelines](../../CONTRIBUTING.md)
-- Review our [security policy](../../SECURITY.md)
+- Review our [security policy](https://github.com/hemilabs/.github/blob/main/SECURITY.md)
 
 ---
 


### PR DESCRIPTION
Replace relative path reference to SECURITY.md with correct GitHub URL

- Fix broken link from ../../SECURITY.md to https://github.com/hemilabs/.github/blob/main/SECURITY.md
- Aligns with the security policy link used in the main README.md
- Resolves file not found error when accessing the security policy documentation