### PR TITLE
ci: use hemilabs/actions/changelog-labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Hemi Labs, Inc.
+# Copyright (c) 2024-2026 Hemi Labs, Inc.
 # Use of this source code is governed by the MIT License,
 # which can be found in the LICENSE file.
 
@@ -7,75 +7,23 @@ name: "Label"
 on:
   pull_request_target:
     branches: ["main"]
-    types: ["labeled", "unlabeled", "opened", "closed", "synchronize"]
+    types: ["opened", "synchronize", "labeled", "unlabeled"]
 
 jobs:
   labeler:
     name: "Pull Request"
     runs-on: "ubuntu-latest"
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - name: "Label pull requests"
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
 
-      - name: "Check if CHANGELOG changed"
-        id: "changelog-check"
-        env:
-          GH_TOKEN: "${{ github.token }}"
-          GH_REPO: "${{ github.repository }}"
-          PR_NUMBER: "${{ github.event.pull_request.number }}"
-        run: |
-          CL_CHANGED=false
-          files=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
-          if echo "$files" | grep -q '^CHANGELOG.md$'; then
-            CL_CHANGED=true
-          fi
-          echo "changed=$CL_CHANGED" >> "$GITHUB_OUTPUT"
-
-      - name: "Manage changelog labels"
-        id: "changelog"
-        env:
-          GH_TOKEN: "${{ github.token }}"
-          GH_REPO: "${{ github.repository }}"
-          PR_NUMBER: "${{ github.event.pull_request.number }}"
-          CL_CHANGED: "${{ steps.changelog-check.outputs.changed }}"
-        run: |
-          labels=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.labels[].name')
-          REQUIRED=false
-
-          edit_label() {
-            action="$1"
-            label="$2"
-
-            if [ "$action" = "add" ]; then
-              gh api -X POST "repos/$GH_REPO/issues/$PR_NUMBER/labels" \
-                -F "labels[]=$(printf '%s' "$label")" >/dev/null 2>&1 || true
-            elif [ "$action" = "remove" ]; then
-              encoded_label=$(printf "%s" "$label" | jq -s -R -r @uri)
-              gh api -X DELETE "repos/$GH_REPO/issues/$PR_NUMBER/labels/$encoded_label" >/dev/null 2>&1 || true
-            else
-              echo "unknown action: $action"
-              exit 1
-            fi
-          }
-
-          if [ "$CL_CHANGED" = "true" ]; then
-            edit_label remove "changelog: required"
-            edit_label add "changelog: done"
-          elif echo "$labels" | grep -q "^changelog: skip$"; then
-            edit_label remove "changelog: required"
-          else
-            edit_label add "changelog: required"
-            edit_label remove "changelog: done"
-            REQUIRED=true
-          fi
-
-          echo "required=$REQUIRED" >> "$GITHUB_OUTPUT"
-
-      - name: "Block if changelog has not been updated"
-        if: "${{ steps.changelog.outputs.required == 'true' }}"
-        run: |
-          echo "❌ This pull request must have either 'changelog: done' or 'changelog: skip' label before merging."
-          exit 1
+      - name: "Update changelog labels"
+        uses: hemilabs/actions/changelog-labeler@e67f2b7d682accaeb026ebe393f8a161b2daa35b # v2.2.0
+        with:
+          changelog-path: "CHANGELOG.md"
+          label-required: "changelog: required"
+          label-skip: "changelog: skip"
+          label-done: "changelog: done"
+          required: true


### PR DESCRIPTION
**Summary**
Update the `labeler.yml` workflow to use the shared `hemilabs/actions/changelog-labeler` action.

**Changes**
- Update `labeler.yml` to use `hemilabs/actions/changelog-labeler@v2.2.0` for managing changelog labels.
