### PR TITLE
ci: add codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  require_ci_to_pass: false
+
+comment:
+  layout: "diff, condensed_files"
+  behavior: default
+  require_changes: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%


### PR DESCRIPTION
**Summary**
Add config YAML file for Codecov.
This was supposed to be included in #703 but I apparently forgot to push the commit, whoops.

This config will:
- Prevent Codecov from adding comments to PRs that do not change coverage
- Include a coverage diff and condensed per-file coverage change list to the comment.

**Changes**
- Add `.github/codecov.yml` to configure Codecov.
