### PR TITLE
all: update to go 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 env:
-  GO_VERSION: "1.24.x"
+  GO_VERSION: "1.25.x"
   GOLICENSER_VERSION: "0.3"
 
 permissions:

--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        go-version: [ "1.24.x" ]
+        go-version: [ "1.25.x" ]
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.24.x"
+  GO_VERSION: "1.25.x"
 
 jobs:
   # Build and test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ our [Security Policy](https://github.com/hemilabs/.github/blob/main/SECURITY.md)
 
 **Prerequisites**
 
-- Go v1.24 or newer - https://go.dev/dl/
+- Go v1.25 or newer - https://go.dev/dl/
 - `git`, `make`
 
 **Setup**

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Hemi Labs, Inc.
+# Copyright (c) 2024-2025 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
@@ -64,9 +64,10 @@ lint:
 	$(shell go env GOPATH)/bin/golicenser -tmpl="$$LICENSE_HEADER" -author="Hemi Labs, Inc." -year-mode=git-range -fix ./...
 
 lint-deps:
-	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1
+	@echo "Installing with $(shell go env GOVERSION)"
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@v0.3
-	GOBIN=$(shell go env GOPATH)/bin go install mvdan.cc/gofumpt@v0.8.0
+	GOBIN=$(shell go env GOPATH)/bin go install mvdan.cc/gofumpt@v0.9.1
 
 tidy:
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and [Docker Hub](https://hub.docker.com/u/hemilabs/). Docker images are currentl
 
 **Prerequisites**
 
-- Go v1.24 or newer - https://go.dev/dl/
+- Go v1.25 or newer - https://go.dev/dl/
 - `git`, `make`
 
 **Build**

--- a/cmd/popmd/README.md
+++ b/cmd/popmd/README.md
@@ -129,7 +129,7 @@ docker run \
 
 #### Prerequisites
 
-- [Go v1.24+](https://go.dev/dl/)
+- [Go v1.25+](https://go.dev/dl/)
 - `make` (optional)
 
 #### Option 1: Using Makefile

--- a/docker/bfgd/Dockerfile
+++ b/docker/bfgd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
+FROM golang:1.25.1-alpine3.22@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/hproxyd/Dockerfile
+++ b/docker/hproxyd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
+FROM golang:1.25.1-alpine3.22@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/popmd/Dockerfile
+++ b/docker/popmd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
+FROM golang:1.25.1-alpine3.22@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS builder
 
 ARG GO_LDFLAGS
 

--- a/docker/tbcd/Dockerfile
+++ b/docker/tbcd/Dockerfile
@@ -3,7 +3,7 @@
 # which can be found in the LICENSE file.
 
 # Build stage
-FROM golang:1.24.7-alpine3.22@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 AS builder
+FROM golang:1.25.1-alpine3.22@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS builder
 
 ARG GO_LDFLAGS
 

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -37,6 +38,9 @@ import (
 )
 
 func nextPort(ctx context.Context, t *testing.T) int {
+	var dialer net.Dialer
+	dialer.Timeout = 1 * time.Second
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -49,7 +53,7 @@ func nextPort(ctx context.Context, t *testing.T) int {
 			t.Fatal(err)
 		}
 
-		if _, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", fmt.Sprintf("%d", port)), 1*time.Second); err != nil {
+		if _, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port))); err != nil {
 			if errors.Is(err, syscall.ECONNREFUSED) {
 				// connection error, port is open
 				return port

--- a/e2e/monitor/README.md
+++ b/e2e/monitor/README.md
@@ -5,7 +5,7 @@ that we want to test against.
 
 ## Prerequisites
 
-* Go 1.24+
+* Go 1.25+
 * `docker` available in your cli
 
 ## Running

--- a/e2e/monitor/go.mod
+++ b/e2e/monitor/go.mod
@@ -1,8 +1,8 @@
 module github.com/hemilabs/heminetwork/e2e/monitor
 
-go 1.24.2
+go 1.25
 
-toolchain go1.24.5
+toolchain go1.25.1
 
 replace github.com/hemilabs/heminetwork/v2 => ../..
 

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -5,7 +5,7 @@
 ARG OP_GETH_COMMIT=ed68446430a8b726f1dceceb0e85cdc5f10f248e
 ARG OPTIMISM_COMMIT=7bb2a14f63d01bcb4de3ab3165b007fd85a6b1f9
 
-FROM golang:1.24.7-bookworm@sha256:08268bff0df66aff6d4f7fcf1b625fcf4f86fb7e6dbb5fdb8bb94f0920025ceb AS build_1
+FROM golang:1.25.1-trixie@sha256:e04c339e2a2a11c9837c7a42f6c687dbc9e3aed8152869b052ea4dffefa71604 AS build_1
 
 WORKDIR /git
 
@@ -15,7 +15,7 @@ RUN git checkout $OP_GETH_COMMIT
 
 RUN go run build/ci.go install -static ./cmd/geth
 
-FROM golang:1.24.7-bookworm@sha256:08268bff0df66aff6d4f7fcf1b625fcf4f86fb7e6dbb5fdb8bb94f0920025ceb AS build_2
+FROM golang:1.25.1-trixie@sha256:e04c339e2a2a11c9837c7a42f6c687dbc9e3aed8152869b052ea4dffefa71604 AS build_2
 
 # store the latest geth here, build with go 1.23
 COPY --from=build_1 /git/op-geth/build/bin/geth /bin/geth

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/hemilabs/heminetwork/v2
 
-go 1.24.2
+go 1.25
 
-toolchain go1.24.7
+toolchain go1.25.1
 
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20250506233109-1eb974aab6ef

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -1249,6 +1249,9 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 }
 
 func nextPort(ctx context.Context, t *testing.T) int {
+	var dialer net.Dialer
+	dialer.Timeout = 1 * time.Second
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1261,7 +1264,7 @@ func nextPort(ctx context.Context, t *testing.T) int {
 			t.Fatal(err)
 		}
 
-		if _, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", fmt.Sprintf("%d", port)), 1*time.Second); err != nil {
+		if _, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port))); err != nil {
 			if errors.Is(err, syscall.ECONNREFUSED) {
 				// connection error, port is open
 				return port


### PR DESCRIPTION
**Summary**
Update Go to 1.25. Also updates linting tools and CI to support 1.25.

**Changes**
- Update required Go version to `1.25`
- Update toolchain to `go1.25.1`
- Update golang alpine images to `1.25.1-alpine3.22`
- Update golang debian images to `1.25.1-trixie` (previously bookworm)
- Update `GO_VERSION` in CI to `1.25.x`
- Update documentation to use Go 1.25+
- Fix new `noctx` linting errors (and remove some `freeport` :) )
