### PR TITLE
fix: don't check l2.SyncProgress when checking if synced

### DIFF
--- a/synctest/synctest.go
+++ b/synctest/synctest.go
@@ -428,18 +428,11 @@ func l2TipsMatch(ctx context.Context, c *config, lastl2BlockNumber *uint64) (boo
 	controlHash := controlBlock.Hash()
 	experimentHash := experimentalBlock.Hash()
 
-	syncProgress, err := l2Experiment.SyncProgress(ctx)
-	if err != nil {
-		return false, fmt.Errorf("could not get sync progress: %s", err)
-	}
-
-	// if sync progress is nil, then we're synced according to op-geth
-	if syncProgress != nil {
-		return false, nil
-	}
-
 	// check if we're in 5 blocks from the tip
 	for range 5 {
+		log.Tracef(
+			"comparing hashes for latest blocks (control) %s ?= (experiment) %s", experimentHash)
+
 		matching := controlHash.Hex() == experimentHash.Hex()
 
 		if matching {


### PR DESCRIPTION


**Summary**
~l2.SyncProgress, in the go library, is not guaranteed to be nil upon being synced.  there is likely an issue within op-geth or the library itself, but we cannot rely on it for determining if a node is synced or not.~

I am not sure that I was ever using `SyncProgress` correct.  regardless, it's not needed.  checking the l2 tip is sufficient, just do that.

**Changes**
remove this check and rely on only the l2 tip itself
