### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
         run: golangci-lint fmt --diff ./...
 
       - name: "Cache golicenser"
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "/home/runner/go/bin/golicenser"
           key: "${{ runner.os }}-golicenser-${{ env.GOLICENSER_VERSION }}-go${{ env.GO_VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,10 @@ jobs:
           check-latest: true
 
       - name: "Install cosign"
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 
       - name: "Install Syft"
-        uses: anchore/sbom-action/download-syft@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        uses: anchore/sbom-action/download-syft@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
 
       - name: "Setup QEMU"
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -60,13 +60,13 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: "Login to DockerHub"
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
 
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: "ghcr.io"
           username: "${{ github.repository_owner }}"


### PR DESCRIPTION
**Summary**
Update used GitHub actions to the latest versions. All changes have been reviewed to ensure nothing unexpected was introduced and no breaking changes requiring our attention were made.

**Changes**
| Action                              | Update | Change                                                                                                                                                                                                                     |
|-------------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `actions/cache`                     | minor  | `v4.2.4 (0400d5f) -> v4.3.0 (0057852)` ([release](https://github.com/actions/cache/releases/tag/v4.3.0), [compare](https://github.com/actions/cache/compare/v4.2.4...v4.3.0))                                              |
| `docker/login-action`               | minor  | `v3.5.0 (184bdaa) -> v3.6.0 (5e57cd1)` ([release](https://github.com/docker/login-action/releases/tag/v3.6.0), [compare](https://github.com/docker/login-action/compare/v3.5.0...v3.6.0))                                  |
| `sigstore/cosign-installer`         | minor  | `v3.9.2 (d58896d) -> v3.10.0 (d7543c9)` ([release](https://github.com/sigstore/cosign-installer/releases/tag/v3.10.0), [compare](https://github.com/sigstore/cosign-installer/compare/v3.9.2...v3.10.0))                   |
| `anchore/sbom-action/download-syft` | patch  | `v0.20.5 (da167ea) -> v0.20.6 (f8bdd1d)` ([release](https://github.com/anchore/sbom-action/download-syft/releases/tag/v0.20.6), [compare](https://github.com/anchore/sbom-action/download-syft/compare/v0.20.5...v0.20.6)) |
