### PR TITLE
e2e/monitor: add retry logic around fragile test

### DIFF
--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -355,9 +355,15 @@ func hvmTipNearBtcTip(t *testing.T, ctx context.Context, l2Client *ethclient.Cli
 
 	waitForTxReceipt(t, ctx, l2Client, tx)
 
+	l2ReadBalancesNonSequencing, err := mybindings.NewL2ReadBalances(contractAddress, l2ClientNonSequencing)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var res []byte
 	headerCompareRetry := 30
 	for i := range headerCompareRetry {
-		res, err := l2ReadBalances.L2ReadBalancesCaller.GetBitcoinLastHeader(nil)
+		res, err = l2ReadBalances.L2ReadBalancesCaller.GetBitcoinLastHeader(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -382,11 +388,6 @@ func hvmTipNearBtcTip(t *testing.T, ctx context.Context, l2Client *ethclient.Cli
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
-	}
-
-	l2ReadBalancesNonSequencing, err := mybindings.NewL2ReadBalances(contractAddress, l2ClientNonSequencing)
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	config := client.ConnConfig{


### PR DESCRIPTION
**Summary**
prior, if the sequencing and non-sequencing btc headers were off (for example, one receives a new block before the other, but we compare the two between them getting that block) a test would fail incorrectly.

now, for a max of 30 times, wait 1 second and check if they're equal.  if so, then the test passes and we break the loop. otherwise fail if we reach the 30th try

fixes #743

**Changes**
see summary
