### PR TITLE
tbcapi: fix miscellaneous typos in comments

### DIFF
--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -377,15 +377,15 @@ type BlockInsertRawResponse struct {
 	Error     *protocol.Error `json:"error,omitempty"`
 }
 
-// BlockDownloadAsyncResponse returns a block if it exists or attempts to
-// download the block from p2p asynchronously.
+// BlockDownloadAsyncRequest requests a block to be downloaded from p2p
+// asynchronously.
 type BlockDownloadAsyncRequest struct {
 	Hash  chainhash.Hash `json:"hash"`
 	Peers uint           `json:"peers"`
 }
 
 // BlockDownloadAsyncResponse replies with a block, an error or nothing. When
-// bot Error and Block are nil it measn the block download request was issued
+// both Error and Block are nil it means the block download request was issued
 // to p2p.
 type BlockDownloadAsyncResponse struct {
 	Block *wire.MsgBlock  `json:"block,omitempty"`


### PR DESCRIPTION


**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->


Corrected documentation comments that were incorrectly associated with the BlockDownloadAsyncRequest and BlockDownloadAsyncResponse structs. 

The comments have been properly matched to their respective structures, and fixed a typo from "bot Error" to "both Error" in the response struct comment. 

This change improves code documentation accuracy and readability.



**Changes**
<!-- A list of changes made by this pull request. -->
