### PR TITLE
update OPTIMISM_COMMIT in localnet

### DIFF
--- a/e2e/genesisl2.sh
+++ b/e2e/genesisl2.sh
@@ -77,6 +77,9 @@ echo "$(jq '.sequencerWindowSize = 200' /shared-dir/deploy-config.json)" > /shar
 echo "$(jq '.l1BlockTime = 3' /shared-dir/deploy-config.json)" > /shared-dir/deploy-config.json
 echo "$(jq '.proofMaturityDelaySeconds = 10' /shared-dir/deploy-config.json)" > /shared-dir/deploy-config.json
 echo "$(jq '.preimageOracleChallengePeriod = 10' /shared-dir/deploy-config.json)" > /shared-dir/deploy-config.json
+echo "$(jq 'del(.customGasTokenAddress)' /shared-dir/deploy-config.json)" > /shared-dir/deploy-config.json
+echo "$(jq '.operatorFeeVaultRecipient = "0x78697c88847dfbbb40523e42c1f2e28a13a170be"' /shared-dir/deploy-config.json)" > /shared-dir/deploy-config.json
+echo "$(jq '.operatorFeeVaultWithdrawalNetwork = 1' /shared-dir/deploy-config.json)" > /shared-dir/deploy-config.json
 
 /git/optimism/op-deployer/bin/op-deployer inspect l1 --workdir .deployer 901 > /shared-dir/l1deployments.json
 

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -5,7 +5,7 @@
 # increment me to break the cache: 2
 
 ARG OP_GETH_COMMIT=e92aa4e51692bcc1bd5bceb16b990f19d610cad4
-ARG OPTIMISM_COMMIT=a1619c2ec0e92f7db28628c7d927bc21edd9b189
+ARG OPTIMISM_COMMIT=c5af0b9241e5c882eda7bbe5fe3503464783285b
 
 # commit near tip on "master" (main) branch.  the most recent release is
 # broken
@@ -98,3 +98,5 @@ COPY --from=foundry_build /git/foundry/target/debug/forge /usr/bin/forge
 RUN forge --help
 
 WORKDIR /git/optimism
+
+RUN git reset --hard


### PR DESCRIPTION
**Summary**
* updated OPTIMISM_COMMIT in localnet to the latest on the hemi branch
* added needed fields to the `deploy-config.json` file when generating it
* added a needed `git reset --hard` command after building an edited op-node (we edit for pop payout rewards, this may be out of date)

**Changes**
see summary
