### PR TITLE
trust: add db wrapper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add RPC request method whitelist to hproxy ([#691](https://github.com/hemilabs/heminetwork/pull/691)).
 - Add TBC notification system ([#725](https://github.com/hemilabs/heminetwork/pull/725)).
 - Add Continuum Transfuctioner protocol and daemon to handle threshold signatures ([#752](https://github.com/hemilabs/heminetwork/pull/752)).
+- Add Trust, rust version of TBC Headers only mode ([#970](https://github.com/hemilabs/heminetwork/pull/970))
 
 ### Changed
 

--- a/crates/trust/src/trust.rs
+++ b/crates/trust/src/trust.rs
@@ -1,7 +1,9 @@
+use crate::trust_db::{BlockHeader, InsertType, RemoveType};
 use crate::trust_db::{
     DB_METADATA_KEY_UPSTREAM_STATE_ID, TrustDB, TrustDBError, TrustDBTable::MetadataCF,
 };
 use bitcoin::Network;
+use bitcoin::block::Header;
 use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
@@ -16,6 +18,8 @@ pub enum TrustError {
     NotFound(String),
     #[error("Invalid state: {0}")]
     InvalidState(String),
+    #[error("Invalid parameters: {0}")]
+    InvalidParams(String),
 }
 
 pub type Result<T> = std::result::Result<T, TrustError>;
@@ -86,7 +90,7 @@ impl Trust {
     /// Pass None for default chain genesis block.
     pub fn external_header_setup(
         &self,
-        genesis_override: Option<(&bitcoin::block::Header, u64, ethnum::U256)>,
+        genesis_override: Option<(&Header, u64, ethnum::U256)>,
         upstream_state_id: &[u8; 32],
     ) -> Result<()> {
         let mut genesis = &bitcoin::blockdata::constants::genesis_block(self.network).header;
@@ -124,6 +128,77 @@ impl Trust {
             }
         }
         Ok(())
+    }
+
+    pub fn add_external_headers(
+        &self,
+        headers: &[Header],
+        upstream_state_id: &[u8; 32],
+    ) -> Result<(InsertType, BlockHeader, BlockHeader, usize)> {
+        if headers.is_empty() {
+            return Err(TrustError::InvalidParams(
+                "add_external_headers: called with no headers".to_string(),
+            ));
+        }
+
+        if upstream_state_id == &[0u8; 32] {
+            return Err(TrustError::InvalidParams(
+                "add_external_headers: upstream state is invalid".to_string(),
+            ));
+        }
+
+        let hooks = [(
+            &MetadataCF,
+            DB_METADATA_KEY_UPSTREAM_STATE_ID.as_bytes(),
+            &upstream_state_id[..],
+        )];
+        self.db
+            .block_headers_insert(headers, &hooks)
+            .map_err(TrustError::TrustDB)
+    }
+
+    pub fn remove_external_headers(
+        &self,
+        headers: &[Header],
+        tip_after_removal: &Header,
+        upstream_state_id: &[u8; 32],
+    ) -> Result<(RemoveType, BlockHeader)> {
+        if headers.is_empty() {
+            return Err(TrustError::InvalidParams(
+                "remove_external_headers: called with no headers".to_string(),
+            ));
+        }
+
+        if upstream_state_id == &[0u8; 32] {
+            return Err(TrustError::InvalidParams(
+                "remove_external_headers: upstream state is invalid".to_string(),
+            ));
+        }
+
+        let hooks = [(
+            &MetadataCF,
+            DB_METADATA_KEY_UPSTREAM_STATE_ID.as_bytes(),
+            &upstream_state_id[..],
+        )];
+        self.db
+            .block_headers_remove(headers, tip_after_removal, &hooks)
+            .map_err(TrustError::TrustDB)
+    }
+
+    pub fn block_header_by_hash(&self, hash: bitcoin::BlockHash) -> Result<(Header, u64)> {
+        let res = self.db.block_header_by_hash(hash)?;
+        Ok((res.header, res.height))
+    }
+
+    pub fn block_header_best(&self) -> Result<(Header, u64)> {
+        let res = self.db.block_header_best()?;
+        Ok((res.header, res.height))
+    }
+
+    pub fn block_headers_by_height(&self, height: u64) -> Result<Vec<Header>> {
+        let res = self.db.block_headers_by_height(height)?;
+        let val: Vec<Header> = res.into_iter().map(|i| i.header).collect();
+        Ok(val)
     }
 }
 
@@ -271,14 +346,12 @@ mod tests {
             Err(e) => panic!("{e}"),
         }
 
-        let best = trust
-            .db
-            .block_header_best()
-            .expect("best header should exist");
+        let (bhb, height) = trust.block_header_best().expect("best header should exist");
         assert_eq!(
-            best.hash.as_byte_array(),
+            bhb.block_hash().as_byte_array(),
             trust.network.chain_hash().as_bytes()
         );
+        assert_eq!(height, 0);
     }
 
     #[test]
@@ -307,9 +380,9 @@ mod tests {
             Err(e) => panic!("{e}"),
         }
 
-        let hh = trust.db.block_headers_by_height(height).unwrap();
+        let hh = trust.block_headers_by_height(height).unwrap();
         assert_eq!(hh.len(), 1);
-        assert_eq!(hh[0].hash, header.block_hash());
+        assert_eq!(hh[0].block_hash(), header.block_hash());
     }
 
     #[test]
@@ -354,6 +427,272 @@ mod tests {
                 _ => panic!("unexpected error: {e}"),
             },
             Ok(_) => panic!("setup should fail with mismatched hashes"),
+        }
+    }
+
+    fn create_test_header(parent_hash: bitcoin::BlockHash, n: u32) -> Header {
+        Header {
+            version: bitcoin::blockdata::block::Version::ONE,
+            prev_blockhash: parent_hash,
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 12345,
+            bits: bitcoin::CompactTarget::from_consensus(0x1d00ffff),
+            nonce: n,
+        }
+    }
+
+    fn setup_trust() -> (Trust, Header) {
+        let tmp = tempdir().expect("temp dir should have been created");
+        let tmp = tmp.path().to_str().expect("path should be string");
+        let cfg = TrustConfig::new_default_config(tmp);
+        let trust = Trust::new(cfg).unwrap();
+
+        let usi = b"this_is_a_test_for_this_test_yes";
+        let genesis = create_test_header(bitcoin::BlockHash::all_zeros(), 0);
+        let genesis_override = Some((&genesis, 0u64, ethnum::U256::from(1_u32)));
+
+        trust
+            .external_header_setup(genesis_override, usi)
+            .expect("external_header_setup should succeed");
+
+        (trust, genesis)
+    }
+
+    #[test]
+    fn test_add_external_headers() {
+        let (trust, genesis) = setup_trust();
+
+        let h1 = create_test_header(genesis.block_hash(), 1);
+        let h2 = create_test_header(h1.block_hash(), 2);
+        let h3 = create_test_header(h2.block_hash(), 3);
+
+        let usi = b"add_external_headers_state_id_ok";
+        let headers = [h1, h2, h3];
+        let (it, canon, last, count) = trust.add_external_headers(&headers, usi).unwrap();
+
+        assert_eq!(it, InsertType::ChainExtend);
+        assert_eq!(count, 3);
+        assert_eq!(last.hash, h3.block_hash());
+        assert_eq!(last.height, 3);
+        assert_eq!(canon.hash, h3.block_hash());
+
+        let (bhb, height) = trust.block_header_best().expect("best header should exist");
+
+        assert_eq!(bhb.block_hash(), h3.block_hash());
+        assert_eq!(height, 3);
+
+        let res = trust
+            .get_upstream_state_id()
+            .expect("upstream state id should be set");
+
+        assert_eq!(res, *usi);
+    }
+
+    #[test]
+    fn test_add_external_headers_errors() {
+        let (trust, genesis) = setup_trust();
+        let usi = b"add_external_headers_state_id_ok";
+
+        // empty headers
+        let empty_res: TrustError = trust
+            .add_external_headers(&[], usi)
+            .expect_err("should fail with empty headers");
+
+        match empty_res {
+            TrustError::InvalidParams(_) => (),
+            e => panic!("unexpected error: {e}"),
+        }
+
+        // invalid upstream state id
+        let h1 = create_test_header(genesis.block_hash(), 1);
+        let invalid_res = trust
+            .add_external_headers(&[h1], &[0u8; 32])
+            .expect_err("should fail with with invalid upstream state id");
+
+        match invalid_res {
+            TrustError::InvalidParams(_) => (),
+            e => panic!("unexpected error: {e}"),
+        }
+    }
+
+    #[test]
+    fn test_remove_external_headers() {
+        let (trust, genesis) = setup_trust();
+
+        let h1 = create_test_header(genesis.block_hash(), 1);
+        let h2 = create_test_header(h1.block_hash(), 2);
+        let h3 = create_test_header(h2.block_hash(), 3);
+
+        let usi_add = b"remove_ext_headers_state_add_ok_";
+        trust
+            .add_external_headers(&[h1, h2, h3], usi_add)
+            .expect("add_external_headers should succeed");
+
+        let usi_remove = b"remove_ext_headers_state_rem_ok_";
+        let (rt, tip) = trust
+            .remove_external_headers(&[h2, h3], &h1, usi_remove)
+            .expect("remove_external_headers should succeed");
+
+        assert_eq!(rt, RemoveType::ChainDescend);
+        assert_eq!(tip.hash, h1.block_hash());
+
+        let (bhb, height) = trust.block_header_best().expect("best header should exist");
+
+        assert_eq!(bhb.block_hash(), h1.block_hash());
+        assert_eq!(height, 1);
+
+        let res = trust
+            .get_upstream_state_id()
+            .expect("upstream state id should be set");
+
+        assert_eq!(res, *usi_remove);
+    }
+
+    #[test]
+    fn test_remove_external_headers_errors() {
+        let (trust, genesis) = setup_trust();
+        let usi = b"add_external_headers_state_id_ok";
+
+        let h1 = create_test_header(genesis.block_hash(), 1);
+        trust
+            .add_external_headers(&[h1], usi)
+            .expect("add_external_headers should succeed");
+
+        // empty headers
+        let empty_res: TrustError = trust
+            .remove_external_headers(&[], &genesis, usi)
+            .expect_err("should fail with empty headers");
+
+        match empty_res {
+            TrustError::InvalidParams(_) => (),
+            e => panic!("unexpected error: {e}"),
+        }
+
+        // invalid upstream state id
+        let h1 = create_test_header(genesis.block_hash(), 1);
+        let invalid_res = trust
+            .remove_external_headers(&[h1], &genesis, &[0u8; 32])
+            .expect_err("should fail with with invalid upstream state id");
+
+        match invalid_res {
+            TrustError::InvalidParams(_) => (),
+            e => panic!("unexpected error: {e}"),
+        }
+    }
+
+    #[test]
+    fn test_block_header_best() {
+        let tmp = tempdir().expect("temp dir should have been created");
+        let tmp = tmp.path().to_str().expect("path should be string");
+        let cfg = TrustConfig::new_default_config(tmp);
+        let trust = Trust::new(cfg).unwrap();
+
+        // test error
+        let res = trust
+            .block_header_best()
+            .expect_err("should fail with no best header");
+
+        match res {
+            TrustError::TrustDB(_) => (),
+            e => panic!("unexpected error: {e}"),
+        }
+
+        // insert genesis
+        let usi = b"this_is_a_test_for_this_test_yes";
+        let genesis = create_test_header(bitcoin::BlockHash::all_zeros(), 0);
+        let genesis_override = Some((&genesis, 0u64, ethnum::U256::from(1_u32)));
+
+        trust
+            .external_header_setup(genesis_override, usi)
+            .expect("external_header_setup should succeed");
+
+        // test success
+        let (bhb, height) = trust.block_header_best().expect("best header should exist");
+
+        assert_eq!(bhb.block_hash(), genesis.block_hash());
+        assert_eq!(height, 0);
+
+        let h1 = create_test_header(genesis.block_hash(), 1);
+        let h2 = create_test_header(h1.block_hash(), 2);
+        let usi = b"test_block_header_best_state_id_";
+        trust
+            .add_external_headers(&[h1, h2], usi)
+            .expect("add_external_headers should succeed");
+
+        let (bhb, height) = trust.block_header_best().expect("best header should exist");
+
+        assert_eq!(bhb.block_hash(), h2.block_hash());
+        assert_eq!(height, 2);
+    }
+
+    #[test]
+    fn test_block_header_by_hash() {
+        let (trust, genesis) = setup_trust();
+
+        // test error
+        let fake_hash = bitcoin::hashes::Hash::hash(&[0xffu8; 32]);
+        let res = trust
+            .block_header_by_hash(fake_hash)
+            .expect_err("should fail for unknown hash");
+
+        match res {
+            TrustError::TrustDB(_) => (),
+            e => panic!("unexpected error: {e}"),
+        }
+
+        // test success
+        let (header, height) = trust
+            .block_header_by_hash(genesis.block_hash())
+            .expect("block_header_by_hash should succeed");
+
+        assert_eq!(header.block_hash(), genesis.block_hash());
+        assert_eq!(height, 0);
+    }
+
+    #[test]
+    fn test_block_headers_by_height() {
+        let (trust, genesis) = setup_trust();
+
+        // test error
+        let err = trust
+            .block_headers_by_height(9999)
+            .expect_err("should fail for non-existent height");
+
+        match err {
+            TrustError::TrustDB(_) => (),
+            e => panic!("unexpected error: {e}"),
+        }
+
+        // test success
+        let h1a = create_test_header(genesis.block_hash(), 1);
+        let h1b = create_test_header(genesis.block_hash(), 2);
+        let usi = b"test_block_headers_by_height_usi";
+        trust
+            .add_external_headers(&[h1a], usi)
+            .expect("add_external_headers should succeed: h1a");
+        trust
+            .add_external_headers(&[h1b], usi)
+            .expect("add_external_headers should succeed: h1b");
+
+        let res0 = trust
+            .block_headers_by_height(0)
+            .expect("block_headers_by_height should succeed: 0");
+
+        assert_eq!(res0.len(), 1);
+        assert_eq!(res0[0].block_hash(), genesis.block_hash());
+
+        let res1 = trust
+            .block_headers_by_height(1)
+            .expect("block_headers_by_height should succeed: 1");
+
+        assert_eq!(res1.len(), 2);
+
+        if !res1.iter().any(|i| i.block_hash() == h1a.block_hash()) {
+            panic!("block header h1a not found")
+        }
+
+        if !res1.iter().any(|i| i.block_hash() == h1b.block_hash()) {
+            panic!("block header h1b not found")
         }
     }
 }


### PR DESCRIPTION
**Summary**
Addresses the remainder of #917. Adds wrappers for `TrustDB` methods to `Trust`.

**Changes**
Added the following methods to `Trust`:
- `add_external_headers`
- `remove_external_headers`
- `block_header_by_hash`
- `block_header_best`
- `block_headers_by_height`
