### PR TITLE
continuum: fix wrong name used in function comment

### DIFF
--- a/service/continuum/protocol.go
+++ b/service/continuum/protocol.go
@@ -428,7 +428,7 @@ func NewSecretFromPrivate(privateKey *secp256k1.PrivateKey) *Secret {
 	}
 }
 
-// NewSecretFromPrivate returns a secret type for the provided string encoded
+// NewSecretFromString returns a secret type for the provided string encoded
 // private key.
 func NewSecretFromString(secret string) (*Secret, error) {
 	s, err := hex.DecodeString(secret)


### PR DESCRIPTION
**Summary**
<!-- A short and concise description of what this pull request does (in present tense). -->
<!-- If this pull request is related to an issue, add "Fixes #<id>" to the end of your summary. -->


The comment for NewSecretFromString incorrectly referenced NewSecretFromPrivate. 

This change corrects the comment to accurately reflect the function's purpose, improving code clarity and maintainability.



**Changes**
<!-- A list of changes made by this pull request. -->
