### PR TITLE
all: update to go 1.24.7

### DIFF
--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.4-alpine3.22@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a AS builder
+FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/bfgd/goreleaser.Dockerfile
+++ b/docker/bfgd/goreleaser.Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS builder
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS builder
 
 # Add ca-certificates, timezone data
 RUN apk --no-cache add --update ca-certificates tzdata

--- a/docker/hproxyd/Dockerfile
+++ b/docker/hproxyd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.4-alpine3.22@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a AS builder
+FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/hproxyd/goreleaser.Dockerfile
+++ b/docker/hproxyd/goreleaser.Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS builder
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS builder
 
 # Add ca-certificates, timezone data
 RUN apk --no-cache add --update ca-certificates tzdata

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.4-alpine3.22@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a AS builder
+FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/popmd/goreleaser.Dockerfile
+++ b/docker/popmd/goreleaser.Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS builder
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS builder
 
 # Add ca-certificates, timezone data
 RUN apk --no-cache add --update ca-certificates tzdata

--- a/docker/tbcd/Dockerfile
+++ b/docker/tbcd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.3-alpine3.22@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 AS builder
+FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/tbcd/goreleaser.Dockerfile
+++ b/docker/tbcd/goreleaser.Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS builder
+FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS builder
 
 # Add ca-certificates, timezone data
 RUN apk --no-cache add --update ca-certificates tzdata

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -5,7 +5,7 @@
 ARG OP_GETH_COMMIT=ed68446430a8b726f1dceceb0e85cdc5f10f248e
 ARG OPTIMISM_COMMIT=7bb2a14f63d01bcb4de3ab3165b007fd85a6b1f9
 
-FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122 AS build_1
+FROM golang:1.24.7-bookworm@sha256:08268bff0df66aff6d4f7fcf1b625fcf4f86fb7e6dbb5fdb8bb94f0920025ceb AS build_1
 
 WORKDIR /git
 
@@ -15,7 +15,7 @@ RUN git checkout $OP_GETH_COMMIT
 
 RUN go run build/ci.go install -static ./cmd/geth
 
-FROM golang:1.24.4-bookworm@sha256:c83619bb18b0207412fffdaf310f57ee3dd02f586ac7a5b44b9c36a29a9d5122 AS build_2
+FROM golang:1.24.7-bookworm@sha256:08268bff0df66aff6d4f7fcf1b625fcf4f86fb7e6dbb5fdb8bb94f0920025ceb AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /git/op-geth/build/bin/geth /bin/geth

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hemilabs/heminetwork/v2
 
 go 1.24.2
 
-toolchain go1.24.5
+toolchain go1.24.7
 
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20250506233109-1eb974aab6ef


### PR DESCRIPTION
**Summary**
Update Go to 1.24.7 before v2 release.

The latest version of Go is 1.25, which we should update to after the `v2.0.0` tag has been made.

**Changes**
- Update Go toolchain to `go1.24.7`
- Update golang alpine image to `golang:1.24.7-alpine3.22`
- Update golang debian image to `golang:golang:1.24.7-bookworm`
- Update alpine image to `3.22.1`
