### PR TITLE
ci: add renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,50 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:best-practices',
+    ':configMigration',
+    ':pinVersions',
+    ':prConcurrentLimit10',
+    ':rebaseStalePrs',
+    'schedule:weekly',
+    'docker:enableMajor',
+    'docker:pinDigests',
+    'preview:dockerCompose',
+    'preview:dockerVersions',
+    'customManagers:dockerfileVersions',
+    'customManagers:githubActionsVersions',
+    'helpers:pinGitHubActionDigests',
+    ':assignAndReview(joshuasing)'
+  ],
+  commitMessagePrefix: 'all:',
+  commitMessageAction: 'update',
+  commitMessageTopic: '{{depName}}',
+  labels: [
+    'type: dependencies',
+  ],
+  minimumReleaseAge: '3 days',
+  packageRules: [
+    {
+      matchDatasources: [
+        'go',
+      ],
+      commitMessageTopic: '{{depName}}'
+    },
+    {
+      matchDatasources: [
+        'docker',
+      ],
+      commitMessageTopic: 'image {{depName}}',
+    },
+  ],
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    enabled: true,
+    addLabels: [
+      'type: security',
+    ],
+    additionalReviewers: [
+      'team:secops'
+    ],
+  },
+}


### PR DESCRIPTION
**Summary**
Add configuration file for Renovate Bot (automated dependency update PRs).

This will cause Renovate to automatically create dependency update pull requests:
1. Weekly, on Monday morning
2. It will assign and request a review from me and code owners
3. Vulnerability updates bypass the schedule
4. Commit messages will have the format `all: update <dependency> to <version>`

**Changes**
- Add `.github/renovate.json5`
