### PR TITLE
service/popm: add fully random backoff

### DIFF
--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -472,7 +472,7 @@ func TestOpgethReconnect(t *testing.T) {
 		}
 
 		if reconAttempts >= 2 {
-			if time.Since(start) <= minDelay {
+			if time.Since(start) < minDelay {
 				t.Fatal("reconnected too fast")
 			}
 			return

--- a/testutil/mock/mock.go
+++ b/testutil/mock/mock.go
@@ -35,6 +35,8 @@ func init() {
 	}
 }
 
+var ErrConnectionClosed = errors.New("mock server closed")
+
 type mockHandler struct {
 	handleFunc func(w http.ResponseWriter, r *http.Request) error
 	errCh      chan error  // use notifyErr to write to it
@@ -78,7 +80,8 @@ func (f *mockHandler) notifyErr(ctx context.Context, err error) {
 func (f *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !f.Running() {
 		log.Infof("%v: %v connection to closed server", f.name, r.RemoteAddr)
-		http.Error(w, string("mock server closed"), http.StatusServiceUnavailable)
+		http.Error(w, ErrConnectionClosed.Error(), http.StatusServiceUnavailable)
+		f.notifyErr(f.pctx, ErrConnectionClosed)
 		return
 	}
 	log.Infof("serving %v: %v", r.RemoteAddr, r.RequestURI)


### PR DESCRIPTION
**Summary**
Fixes #664 

**Changes**
As previously discussed, replaces the exponential backoff with a fully random backoff.

On disconnect, attempt to reconnect after [minDelay, MaxDelay].
