### PR TITLE
docs: improve release process documentation with step-by-step guide

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,20 +1,25 @@
-This is a guide to releasing new releases of Hemi Network. It's super easy, even if you're new and afraid of breaking something. We'll write it as is, no extra words.
+This is a guide to releasing new releases of **Hemi Network**. It's super easy, even if you're new and afraid of breaking something. We'll write it as is, no extra words.
 
 Versions – What are those numbers? We use SemVer, it's MAJOR.MINOR.PATCH. Here's the deal:
 
-MAJOR – Major changes that break everything. API, config, protocols. Users need to fix their configs or they're screwed. MINOR – New features, old stuff still works. Upgrade and enjoy. PATCH – Bug fixes, code improvements, documentation. Upgrade safely, no stress.
+**MAJOR** – Major changes that break everything. API, config, protocols. Users need to fix their configs or they're screwed. 
+
+**MINOR** – New features, old stuff still works. Upgrade and enjoy. 
+
+**PATCH** – Bug fixes, code improvements, documentation. Upgrade safely, no stress.
 
 Examples:
-2.0.0 – Protocol rewrite, get ready for manual config changes.
 
-2.1.0 – Validator detection added.
+`2.0.0` – Protocol rewrite, get ready for manual config changes.
 
-2.1.1 – Memory leak fixed.
+`2.1.0` – Validator detection added.
 
-Tip: Not sure which version to upgrade? Write to the team in chat, they will figure it out.
+`2.1.1` – Memory leak fixed.
 
-Changelog - tell us what changed. The changelog is your story about what you wrote and why. Don't just say "something changed", but explain it as if you were talking to a friend. Tell us what's new, what's fixed, and what might break. Example:
 
+Changelog - tell us what changed. The changelog is your story about what you wrote and why. Don't just say "something changed", but explain it as if you were talking to a friend. Tell us what's new, what's fixed, and what might break. 
+
+*Example:*
 [2.0.0] - 2025-08-07
 News
 Added support for X, now you can process Y faster.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -8,10 +8,13 @@ MAJOR – Big changes that break stuff. APIs, configs, protocols. Users gotta fi
 MINOR – New features, old stuff still works. Update and enjoy.
 PATCH – Bug fixes, code tweaks, docs. Safe to update, no stress.
 
-Examples:
+#### Examples:
 2.0.0 – Rewrote the protocol, brace for manual config changes.
+
 2.1.0 – Added validator discovery thing.
+
 2.1.1 – Plugged a memory leak.
