### PR TITLE
ci: update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,10 @@
       commitMessageTopic: 'image {{depName}}',
     },
     {
+      matchManagers: ['gomod'],
+      commitMessagePrefix: 'go.mod:',
+    },
+    {
       matchManagers: ['github-actions'],
       commitMessagePrefix: 'ci:',
     },


### PR DESCRIPTION
**Summary**
Update Renovate config to fix a few issues.

**Changes**
- Add `changelog: skip` label to all pull requests opened by Renovate (dependency changes very rarely need to be included in the changelog)
- Set commit message prefix to `ci:` when updating GitHub actions
- Change commit message action to `pin` when changing digests or pinning dependencies.
