### PR TITLE
e2e: retry underpriced transaction

### DIFF
--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -893,7 +893,10 @@ func deployL1TestToken(t *testing.T, ctx context.Context, l1Client *ethclient.Cl
 
 		tx, err = testToken.Approve(auth, l1StandardBridge(t), big.NewInt(100))
 		if err != nil {
-			t.Fatal(err)
+			if i == abort {
+				t.Fatal(err)
+			}
+			continue
 		}
 
 		receipt = waitForTxReceipt(t, ctx, l1Client, tx)


### PR DESCRIPTION
**Summary**
if the approval transaction in localnet is underprice, retry.

fixes #839

**Changes**
see summary
