### PR TITLE
readme: update VDP program details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ _All contributions to this repository must be made under the terms of the [MIT L
 > Never report security vulnerabilities publicly, especially in GitHub issues.
 
 If you discover vulnerabilities in Hemi, please report it responsibly so we can resolve it quickly. We ask you to help
-us better protect Hemi and our users by reporting vulnerabilities through HackerOne.
+us better protect Hemi and our users by reporting vulnerabilities through Bugcrowd.
 
-- [Submit a report through Hemi's HackerOne VDP program](https://hackerone.com/hemi_labs_vdp)
+- [Submit a report through Hemi's Bugcrowd program](https://bugcrowd.com/engagements/hemi)
 
 If you have discovered a security vulnerability, please report it in accordance with
 our [Security Policy](https://github.com/hemilabs/.github/blob/main/SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The Hemi Network is composed of many services. The core Hemi services in this re
 
 This repository also contains several utility binaries.
 
-| Name                       | Description                   |
-|----------------------------|-------------------------------|
-| [`btctool`](./cmd/btctool) | Bitcoin utility tool          |
-| [`hemictl`](./cmd/hemictl) | Hemi network controller CLI   |
-| [`keygen`](./cmd/keygen)   | Keypair generation tool       |
+| Name                       | Description                 |
+|----------------------------|-----------------------------|
+| [`btctool`](./cmd/btctool) | Bitcoin utility tool        |
+| [`hemictl`](./cmd/hemictl) | Hemi network controller CLI |
+| [`keygen`](./cmd/keygen)   | Keypair generation tool     |
 
 ## Installation
 
@@ -99,10 +99,10 @@ Discord server](https://discord.gg/hemixyz).
 
 If you discover vulnerabilities in Hemi, we encourage responsible disclosure of the vulnerability so that we can take
 steps to resolve the vulnerability as quickly as possible. We ask you to help us better protect Hemi and our users by
-reporting vulnerabilities through HackerOne. **Never report security vulnerabilities publicly, especially on GitHub
+reporting vulnerabilities through Bugcrowd. **Never report security vulnerabilities publicly, especially on GitHub
 issues.**
 
-- [Submit a report through Hemi's HackerOne VDP program](https://hackerone.com/hemi_labs_vdp)
+- [Submit a report through Hemi's Bugcrowd program](https://bugcrowd.com/engagements/hemi)
 
 If you have discovered a security vulnerability, please report it in accordance with
 our [Security Policy](https://github.com/hemilabs/.github/blob/main/SECURITY.md).


### PR DESCRIPTION
**Summary**
Update VDP program details to point to Bugcrowd in `README.md` and `CONTRIBUTING.md`.
It looks like I missed these when updating `SECURITY.md` in the past.

**Changes**
- Change VDP links to Bugcrowd in `README.md` and `CONTRIBUTING.md`.
