### PR TITLE
localnet: updated deprecated flag in forge when building op-stack image for localnet

### DIFF
--- a/e2e/genesisl2.sh
+++ b/e2e/genesisl2.sh
@@ -9,7 +9,7 @@ MY_ADDRESS="0x78697c88847dfbbb40523e42c1f2e28a13a170be"
 
 cd /git/optimism/packages/contracts-bedrock
 
-forge build --deny-warnings --skip test --out .artifacts
+forge build --deny never --skip test --out .artifacts
 
 /git/optimism/op-deployer/bin/op-deployer init --l1-chain-id 1337 --l2-chain-ids 901 --workdir .deployer --intent-type custom
 


### PR DESCRIPTION
**Summary**
the `--deny-warnings` flag is deprecated, and the optimism files that are built fail linting.  

**Changes**
update the flag to `--deny never` to allow building to succeed.
