### PR TITLE
ci: remove unused postgres service

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -90,18 +90,6 @@ jobs:
   test:
     name: "Test"
     runs-on: "ubuntu-latest"
-    services:
-      postgres:
-        image: postgres:16.3-alpine3.20
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_PASSWORD: "postgres"
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -119,7 +107,6 @@ jobs:
 
       - name: "make test (with E2E tests)"
         env:
-          PGTESTURI: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
           HEMI_DOCKER_TESTS: "1"
         run: make GOCACHE="$(go env GOCACHE)" test
 


### PR DESCRIPTION
**Summary**
Remove unused postgres service in the go workflow.

`PGTESTURI` and the postgres container were previously used by BFG for running tests with the postgres database, however as BFG no longer uses postgres, this is no longer needed or used.

**Changes**
- Remove `postgres` service in the `test` job of the `go.yml` workflow.
- Remove `PGTESTURI` environment variable
