### PR TITLE
tbc: Fix hemi keystone genesis.

### DIFF
--- a/service/tbc/mempool.go
+++ b/service/tbc/mempool.go
@@ -201,7 +201,7 @@ func (m *Mempool) txsRemove(ctx context.Context, txs []chainhash.Hash) {
 
 	// if the map length does not change, nothing was deleted.
 	if reaped != 0 {
-		log.Infof("Mempool removed txs: %v", reaped)
+		log.Tracef("Mempool removed txs: %v", reaped)
 	}
 }
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -92,7 +92,7 @@ var (
 		Height: 2577400,
 	}
 	testnet4HemiGenesis = &HashHeight{
-		Hash:   s2h("00000000916dacbf30938a100bd67a048389c1c6676f656853e9a55129747218"),
+		Hash:   s2h("00000000a14c6e63123ba02d7e9fd173d4b04412c71a31b7a6ab8bb3106c9231"),
 		Height: 84190,
 	}
 	localnetHemiGenesis = &HashHeight{


### PR DESCRIPTION
Somehow I picked a genesis point that was forked out. Replace with the correct hash. While fix a debug message that should not be printed at every block insertion.