### PR TITLE
ci: fix release attestation steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,14 +90,14 @@ jobs:
       - name: "Attest release artifacts"
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          subject-checksums: "./dist/heminetwork_v{{ steps.version.outputs.version }}_checksums.txt"
+          subject-checksums: "./dist/heminetwork_v${{ steps.version.outputs.version }}_checksums.txt"
 
       - name: "Attest release images"
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          subject-checksums: "./dist/heminetwork_v{{ steps.version.outputs.version }}_image_digests.txt"
+          subject-checksums: "./dist/heminetwork_v${{ steps.version.outputs.version }}_image_digests.txt"
 
       - name: "Attest checksums file"
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          subject-path: "./dist/heminetwork_v{{ steps.version.outputs.version }}_checksums.txt"
+          subject-path: "./dist/heminetwork_v${{ steps.version.outputs.version }}_checksums.txt"


### PR DESCRIPTION
**Summary**
Add missing `$` for the variables used in attestations steps in the release workflow.

**Changes**
<!-- A list of changes made by this pull request. -->