+
 Tip: Not sure which version to bump? Ping the team in chat, they’ll sort you out.
 
  Changelog – Spill What Changed

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,71 @@
+Hemi Network – How to Drop a Release
+Yo, this is the guide for pushing out new Hemi Network releases. It’s dead simple, even if you’re a newbie scared of breaking stuff. Writing this like it is, no fancy fluff.
+
+Versions – What’s with the Numbers?
+We use SemVer, that’s MAJOR.MINOR.PATCH. Here’s the deal:
+
+MAJOR – Big changes that break stuff. APIs, configs, protocols. Users gotta fix their setups or they’re screwed.
+MINOR – New features, old stuff still works. Update and enjoy.
+PATCH – Bug fixes, code tweaks, docs. Safe to update, no stress.
+
+Examples:2.0.0 – Rewrote the protocol, brace for manual config changes.2.1.0 – Added validator discovery thing.2.1.1 – Plugged a memory leak.
+Tip: Not sure which version to bump? Ping the team in chat, they’ll sort you out.
+
+ Changelog – Spill What Changed
+Changelog is your story of what you coded and why. Don’t just say “changed stuff,” explain it like you’re chatting with a buddy. Say what’s new, what’s fixed, and what might break.
+Example:
+## [2.0.0] – 2025-08-07
+
+###  New Stuff
+- Added X support, now you can do Y faster.
+- New validator protocol, runs smoother.
+
+###  Tweaks
+- Sped up startup by like 20 seconds.
+- Rewrote sync logic, fewer bugs.
+
+###  Fixes
+- Killed a memory leak in the PoP module.
+
+###  Stuff That Might Break
+- Renamed `syncMode` to `mode` – update your configs or it’s toast.
+- Swapped `/v1/nodes` endpoint for `/v2/nodes` – fix your scripts.
+
+Tip: Write so users get what to do. If it’s a pain, ask the team in chat for help.
+
+ What We Ship
+Each release needs a few files so users can run Hemi. Here’s what to build:
+
+Docker image: docker build -t hemilabs/hemi:<VERSION> . && docker push hemilabs/hemi:<VERSION> – gets you hemilabs/hemi:<VERSION>.
+Linux binary: make build-linux – spits out ./bin/hemi-<VERSION>-linux-amd64.
+Helm chart (if needed): helm package ./charts/hemi – makes hemi-<VERSION>.tgz.
+
+Tip: If a command fails, don’t freak, just ping the team.
+
+How to Push a Release
+Step-by-step, no confusion:
+
+Check the code: Run make test. All green? Sweet. If not, yell for the team.
+Bump the version: Grab bump2version (pip install bump2version), then bump2version <major|minor|patch>. Updates VERSION and tags. Push it: git push && git push --tags.
+Write the changelog: Open CHANGELOG.md, slap in a new section like above. Keep it clear, don’t bore people.
+Build artifacts: Run the Docker, binary, and Helm commands. Make sure it all works.
+Post the release: On GitHub, go to “Releases,” hit “Create a new release.” Add the tag (like v2.0.0), paste the changelog, attach the binary and Helm chart.
+Shout it out: Tell the team in chat or tweet: “Dropped 2.0.0, check what’s new!”
+
+Tip: Stuck somewhere? It’s not the end of the world, hit up the team chat.
+
+Tools to Save Your Butt
+
+Versions: bump2version – saves you from manual edits.
+Tests: Set up GitHub Actions to auto-check code.
+Changelog: Write it yourself or mess with git-chglog if you’re feeling fancy.
+
+
+ If It All Goes to Hell
+
+Bug in the release? Push a patch (2.0.1) to fix it.
+Lost on a step? Ask in chat or the Issue, no shame.
+Users whining? Check the changelog – did you explain how to update?
+
+
+This is a simple way to drop releases without losing your mind. Got questions? 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,4 +1,4 @@
-Hemi Network – How to Drop a Release
+### Hemi Network – How to Drop a Release
 Yo, this is the guide for pushing out new Hemi Network releases. It’s dead simple, even if you’re a newbie scared of breaking stuff. Writing this like it is, no fancy fluff.
 
 Versions – What’s with the Numbers?
@@ -8,7 +8,10 @@ MAJOR – Big changes that break stuff. APIs, configs, protocols. Users gotta fi
 MINOR – New features, old stuff still works. Update and enjoy.
 PATCH – Bug fixes, code tweaks, docs. Safe to update, no stress.
 
-Examples:2.0.0 – Rewrote the protocol, brace for manual config changes.2.1.0 – Added validator discovery thing.2.1.1 – Plugged a memory leak.
+Examples:
+2.0.0 – Rewrote the protocol, brace for manual config changes.
+2.1.0 – Added validator discovery thing.
+2.1.1 – Plugged a memory leak.
 Tip: Not sure which version to bump? Ping the team in chat, they’ll sort you out.
 
  Changelog – Spill What Changed

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,77 +1,57 @@
-### Hemi Network – How to Drop a Release
-Yo, this is the guide for pushing out new Hemi Network releases. It’s dead simple, even if you’re a newbie scared of breaking stuff. Writing this like it is, no fancy fluff.
+Hemi Network – How to Reject a Release
+Yo, this is a guide to releasing new releases of Hemi Network. It's super easy, even if you're new and afraid of breaking something. We'll write it as is, no extra words.
 
-Versions – What’s with the Numbers?
-We use SemVer, that’s MAJOR.MINOR.PATCH. Here’s the deal:
+Versions – What are those numbers? We use SemVer, it's MAJOR.MINOR.PATCH. Here's the deal:
 
-MAJOR – Big changes that break stuff. APIs, configs, protocols. Users gotta fix their setups or they’re screwed.
-MINOR – New features, old stuff still works. Update and enjoy.
-PATCH – Bug fixes, code tweaks, docs. Safe to update, no stress.
+MAJOR – Major changes that break everything. API, config, protocols. Users need to fix their configs or they're screwed. MINOR – New features, old stuff still works. Upgrade and enjoy. PATCH – Bug fixes, code improvements, documentation. Upgrade safely, no stress.
 
