### PR TITLE
.github/renovate.json5: enable go toolchain updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,13 @@
       enabled: false,
     },
     {
+      description: 'Enable Go toolchain updates',
+      matchManagers: ['gomod'],
+      matchDepTypes: ['toolchain'],
+      enabled: true,
+      rangeStrategy: 'bump',
+    },
+    {
       matchManagers: ['github-actions'],
       commitMessagePrefix: 'ci:',
     },


### PR DESCRIPTION
**Summary**
Update Renovate bot config to automatically update the Go toolchain version.

**Changes**
