### PR TITLE
goreleaser: only publish tags with full version for pre-releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -239,7 +239,11 @@ dockers_v2:
     images:
       - "hemilabs/bfgd"
       - "ghcr.io/hemilabs/bfgd"
-    tags: [ "latest", "{{ .Version }}", "{{ .Major }}", "{{ .Major }}.{{ .Minor }}" ]
+    tags:
+      - "{{ .Version }}"
+      - "{{if not .Prerelease}}latest{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}.{{ .Minor }}{{end}}"
     platforms:
       - "linux/amd64"
       - "linux/arm64"
@@ -254,7 +258,11 @@ dockers_v2:
     images:
       - "hemilabs/popmd"
       - "ghcr.io/hemilabs/popmd"
-    tags: [ "latest", "{{ .Version }}", "{{ .Major }}", "{{ .Major }}.{{ .Minor }}" ]
+    tags:
+      - "{{ .Version }}"
+      - "{{if not .Prerelease}}latest{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}.{{ .Minor }}{{end}}"
     platforms:
       - "linux/amd64"
       - "linux/arm64"
@@ -270,7 +278,11 @@ dockers_v2:
     images:
       - "hemilabs/tbcd"
       - "ghcr.io/hemilabs/tbcd"
-    tags: [ "latest", "{{ .Version }}", "{{ .Major }}", "{{ .Major }}.{{ .Minor }}" ]
+    tags:
+      - "{{ .Version }}"
+      - "{{if not .Prerelease}}latest{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}.{{ .Minor }}{{end}}"
     platforms:
       - "linux/amd64"
       - "linux/arm64"
@@ -285,7 +297,11 @@ dockers_v2:
     images:
       - "hemilabs/hproxyd"
       - "ghcr.io/hemilabs/hproxyd"
-    tags: [ "latest", "{{ .Version }}", "{{ .Major }}", "{{ .Major }}.{{ .Minor }}" ]
+    tags:
+      - "{{ .Version }}"
+      - "{{if not .Prerelease}}latest{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}{{end}}"
+      - "{{if not .Prerelease}}{{ .Major }}.{{ .Minor }}{{end}}"
     platforms:
       - "linux/amd64"
       - "linux/arm64"


### PR DESCRIPTION
**Summary**
When publishing a pre-release (e.g. `beta`, `alpha`, `rc.1`), only publish Docker images with the full version tag (e.g. `v2.1.0-beta.1`), to avoid publishing a pre-release tagged `latest` or `2.1`

**Changes**
- Update GoReleaser config to only add `latest`, `major` and `major.minor` tags for full releases.