-#### Examples:
-2.0.0 – Rewrote the protocol, brace for manual config changes.
+Examples:
+2.0.0 – Protocol rewrite, get ready for manual config changes.
 
-2.1.0 – Added validator discovery thing.
+2.1.0 – Validator detection added.
 
-2.1.1 – Plugged a memory leak.
+2.1.1 – Memory leak fixed.
 
-Tip: Not sure which version to bump? Ping the team in chat, they’ll sort you out.
+Tip: Not sure which version to upgrade? Write to the team in chat, they will figure it out.
 
- Changelog – Spill What Changed
-Changelog is your story of what you coded and why. Don’t just say “changed stuff,” explain it like you’re chatting with a buddy. Say what’s new, what’s fixed, and what might break.
-Example:
-## [2.0.0] – 2025-08-07
+Changelog - tell us what changed. The changelog is your story about what you wrote and why. Don't just say "something changed", but explain it as if you were talking to a friend. Tell us what's new, what's fixed, and what might break. Example:
 
-###  New Stuff
-- Added X support, now you can do Y faster.
-- New validator protocol, runs smoother.
+[2.0.0] - 2025-08-07
+News
+Added support for X, now you can process Y faster.
+New validator protocol runs smoother.
+Improvements
+About 20 seconds faster startup.
+Rewritten sync logic, fewer errors.
+Bugfixes
+Fixed a memory leak in the PoP module.
+What might break
+Renamed syncMode to mode - update your configs, otherwise it's all over.
+Replaced /v1/nodes endpoint with /v2/nodes - fix your scripts. Tip: Write in a way that users understand what to do. If this is difficult, ask the team for help in the chat.
 
-###  Tweaks
-- Sped up startup by like 20 seconds.
-- Rewrote sync logic, fewer bugs.
+What we ship. Each release requires a few files to allow users to run Hemi. Here's what needs to be built:
 
-###  Fixes
-- Killed a memory leak in the PoP module.
+A Docker image: docker build -t hemilabs/hemi: . && docker push hemilabs/hemi: – produces hemilabs/hemi:. A Linux binary: make build-linux – produces ./bin/hemi--linux-amd64. A Helm chart (if needed): helm package ./charts/hemi – produces hemi-.tgz.
 
-###  Stuff That Might Break
-- Renamed `syncMode` to `mode` – update your configs or it’s toast.
-- Swapped `/v1/nodes` endpoint for `/v2/nodes` – fix your scripts.
+Tip: If the command fails, don't worry, just contact the team.
 
-Tip: Write so users get what to do. If it’s a pain, ask the team in chat for help.
+How to ship a release step by step, without confusion:
 
- What We Ship
-Each release needs a few files so users can run Hemi. Here’s what to build:
+Test the code: run make test.
 
-Docker image: docker build -t hemilabs/hemi:<VERSION> . && docker push hemilabs/hemi:<VERSION> – gets you hemilabs/hemi:<VERSION>.
-Linux binary: make build-linux – spits out ./bin/hemi-<VERSION>-linux-amd64.
-Helm chart (if needed): helm package ./charts/hemi – makes hemi-<VERSION>.tgz.
+Everything green? Great. If not, let the team know.
+Upgrade: Get bump2version (pip install bump2version), then bump2version <major|minor|patch>.
+Update VERSION and tags. Push: git push && git push --tags.
 
-Tip: If a command fails, don’t freak, just ping the team.
+Write a changelog: Open CHANGELOG.md, add a new section as above. Don't overload, don't bore users. Build artifacts: Run Docker commands, binaries, and Helm. Make sure everything works. Publish a release: On GitHub, go to "Releases" and click "Create a new release". Add a tag (e.g. v2.0.0), paste the changelog, attach the binary and Helm chart.
+Notify your team in chat or discord: "Version 2.0.0 released, check out what's new!"
 
-How to Push a Release
-Step-by-step, no confusion:
+Tools:
 
