### PR TITLE
ci, e2e: pull in latest op-stack to test; fix critical bugs

### DIFF
--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         go-version: [ "1.25.x" ]
         gethl1:
-          - "ethereum/client-go:v1.15.8@sha256:a5ef22282a8d154d9f634d38cdcc233e72daef454edc6339d13b3fc456355fa2"
           - "ethereum/client-go:v1.16.7@sha256:fc5cee2ac93202d72af2eacaffbd17a43f6d9316032dc5f3c67663f91d43aa5f"
     steps:
       - name: "Checkout repository"

--- a/e2e/genesisl2.sh
+++ b/e2e/genesisl2.sh
@@ -7,6 +7,15 @@ set -ex
 
 MY_ADDRESS="0x78697c88847dfbbb40523e42c1f2e28a13a170be"
 
+# need an older version of op-deployer here, need to update the repo
+# to use the new one but this will do for our purposes now
+# this should only affect the op-geth-l2-setup container (no others)
+cd /git/optimism
+git checkout 12dba15e5e3fdc48620a81872b381b2e79fcb62b
+git submodule update --init --recursive
+cd /git/optimism/op-deployer
+just build
+
 cd /git/optimism/packages/contracts-bedrock
 
 forge build --deny never --skip test --out .artifacts


### PR DESCRIPTION
**Summary**
* pull in latest hemi branches in our op-stack repos
* pass docker build args to ALL build steps so we're building the correct commits
* the latest foundry release is broken, so use a commit near tip on the main/master branch
* use older optimism commit to build op-deployer so we don't have to modify initial deploy in localnet
* remove older geth version from localnet workflow

fixes https://github.com/hemilabs/heminetwork/issues/790

**Changes**
see summary
