### PR TITLE
tbc: fix mock tbc server; use Unlock, not Lock

### DIFF
--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -261,7 +261,7 @@ func (f *TBCMockHandler) mockTBCHandleFunc(w http.ResponseWriter, r *http.Reques
 		CompressionMode: websocket.CompressionContextTakeover,
 	})
 	if err != nil {
-		f.mtx.Lock()
+		f.mtx.Unlock()
 		panic(fmt.Errorf("failed to accept websocket connection for %s: %w",
 			r.RemoteAddr, err))
 	}
@@ -274,7 +274,7 @@ func (f *TBCMockHandler) mockTBCHandleFunc(w http.ResponseWriter, r *http.Reques
 
 	wsConn := protocol.NewWSConn(conn)
 	if err = tbcapi.Write(r.Context(), wsConn, "0", ping); err != nil {
-		f.mtx.Lock()
+		f.mtx.Unlock()
 		panic(fmt.Errorf("write ping: %w", err))
 	}
 


### PR DESCRIPTION


**Summary**
in our mock tbc server, if we come accross an error, we may attempt to Lock() a mutex that's already locked.  I think this is supposed to be Unlock().  Update it.

fixes #967

**Changes**
see summary