-Check the code: Run make test. All green? Sweet. If not, yell for the team.
-Bump the version: Grab bump2version (pip install bump2version), then bump2version <major|minor|patch>. Updates VERSION and tags. Push it: git push && git push --tags.
-Write the changelog: Open CHANGELOG.md, slap in a new section like above. Keep it clear, don’t bore people.
-Build artifacts: Run the Docker, binary, and Helm commands. Make sure it all works.
-Post the release: On GitHub, go to “Releases,” hit “Create a new release.” Add the tag (like v2.0.0), paste the changelog, attach the binary and Helm chart.
-Shout it out: Tell the team in chat or tweet: “Dropped 2.0.0, check what’s new!”
+Versions: bump2version — saves you from manual editing. Tests: Set up GitHub actions to automatically check your code. Changelog: Write your own or play around with git-chglog if you want.
 
-Tip: Stuck somewhere? It’s not the end of the world, hit up the team chat.
+If it all goes to hell
 
-Tools to Save Your Butt
+Bug in a release? Push a patch (2.0.1) to fix it. Lost on a step? Ask in chat or in an Issue, no shame. Users complaining? Check the changelog — have you explained how to upgrade?
 
-Versions: bump2version – saves you from manual edits.
-Tests: Set up GitHub Actions to auto-check code.
-Changelog: Write it yourself or mess with git-chglog if you’re feeling fancy.
-
-
- If It All Goes to Hell
-
-Bug in the release? Push a patch (2.0.1) to fix it.
-Lost on a step? Ask in chat or the Issue, no shame.
-Users whining? Check the changelog – did you explain how to update?
-
-
-This is a simple way to drop releases without losing your mind. Got questions? 
+This is an easy way to revert releases without going crazy. Any questions?

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,61 +1,76 @@
-This is a guide to releasing new releases of **Hemi Network**. It's super easy, even if you're new and afraid of breaking something. We'll write it as is, no extra words.
+# Hemi Network – Release Guide
 
-Versions – What are those numbers? We use SemVer, it's MAJOR.MINOR.PATCH. Here's the deal:
+This is a guide to releasing new releases of **Hemi Network**.
 
-**MAJOR** – Major changes that break everything. API, config, protocols. Users need to fix their configs or they're screwed. 
+---
 
-**MINOR** – New features, old stuff still works. Upgrade and enjoy. 
+## Versions – What Are Those Numbers?
 
-**PATCH** – Bug fixes, code improvements, documentation. Upgrade safely, no stress.
+We use **SemVer**, it's `MAJOR.MINOR.PATCH`. Here's the deal:
 
-Examples:
+- **MAJOR** – Major changes that break everything. API, config, protocols. Users need to fix their configs or they're screwed.  
+- **MINOR** – New features, old stuff still works. Upgrade and enjoy.  
+- **PATCH** – Bug fixes, code improvements, documentation. Upgrade safely, no stress.
 
-`2.0.0` – Protocol rewrite, get ready for manual config changes.
+**Examples**:  
+- `2.0.0` – Protocol rewrite, get ready for manual config changes.  
+- `2.1.0` – Validator detection added.  
+- `2.1.1` – Memory leak fixed.
 
-`2.1.0` – Validator detection added.
+---
 
-`2.1.1` – Memory leak fixed.
+## Changelog – Tell Us What Changed
 
+The changelog is your story about what you wrote and why. Don't just say "something changed", but explain it as if you were talking to a friend. Tell us what's new, what's fixed, and what might break.
 
-Changelog - tell us what changed. The changelog is your story about what you wrote and why. Don't just say "something changed", but explain it as if you were talking to a friend. Tell us what's new, what's fixed, and what might break. 
-
-*Example:*
+**Example**:
+```
 [2.0.0] - 2025-08-07
 News
-Added support for X, now you can process Y faster.
-New validator protocol runs smoother.
+- Added support for X, now you can process Y faster.
+- New validator protocol runs smoother.
 Improvements
-About 20 seconds faster startup.
-Rewritten sync logic, fewer errors.
+- About 20 seconds faster startup.
+- Rewritten sync logic, fewer errors.
 Bugfixes
-Fixed a memory leak in the PoP module.
+- Fixed a memory leak in the PoP module.
 What might break
-Renamed syncMode to mode - update your configs, otherwise it's all over.
-Replaced /v1/nodes endpoint with /v2/nodes - fix your scripts. Tip: Write in a way that users understand what to do. If this is difficult, ask the team for help in the chat.
+- Renamed syncMode to mode - update your configs, otherwise it's all over.
+- Replaced /v1/nodes endpoint with /v2/nodes - fix your scripts.
+```
 
