### PR TITLE
makefile, ci: pin linter versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
     'customManagers:dockerfileVersions',
     'customManagers:githubActionsVersions',
     'helpers:pinGitHubActionDigests',
-    ':assignAndReview(joshuasing)'
+    ':assignAndReview(joshuasing)',
   ],
   commitMessagePrefix: 'all:',
   commitMessageAction: 'update',
@@ -60,4 +60,15 @@
       'team:secops',
     ],
   },
+  customManagers: [
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/(^|/)Makefile$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
+      ],
+    },
+  ],
 }

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,10 @@ concurrency:
   cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 env:
-  GOLICENSER_VERSION: "0.3"
+  # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=semver
+  GOLANGCI_LINT_VERSION: "v2.6.2"
+  # renovate: datasource=github-releases depName=joshuasing/golicenser versioning=semver
+  GOLICENSER_VERSION: "v0.3.1"
 
 permissions:
   contents: read
@@ -41,7 +44,7 @@ jobs:
       - name: "golangci-lint"
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: "v2.4"
+          version: "${{ env.GOLANGCI_LINT_VERSION }}"
 
       - name: "golangci-lint fmt"
         run: golangci-lint fmt --diff ./...
@@ -60,7 +63,7 @@ jobs:
             which can be found in the LICENSE file.
         run: |
           if ! (command -v 'golicenser' >/dev/null); then
-            go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
+            go install github.com/joshuasing/golicenser/cmd/golicenser@$GOLICENSER_VERSION
           fi
           echo "$LICENSE_HEADER" > license_header.txt
           golicenser -author="Hemi Labs, Inc." -year-mode=git-range ./...

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,13 @@ export GOCACHE=$(PROJECTPATH)/.gocache
 export GOPKG=$(PROJECTPATH)/pkg
 
 GO_LDFLAGS=
-DIST=$(PROJECTPATH)/dist
 
-project = heminetwork
-version = $(shell git describe --tags 2>/dev/null || echo "v0.0.0")
+# renovate: datasource=github-releases depName=golangci/golangci-lint versioning=semver
+GOLANGCI_LINT_VERSION="v2.6.2"
+# renovate: datasource=github-releases depName=joshuasing/golicenser versioning=semver
+GOLICENSER_VERSION="v0.3.1"
+# renovate: datasource=github-releases depName=mvdan/gofumpt versioning=semver
+GOFUMPT_VERSION="v0.9.2"
 
 cmds = \
 	bfgd	\
@@ -65,9 +68,9 @@ lint:
 
 lint-deps:
 	@echo "Installing with $(shell go env GOVERSION)"
-	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
-	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@v0.3
-	GOBIN=$(shell go env GOPATH)/bin go install mvdan.cc/gofumpt@v0.9.1
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(shell go env GOPATH)/bin go install github.com/joshuasing/golicenser/cmd/golicenser@$(GOLICENSER_VERSION)
+	GOBIN=$(shell go env GOPATH)/bin go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 
 tidy:
 	go mod tidy


### PR DESCRIPTION
**Summary**
Update CI and Makefile to pin lint dependencies to full versions, and setup Renovate to automatically create PRs to update them.

**Changes**
- Update `golangci-lint` to `v2.6.2` (previously `v2.4.0`)
- Update `gofumpt` to `v0.9.2` (previously `v0.9.1`)
- Move `golangci-lint` version in `go.yml` workflow to `GOLANGCI_LINT_VERSION`
- Add `GOLANGCI_LINT_VERSION`, `GOLICENSER_VERSION` and `GOFUMPT_VERSION` variables to `Makefile`
- Add `renovate:` comments to version variables to allow automatic update PRs.
- Add custom regexp manager to renovate config for version updates in `Makefile` variables. 
