### PR TITLE
tbcgozer: limit in-flight goroutine calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug that allowed invalid headers to be indexed ([#950](https://github.com/hemilabs/heminetwork/pull/950))
 
-- Fix bug that let to delayed request processing in tbcgozer ([#969](https://github.com/hemilabs/heminetwork/pull/969))
+- Fix bug that led to delayed request processing in tbcgozer ([#969](https://github.com/hemilabs/heminetwork/pull/969))
 
 ## [v2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug that allowed invalid headers to be indexed ([#950](https://github.com/hemilabs/heminetwork/pull/950))
 
+- Fix bug that let to delayed request processing in tbcgozer ([#969](https://github.com/hemilabs/heminetwork/pull/969))
+
 ## [v2.0.0]
 
 ### Breaking Changes

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -296,14 +296,29 @@ func (t *tbcGozer) handleTBCWebsocketCall(pctx context.Context, conn *protocol.C
 
 	log.Tracef("handleTBCWebsocketCall")
 	defer log.Tracef("handleTBCWebsocketCall exit")
+
+	// Limit the number of concurrent in-flight Call goroutines.
+	// Each Call goroutine acquires a write lock on the conn's
+	// RWMutex, while the reader goroutine in handleTBCWebsocketRead
+	// acquires a read lock to dispatch responses. With too many
+	// concurrent writers, the reader may become starved.
+	sem := make(chan struct{}, DefaultCommandQueueDepth)
+
 	for {
 		select {
 		case <-pctx.Done():
 			return
 		case c := <-t.cmdCh:
+			select {
+			case <-pctx.Done():
+				return
+			case sem <- struct{}{}:
+			}
 			// Parallelize calls. There is no reason to do them
 			// in order and wait for potentially slow completion.
 			go func(bc tbcCmd) {
+				defer func() { <-sem }()
+
 				if bc.timeout == 0 {
 					bc.timeout = DefaultRequestTimeout
 				}

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -68,6 +68,7 @@ func TestTBCGozerConnection(t *testing.T) {
 		}
 	}
 
+	DefaultRequestTimeout = 10 * time.Second // CI is slow as balls
 	b := New(fmt.Sprintf("http://%s/v1/ws", tbcAddr))
 	err = b.Run(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
**Summary**
Addresses #967.

`tbcGozer` will wait for a request, and then spawn a goroutine that performs a call to the `TBC` server (`handleTBCWebsocketCall`). The calls are limited by a `chan` of a certain depth. However, since the processing of the call is done inside a goroutine, these requests get consumed almost instantly.

At the same time, a reader (`handleTBCWebsocketRead`) goroutine continously reads the responses from the `TBC` server, and sends it to the corresponding caller. 

However, both the caller and reader goroutines acquire a `RWLock` for the connection internally (to create and retrieve channels to route the responses to, respectively). There is only a single reader, but multiple callers, which can lead to the starvation of the reader, who must wait a very long time to acquire the lock.

The test `TestTBCGozerCalls` spawns 1000 goroutines, each performing 4 calls to the mock `TBC` server. There is also a limit to how long a caller will wait for a response (10s) before timing out. In CI, a reader would sometimes be delayed in processing responses, which would lead to certain callers timing out, waiting for a response.

**Changes**
Adds a semaphore `handleTBCWebsocketCall`, preventing unlimited calls to occur simultaneously, starving the response reader.

**NOTE**: The test was run 600 times, split between two actions runs, with no failures. Results can be seen [here](https://github.com/hemilabs/heminetwork/actions/runs/24449952738) and [here](https://github.com/hemilabs/heminetwork/actions/runs/24451002306).