### PR TITLE
goreleaser: fix pre-releases failing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -538,8 +538,6 @@ release:
     name: "heminetwork"
   replace_existing_draft: true
   prerelease: "auto"
-  make_latest: true
-  mode: "keep-existing"
 
 # Closes milestones for the released tag.
 milestones:


### PR DESCRIPTION
**Summary**
Fix pre-releases failing in GoReleaser due to `make_latest` attempting to set the release as latest, which is incompatible with being a pre-release. Also remove redundant `mode` variable.

**Changes**
<!-- A list of changes made by this pull request. -->
