### PR TITLE
ci: use go version from go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 env:
-  GO_VERSION: "1.25.x"
   GOLICENSER_VERSION: "0.3"
 
 permissions:
@@ -33,11 +32,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Setup Go ${{ env.GO_VERSION }}"
+      - name: "Setup Go"
+        id: "go"
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: true
+          go-version-file: "go.mod"
 
       - name: "golangci-lint"
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
@@ -51,7 +50,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "/home/runner/go/bin/golicenser"
-          key: "${{ runner.os }}-golicenser-${{ env.GOLICENSER_VERSION }}-go${{ env.GO_VERSION }}"
+          key: "${{ runner.os }}-golicenser-${{ env.GOLICENSER_VERSION }}-go${{ steps.go.outputs.go-version }}"
 
       - name: "golicenser"
         env:
@@ -73,12 +72,10 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: "Setup Go ${{ env.GO_VERSION }}"
+      - name: "Setup Go"
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: true
-          check-latest: true
+          go-version-file: "go.mod"
 
       - name: "Download and verify dependencies"
         id: deps
@@ -94,12 +91,10 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: "Setup Go ${{ env.GO_VERSION }}"
+      - name: "Setup Go"
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: true
-          check-latest: true
+          go-version-file: "go.mod"
 
       - name: "Download and verify dependencies"
         id: deps
@@ -123,12 +118,10 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: "Setup Go ${{ env.GO_VERSION }}"
+      - name: "Setup Go"
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: true
-          check-latest: true
+          go-version-file: "go.mod"
 
       - name: "Download and verify dependencies"
         id: deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,6 @@ concurrency:
   group: "release-${{ github.ref }}"
   cancel-in-progress: true
 
-env:
-  GO_VERSION: "1.25.x"
-
 jobs:
   # Build and test
   test-go:
@@ -40,12 +37,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Setup Go ${{ env.GO_VERSION }}"
+      - name: "Setup Go"
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: "${{ env.GO_VERSION }}"
-          cache: true
-          check-latest: true
+          go-version-file: "go.mod"
 
       - name: "Install cosign"
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0


### PR DESCRIPTION
**Summary**
Setup Go and Release workflows to detect the Go version based on `go.mod` (https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file).

**Changes**
- Change `actions/setup-go` to use Go version from `go.mod`
