### PR TITLE
ci: fix gh api errors failing labeler job

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -51,10 +51,10 @@ jobs:
 
             if [ "$action" = "add" ]; then
               gh api -X POST "repos/$GH_REPO/issues/$PR_NUMBER/labels" \
-                -F "labels[]=$(printf '%s' "$label")" >/dev/null
+                -F "labels[]=$(printf '%s' "$label")" >/dev/null 2>&1 || true
             elif [ "$action" = "remove" ]; then
               encoded_label=$(printf "%s" "$label" | jq -s -R -r @uri)
-              gh api -X DELETE "repos/$GH_REPO/issues/$PR_NUMBER/labels/$encoded_label" >/dev/null
+              gh api -X DELETE "repos/$GH_REPO/issues/$PR_NUMBER/labels/$encoded_label" >/dev/null 2>&1 || true
             else
               echo "unknown action: $action"
               exit 1


### PR DESCRIPTION
**Summary**
Prevent `gh api` commands from failing the labeler workflow. The `gh api` commands will fail when a label is already applied (add) or has not been applied (remove).

**Changes**
- Add `2>&1 || true` to ignore stderr output and always exit with `0`