-What we ship. Each release requires a few files to allow users to run Hemi. Here's what needs to be built:
+**Tip**: Write in a way that users understand what to do. If this is difficult, ask the team for help in the chat.
 
-A Docker image: docker build -t hemilabs/hemi: . && docker push hemilabs/hemi: – produces hemilabs/hemi:. A Linux binary: make build-linux – produces ./bin/hemi--linux-amd64. A Helm chart (if needed): helm package ./charts/hemi – produces hemi-.tgz.
+---
 
-Tip: If the command fails, don't worry, just contact the team.
+## What We Ship
 
-How to ship a release step by step, without confusion:
+Each release requires a few files to allow users to run Hemi. Here's what needs to be built:
 
-Test the code: run make test.
+- **A Docker image**: `docker build -t hemilabs/hemi:<VERSION> . && docker push hemilabs/hemi:<VERSION>` – produces `hemilabs/hemi:<VERSION>`.  
+- **A Linux binary**: `make build-linux` – produces `./bin/hemi-<VERSION>-linux-amd64`.  
+- **A Helm chart (if needed)**: `helm package ./charts/hemi` – produces `hemi-<VERSION>.tgz`.
 
-Everything green? Great. If not, let the team know.
-Upgrade: Get bump2version (pip install bump2version), then bump2version <major|minor|patch>.
-Update VERSION and tags. Push: git push && git push --tags.
+**Tip**: If the command fails, don't worry, just contact the team.
 
-Write a changelog: Open CHANGELOG.md, add a new section as above. Don't overload, don't bore users. Build artifacts: Run Docker commands, binaries, and Helm. Make sure everything works. Publish a release: On GitHub, go to "Releases" and click "Create a new release". Add a tag (e.g. v2.0.0), paste the changelog, attach the binary and Helm chart.
-Notify your team in chat or discord: "Version 2.0.0 released, check out what's new!"
+---
 
-Tools:
+## How to Ship a Release
 
-Versions: bump2version — saves you from manual editing. Tests: Set up GitHub actions to automatically check your code. Changelog: Write your own or play around with git-chglog if you want.
+Step by step, without confusion:
 
-If it all goes to hell
+1. **Test the code**: Run `make test`. Everything green? Great. If not, let the team know.  
+2. **Upgrade**: Get `bump2version` (`pip install bump2version`), then `bump2version <major|minor|patch>`. Update `VERSION` and tags. Push: `git push && git push --tags`.  
+3. **Write a changelog**: Open `CHANGELOG.md`, add a new section as above. Don't overload, don't bore users.  
+4. **Build artifacts**: Run Docker commands, binaries, and Helm. Make sure everything works.  
+5. **Publish a release**: On GitHub, go to "Releases" and click "Create a new release". Add a tag (e.g. `v2.0.0`), paste the changelog, attach the binary and Helm chart.  
 
-Bug in a release? Push a patch (2.0.1) to fix it. Lost on a step? Ask in chat or in an Issue, no shame. Users complaining? Check the changelog — have you explained how to upgrade?
+---
 
-This is an easy way to revert releases without going crazy. Any questions?
+## Tools
+
+- **Versions**: `bump2version` — saves you from manual editing.  
+- **Tests**: Set up GitHub Actions to automatically check your code.  
+- **Changelog**: Write your own or play around with `git-chglog` if you want.
+
+---

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,5 +1,4 @@
-Hemi Network – How to Reject a Release
-Yo, this is a guide to releasing new releases of Hemi Network. It's super easy, even if you're new and afraid of breaking something. We'll write it as is, no extra words.
+This is a guide to releasing new releases of Hemi Network. It's super easy, even if you're new and afraid of breaking something. We'll write it as is, no extra words.
 
 Versions – What are those numbers? We use SemVer, it's MAJOR.MINOR.PATCH. Here's the deal:
 


### PR DESCRIPTION
Added a clear and simple guide for releasing new Hemi versions: versioning, changelog, building Docker/Linux/Helm, and release steps. This will make the process faster and easier for everyone.