### PR TITLE
tbcd: restore witness data in block storage and add v5 db upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved signal handling in the daemons ([#763](https://github.com/hemilabs/heminetwork/pull/763)).
 
+- Bump tbcd database schema to v5; first start after upgrade
+  wipes the stored block bodies and re-downloads them with
+  witness data, triggered by the witness-download fix below.
+
 ### Fixed
 
 - Fix typos across the codebase
@@ -43,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug that allowed invalid headers to be indexed ([#950](https://github.com/hemilabs/heminetwork/pull/950))
 
 - Fix bug that led to delayed request processing in tbcgozer ([#969](https://github.com/hemilabs/heminetwork/pull/969))
+
+- Fix tbcd requesting witness-stripped blocks and txs from
+  peers (BIP-144); on-disk blocks are now witness-inclusive
+  after a v5 upgrade plus resync.
 
 ## [v2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved signal handling in the daemons ([#763](https://github.com/hemilabs/heminetwork/pull/763)).
 
-- Bump tbcd database schema to v5; first start after upgrade
-  wipes the stored block bodies and re-downloads them with
-  witness data, triggered by the witness-download fix below.
+- Bump tbcd database schema to v5; first start after upgrade wipes the stored block bodies and re-downloads them
+  with witness data, triggered by the witness-download fix below
+  ([#972](https://github.com/hemilabs/heminetwork/pull/972)).
 
 ### Fixed
 
@@ -48,9 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug that led to delayed request processing in tbcgozer ([#969](https://github.com/hemilabs/heminetwork/pull/969))
 
-- Fix tbcd requesting witness-stripped blocks and txs from
-  peers (BIP-144); on-disk blocks are now witness-inclusive
-  after a v5 upgrade plus resync.
+- Fix tbcd requesting witness-stripped blocks and txs from peers (BIP-144); on-disk blocks are now
+  witness-inclusive after a v5 upgrade plus resync
+  ([#972](https://github.com/hemilabs/heminetwork/pull/972)).
 
 ## [v2.0.0]
 

--- a/database/level/level.go
+++ b/database/level/level.go
@@ -130,6 +130,16 @@ func (l *Database) RawDB() RawPool {
 	return maps.Clone(l.rawPool)
 }
 
+// Config returns a shallow copy of the database configuration.
+// XXX this is a band-aid; the interfaces inside opt.Options (Filter,
+// Comparer, Cacher) are shared references, not deep copies.  Safe
+// today because nothing mutates them after open, but a proper fix
+// would be to stop duplicating pool/rawPool on ldb and use the
+// embedded Database directly.
+func (l *Database) Config() Config {
+	return *l.cfg
+}
+
 func (l *Database) openDB(name string) error {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -47,7 +47,7 @@ import (
 //	UTXOs
 
 const (
-	ldbVersion = 4
+	ldbVersion = 5
 
 	logLevel = "INFO"
 	verbose  = false
@@ -291,6 +291,10 @@ func New(ctx context.Context, cfg *Config) (*ldb, error) {
 		case 3:
 			// Upgrade to v4
 			err = l.v4(ctx)
+		case 4:
+			// Upgrade to v5: wipe witness-stripped block
+			// bodies and rebuild blocksmissing from headers.
+			err = l.v5(ctx)
 		default:
 			if ldbVersion == dbVersion {
 				if Welcome {

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -192,6 +192,9 @@ func NewConfig(network, home, blockheaderCacheSizeS, blockCacheSizeS string) (*C
 	if err != nil {
 		return nil, fmt.Errorf("homedir: %w", err)
 	}
+	if !filepath.IsAbs(homedir) {
+		return nil, fmt.Errorf("home directory must be absolute: %v", homedir)
+	}
 
 	return &Config{
 		Home:                 homedir,

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -847,6 +847,204 @@ func encodeKeystoneToSliceV1(ks tbcd.Keystone) []byte {
 	return eks[:]
 }
 
+// TestDbUpgradeV5 validates the v4 -> v5 upgrade that wipes
+// witness-stripped block bodies and rebuilds BlocksMissingDB from
+// the header chain.  The upgrade must:
+//
+//   - empty BlocksDB rawdb completely (both index and data);
+//   - populate BlocksMissingDB with one heightHashToKey entry per
+//     row in BlockHeadersDB (skipping the canonical-tip sentinel);
+//   - leave every other database untouched — specifically
+//     TransactionsDB, OutputsDB, KeystonesDB, BlockHeadersDB,
+//     HeightHashDB, and the indexer tips in MetadataDB — because
+//     those are all witness-independent;
+//   - bump the schema version from 4 to 5.
+func TestDbUpgradeV5(t *testing.T) {
+	const blkNum uint64 = 5
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	home := t.TempDir()
+	t.Logf("temp: %v", home)
+	cfg, err := NewConfig("upgradetest", home, "0mb", "0mb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Phase 1: open in upgrade-skipping mode so the fresh-db
+	// version stamp can be overwritten with 4 before close.
+	// Build a short chain of headers + blocks, plant survivor
+	// rows in the tables v5 must not touch, then stamp the
+	// version down so reopen runs v5.
+	cfg.SetUpgradeOpen(true)
+	db, err := New(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hashes := make([]chainhash.Hash, 0, blkNum)
+	heights := make(map[chainhash.Hash]uint64, blkNum)
+	prevHash := &chainhash.Hash{}
+	for i := range blkNum {
+		bh, _, err := insertBlockHeader(ctx, db, prevHash, i, i)
+		if err != nil {
+			t.Fatalf("insertBlockHeader %v: %v", i, err)
+		}
+		if err := insertBlock(ctx, db, bh); err != nil {
+			t.Fatalf("insertBlock %v: %v", i, err)
+		}
+		h := bh.BlockHash()
+		hashes = append(hashes, *h)
+		heights[*h] = bh.Height
+		prevHash = h
+	}
+
+	// Survivor rows: arbitrary bytes written to tables whose
+	// contents v5 must not touch.  The keys are deliberately
+	// unique so a post-upgrade Get confirms exact preservation.
+	survivors := map[string][2][]byte{
+		level.TransactionsDB: {
+			[]byte("v5-test-tx-key"),
+			[]byte("v5-test-tx-value"),
+		},
+		level.OutputsDB: {
+			[]byte("v5-test-utxo-key"),
+			[]byte("v5-test-utxo-value"),
+		},
+		level.KeystonesDB: {
+			[]byte("v5-test-keystone-key"),
+			[]byte("v5-test-keystone-value"),
+		},
+	}
+	for table, kv := range survivors {
+		if err := db.insertTable(table, kv[0], kv[1]); err != nil {
+			t.Fatalf("seed %v: %v", table, err)
+		}
+	}
+
+	// Sanity: BlocksDB rawdb actually holds the seeded blocks
+	// before the upgrade runs.  v5's correctness story is "we
+	// wiped what was there"; without this check a silently
+	// empty pre-state would make the post-upgrade empty
+	// assertion vacuous.
+	preBdb := db.rawPool[level.BlocksDB]
+	preIt := preBdb.DB().NewIterator(nil, nil)
+	var preCount int
+	for preIt.Next() {
+		preCount++
+	}
+	preIt.Release()
+	if err := preIt.Error(); err != nil {
+		t.Fatal(err)
+	}
+	if preCount != int(blkNum) {
+		t.Fatalf("pre-upgrade BlocksDB: got %v entries want %v",
+			preCount, blkNum)
+	}
+
+	v4 := make([]byte, 8)
+	binary.BigEndian.PutUint64(v4, 4)
+	if err := db.MetadataPut(ctx, versionKey, v4); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Phase 2: reopen with the upgrade ladder enabled.  The
+	// stamped v4 triggers v5 end-to-end.
+	cfg.SetUpgradeOpen(false)
+	db2, err := New(ctx, cfg)
+	if err != nil {
+		t.Fatalf("reopen (runs v5): %v", err)
+	}
+	defer func() {
+		if err := db2.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Assertion 1: BlocksDB rawdb is empty after v5.
+	bdb := db2.rawPool[level.BlocksDB]
+	it := bdb.DB().NewIterator(nil, nil)
+	var bcount int
+	for it.Next() {
+		bcount++
+	}
+	it.Release()
+	if err := it.Error(); err != nil {
+		t.Fatal(err)
+	}
+	if bcount != 0 {
+		t.Fatalf("BlocksDB not empty after v5: %v entries", bcount)
+	}
+
+	// Assertion 2: BlocksMissingDB has exactly one entry per
+	// header row, keyed by heightHashToKey(height, hash).
+	bmDB := db2.pool[level.BlocksMissingDB]
+	seen := make(map[chainhash.Hash]bool, len(hashes))
+	bmIt := bmDB.NewIterator(nil, nil)
+	for bmIt.Next() {
+		height, hash := keyToHeightHash(bmIt.Key())
+		expected, ok := heights[*hash]
+		if !ok {
+			t.Fatalf("blocksmissing has unexpected hash %v", hash)
+		}
+		if height != expected {
+			t.Fatalf("blocksmissing height mismatch for %v: got %v want %v",
+				hash, height, expected)
+		}
+		if seen[*hash] {
+			t.Fatalf("blocksmissing duplicate hash %v", hash)
+		}
+		seen[*hash] = true
+	}
+	bmIt.Release()
+	if err := bmIt.Error(); err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != len(hashes) {
+		t.Fatalf("blocksmissing coverage: got %v entries want %v",
+			len(seen), len(hashes))
+	}
+
+	// Assertion 3: survivor rows are intact.
+	for table, kv := range survivors {
+		tdb := db2.pool[table]
+		got, err := tdb.Get(kv[0], nil)
+		if err != nil {
+			t.Fatalf("survivor get %v: %v", table, err)
+		}
+		if !bytes.Equal(got, kv[1]) {
+			t.Fatalf("survivor %v: got %q want %q", table, got, kv[1])
+		}
+	}
+
+	// Assertion 4: BlockHeadersDB and HeightHashDB are
+	// untouched.  Cheap way to confirm: every header hash we
+	// seeded is still retrievable and reports the same height.
+	for _, h := range hashes {
+		bh, err := db2.BlockHeaderByHash(ctx, h)
+		if err != nil {
+			t.Fatalf("blockheader %v: %v", h, err)
+		}
+		if bh.Height != heights[h] {
+			t.Fatalf("blockheader %v height: got %v want %v",
+				h, bh.Height, heights[h])
+		}
+	}
+
+	// Assertion 5: schema version is now 5.
+	got, err := db2.Version(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 5 {
+		t.Fatalf("version after v5: got %v want 5", got)
+	}
+}
+
 func createTestBlock(prevHash *chainhash.Hash, nonce int64) *btcutil.Block {
 	bh := wire.NewBlockHeader(0, prevHash, &chainhash.Hash{}, 0, uint32(nonce))
 	bh.Timestamp = time.Unix(nonce, 0)

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1547,6 +1548,165 @@ func TestBlockHeadersRemove(t *testing.T) {
 						tti.removeType[i], rt)
 				}
 			}
+		})
+	}
+}
+
+// TestDbUpgradeV5Errors drives v5 against a v4 database whose
+// in-memory pool has been surgically damaged to force each of the
+// defensive error returns.  Each case opens a v4 database with
+// SetUpgradeOpen(true), mutates l.pool / l.rawPool / stored rows
+// to set up the specific failure, then calls v5 directly and
+// asserts the wrapped error prefix.  Calling v5 directly (not
+// through New's upgrade ladder) keeps each subtest focused on a
+// single branch.
+func TestDbUpgradeV5Errors(t *testing.T) {
+	type tc struct {
+		name      string
+		setup     func(t *testing.T, db *ldb)
+		wantErrIn string
+	}
+	cases := []tc{
+		{
+			name: "missing blocks rawdb handle",
+			setup: func(_ *testing.T, db *ldb) {
+				delete(db.rawPool, level.BlocksDB)
+			},
+			wantErrIn: "rawdb not found",
+		},
+		{
+			name: "closed blocks rawdb",
+			setup: func(t *testing.T, db *ldb) {
+				// Close the rawdb once; v5's Close call
+				// then hits leveldb.ErrClosed on the
+				// underlying index.
+				if err := db.rawPool[level.BlocksDB].Close(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErrIn: "close blocks rawdb",
+		},
+		{
+			name: "missing blocksmissing handle",
+			setup: func(_ *testing.T, db *ldb) {
+				delete(db.pool, level.BlocksMissingDB)
+			},
+			wantErrIn: "db not found: " + level.BlocksMissingDB,
+		},
+		{
+			name: "closed blocksmissing iterator",
+			setup: func(t *testing.T, db *ldb) {
+				// Close the leveldb handle behind
+				// BlocksMissingDB's back.  The iterator
+				// over a closed db surfaces the error
+				// through clearIt.Error() after the
+				// loop.
+				if err := db.pool[level.BlocksMissingDB].Close(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErrIn: "blocksmissing iterator",
+		},
+		{
+			name: "missing blockheaders handle",
+			setup: func(_ *testing.T, db *ldb) {
+				delete(db.pool, level.BlockHeadersDB)
+			},
+			wantErrIn: "db not found: " + level.BlockHeadersDB,
+		},
+		{
+			name: "malformed blockheader value size",
+			setup: func(t *testing.T, db *ldb) {
+				// Plant a row whose key looks like a
+				// 32-byte hash but whose value is
+				// shorter than blockheaderSize.
+				h := testutil.String2Hash(
+					"1111111111111111111111111111111111111111111111111111111111111111")
+				if err := db.insertTable(level.BlockHeadersDB,
+					h[:], []byte("short")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErrIn: "blockheader value size",
+		},
+		{
+			name: "closed blockheaders iterator",
+			setup: func(t *testing.T, db *ldb) {
+				// Step 3 of v5 iterates BlockHeadersDB.
+				// Closing the handle before v5 runs
+				// surfaces the error through
+				// it.Error() after the loop.
+				if err := db.pool[level.BlockHeadersDB].Close(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErrIn: "blockheaders iterator",
+		},
+		{
+			name: "metadata put fails",
+			setup: func(t *testing.T, db *ldb) {
+				// Close the MetadataDB handle so the
+				// final MetadataPut(versionKey, 5) at
+				// end of v5 fails.
+				if err := db.pool[level.MetadataDB].Close(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			// MetadataPut wraps through startTransaction
+			// which returns "unable to open db transaction"
+			// on a closed handle.
+			wantErrIn: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			home := t.TempDir()
+			cfg, err := NewConfig("upgradetest", home, "0mb", "0mb")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg.SetUpgradeOpen(true)
+			db, err := New(ctx, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				// Best effort — several subtests close
+				// pool entries so a final Close may or
+				// may not succeed.
+				_ = db.Close()
+			}()
+
+			// Seed one header + one block so step 1 has
+			// something to wipe and step 3 has a row to
+			// rebuild from.  Skip for the malformed-value
+			// case, which plants its own bogus header.
+			if c.name != "malformed blockheader value size" {
+				bh, _, err := insertBlockHeader(ctx, db,
+					&chainhash.Hash{}, 0, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := insertBlock(ctx, db, bh); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			c.setup(t, db)
+
+			err = db.v5(ctx)
+			if err == nil {
+				t.Fatalf("expected v5 error, got nil")
+			}
+			if c.wantErrIn != "" && !strings.Contains(err.Error(), c.wantErrIn) {
+				t.Fatalf("v5 error %q does not contain %q",
+					err.Error(), c.wantErrIn)
+			}
+			t.Logf("v5 returned: %v", err)
 		})
 	}
 }

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -1559,12 +1559,13 @@ func TestBlockHeadersRemove(t *testing.T) {
 // up the specific failure, then calls v5 directly and asserts the
 // wrapped error prefix.
 func TestDbUpgradeV5Errors(t *testing.T) {
-	type tc struct {
+	type test struct {
 		name      string
 		setup     func(t *testing.T, db *ldb)
 		wantErrIn string
+		seedBlock bool
 	}
-	cases := []tc{
+	tests := []test{
 		{
 			name: "close database fails",
 			setup: func(t *testing.T, db *ldb) {
@@ -1576,6 +1577,7 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 				}
 			},
 			wantErrIn: "close database",
+			seedBlock: true,
 		},
 		{
 			name: "malformed blockheader value size",
@@ -1591,11 +1593,12 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 				}
 			},
 			wantErrIn: "blockheader value size",
+			seedBlock: false,
 		},
 	}
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
@@ -1618,9 +1621,8 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 
 			// Seed one header + one block so step 1 has
 			// something to wipe and step 2 has a row to
-			// rebuild from.  Skip for the malformed-value
-			// case, which plants its own bogus header.
-			if c.name != "malformed blockheader value size" {
+			// rebuild from.
+			if tt.seedBlock {
 				bh, _, err := insertBlockHeader(ctx, db,
 					&chainhash.Hash{}, 0, 0)
 				if err != nil {
@@ -1631,15 +1633,15 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 				}
 			}
 
-			c.setup(t, db)
+			tt.setup(t, db)
 
 			err = db.v5(ctx)
 			if err == nil {
 				t.Fatalf("expected v5 error, got nil")
 			}
-			if c.wantErrIn != "" && !strings.Contains(err.Error(), c.wantErrIn) {
+			if tt.wantErrIn != "" && !strings.Contains(err.Error(), tt.wantErrIn) {
 				t.Fatalf("v5 error %q does not contain %q",
-					err.Error(), c.wantErrIn)
+					err.Error(), tt.wantErrIn)
 			}
 			t.Logf("v5 returned: %v", err)
 		})

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -1555,11 +1555,9 @@ func TestBlockHeadersRemove(t *testing.T) {
 // TestDbUpgradeV5Errors drives v5 against a v4 database whose
 // in-memory pool has been surgically damaged to force each of the
 // defensive error returns.  Each case opens a v4 database with
-// SetUpgradeOpen(true), mutates l.pool / l.rawPool / stored rows
-// to set up the specific failure, then calls v5 directly and
-// asserts the wrapped error prefix.  Calling v5 directly (not
-// through New's upgrade ladder) keeps each subtest focused on a
-// single branch.
+// SetUpgradeOpen(true), mutates pool state or stored rows to set
+// up the specific failure, then calls v5 directly and asserts the
+// wrapped error prefix.
 func TestDbUpgradeV5Errors(t *testing.T) {
 	type tc struct {
 		name      string
@@ -1568,51 +1566,16 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 	}
 	cases := []tc{
 		{
-			name: "missing blocks rawdb handle",
-			setup: func(_ *testing.T, db *ldb) {
-				delete(db.rawPool, level.BlocksDB)
-			},
-			wantErrIn: "rawdb not found",
-		},
-		{
-			name: "closed blocks rawdb",
+			name: "close database fails",
 			setup: func(t *testing.T, db *ldb) {
-				// Close the rawdb once; v5's Close call
-				// then hits leveldb.ErrClosed on the
-				// underlying index.
-				if err := db.rawPool[level.BlocksDB].Close(); err != nil {
-					t.Fatal(err)
-				}
-			},
-			wantErrIn: "close blocks rawdb",
-		},
-		{
-			name: "missing blocksmissing handle",
-			setup: func(_ *testing.T, db *ldb) {
-				delete(db.pool, level.BlocksMissingDB)
-			},
-			wantErrIn: "db not found: " + level.BlocksMissingDB,
-		},
-		{
-			name: "closed blocksmissing iterator",
-			setup: func(t *testing.T, db *ldb) {
-				// Close the leveldb handle behind
-				// BlocksMissingDB's back.  The iterator
-				// over a closed db surfaces the error
-				// through clearIt.Error() after the
-				// loop.
+				// Pre-close a handle so that v5's
+				// initial l.Close() encounters a
+				// double-close error.
 				if err := db.pool[level.BlocksMissingDB].Close(); err != nil {
 					t.Fatal(err)
 				}
 			},
-			wantErrIn: "blocksmissing iterator",
-		},
-		{
-			name: "missing blockheaders handle",
-			setup: func(_ *testing.T, db *ldb) {
-				delete(db.pool, level.BlockHeadersDB)
-			},
-			wantErrIn: "db not found: " + level.BlockHeadersDB,
+			wantErrIn: "close database",
 		},
 		{
 			name: "malformed blockheader value size",
@@ -1628,34 +1591,6 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 				}
 			},
 			wantErrIn: "blockheader value size",
-		},
-		{
-			name: "closed blockheaders iterator",
-			setup: func(t *testing.T, db *ldb) {
-				// Step 3 of v5 iterates BlockHeadersDB.
-				// Closing the handle before v5 runs
-				// surfaces the error through
-				// it.Error() after the loop.
-				if err := db.pool[level.BlockHeadersDB].Close(); err != nil {
-					t.Fatal(err)
-				}
-			},
-			wantErrIn: "blockheaders iterator",
-		},
-		{
-			name: "metadata put fails",
-			setup: func(t *testing.T, db *ldb) {
-				// Close the MetadataDB handle so the
-				// final MetadataPut(versionKey, 5) at
-				// end of v5 fails.
-				if err := db.pool[level.MetadataDB].Close(); err != nil {
-					t.Fatal(err)
-				}
-			},
-			// MetadataPut wraps through startTransaction
-			// which returns "unable to open db transaction"
-			// on a closed handle.
-			wantErrIn: "",
 		},
 	}
 
@@ -1682,7 +1617,7 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 			}()
 
 			// Seed one header + one block so step 1 has
-			// something to wipe and step 3 has a row to
+			// something to wipe and step 2 has a row to
 			// rebuild from.  Skip for the malformed-value
 			// case, which plants its own bogus header.
 			if c.name != "malformed blockheader value size" {

--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -622,5 +622,138 @@ func (l *ldb) v4(ctx context.Context) error {
 	// Write new version
 	v := make([]byte, 8)
 	binary.BigEndian.PutUint64(v, 4)
+	return l.MetadataPut(ctx, versionKey, v)
+}
+
+// v5 upgrades the database from v4 to v5.
+//
+// Older tbcd versions requested blocks from peers with
+// wire.InvTypeBlock, which under BIP-144 instructs the remote to
+// strip witness data before serialising the reply. The stripped
+// bytes were what ended up on disk in the BlocksDB rawdb. Those
+// bytes cannot be reconstructed locally: the witness never arrived.
+//
+// This upgrade wipes the stored block bodies and marks every known
+// block as missing again, so the normal sync loop re-downloads them
+// with the witness-inclusive getdata that the fix introduced. Every
+// other database in the pool is witness-independent and is left
+// untouched:
+//
+//   - BlockHeadersDB  kept: 80-byte headers, no witness
+//   - HeightHashDB    kept: derived from headers
+//   - TransactionsDB  kept: txid maps over the non-witness tx
+//     serialisation; txid and spent-outpoint records do not
+//     observe the witness
+//   - OutputsDB       kept: utxo set is computed from TxIn and
+//     TxOut, both of which precede the witness section
+//   - KeystonesDB     kept: PoP commitments live in coinbase
+//     OP_RETURNs, witness-independent
+//   - metadata indexer tips kept: re-processing the re-downloaded
+//     blocks would produce identical output, so the tips can stay
+//
+// Changes:
+//   - BlocksDB rawdb: wipe both index and data files, then reopen
+//     to an empty state ready to receive blocks with witness.
+//   - BlocksMissingDB: wipe, then repopulate from every row in
+//     BlockHeadersDB. The next BlocksMissing call the sync loop
+//     makes returns the full set for download.
+//
+// First start after the upgrade triggers a full re-download of the
+// chain's block bodies. BlockByHash and TxById return NotFound for
+// any block that has not yet been re-fetched during that window.
+func (l *ldb) v5(ctx context.Context) error {
+	log.Tracef("v5")
+	defer log.Tracef("v5 exit")
+
+	log.Infof("Upgrading database from v4 to v5: " +
+		"wiping stripped block bodies and rebuilding blocksmissing")
+
+	// 1. Wipe the BlocksDB rawdb.  Close the handle, remove the
+	// on-disk directory tree, reopen to recreate an empty rawdb.
+	// rawdb.Open MkdirAlls the data dir and reopens leveldb for
+	// the index, so a single os.RemoveAll of the rawdb home is
+	// enough to clear both index and data sides at once.
+	bdb, ok := l.rawPool[level.BlocksDB]
+	if !ok || bdb == nil {
+		return fmt.Errorf("rawdb not found: %v", level.BlocksDB)
+	}
+	if err := bdb.Close(); err != nil {
+		return fmt.Errorf("close blocks rawdb: %w", err)
+	}
+	blocksHome := filepath.Join(l.cfg.Home, level.BlocksDB)
+	if err := os.RemoveAll(blocksHome); err != nil {
+		return fmt.Errorf("remove blocks rawdb tree: %w", err)
+	}
+	if err := bdb.Open(); err != nil {
+		return fmt.Errorf("reopen blocks rawdb: %w", err)
+	}
+
+	// 2. Clear BlocksMissingDB.  Iterate and batch-delete rather
+	// than removing the leveldb files; the pool still holds the
+	// open handle and we want it to stay usable in step 3.
+	bmDB, ok := l.pool[level.BlocksMissingDB]
+	if !ok || bmDB == nil {
+		return fmt.Errorf("db not found: %v", level.BlocksMissingDB)
+	}
+	clearBatch := new(leveldb.Batch)
+	clearIt := bmDB.NewIterator(nil, nil)
+	for clearIt.Next() {
+		// Copy the key because the iterator reuses its buffer
+		// across Next calls; leveldb.Batch stores a reference
+		// until Write.
+		k := append([]byte(nil), clearIt.Key()...)
+		clearBatch.Delete(k)
+	}
+	clearIt.Release()
+	if err := clearIt.Error(); err != nil {
+		return fmt.Errorf("blocksmissing iterator: %w", err)
+	}
+	if err := bmDB.Write(clearBatch, nil); err != nil {
+		return fmt.Errorf("blocksmissing clear: %w", err)
+	}
+
+	// 3. Repopulate BlocksMissingDB from BlockHeadersDB.  For
+	// every header row (key=hash[32], value starts with height
+	// in 8 BE bytes), insert a heightHashToKey entry exactly as
+	// BlockHeadersInsert would on first receipt.  BlocksMissing
+	// picks these up in ascending height order.
+	bhsDB, ok := l.pool[level.BlockHeadersDB]
+	if !ok || bhsDB == nil {
+		return fmt.Errorf("db not found: %v", level.BlockHeadersDB)
+	}
+	bmBatch := new(leveldb.Batch)
+	var records int
+	it := bhsDB.NewIterator(nil, nil)
+	for it.Next() {
+		key := it.Key()
+		val := it.Value()
+		// BlockHeadersDB also stores a canonical-tip sentinel
+		// under a non-hash key (bhsCanonicalTipKey); skip any
+		// row whose key is not a 32-byte hash.
+		if len(key) != chainhash.HashSize {
+			continue
+		}
+		if len(val) != blockheaderSize {
+			// Defensive: reject malformed rows rather than
+			// insert bogus entries into blocksmissing.
+			return fmt.Errorf("blockheader value size: got %v want %v",
+				len(val), blockheaderSize)
+		}
+		height := binary.BigEndian.Uint64(val[0:8])
+		bmBatch.Put(heightHashToKey(height, key), []byte{})
+		records++
+	}
+	it.Release()
+	if err := it.Error(); err != nil {
+		return fmt.Errorf("blockheaders iterator: %w", err)
+	}
+	if err := bmDB.Write(bmBatch, nil); err != nil {
+		return fmt.Errorf("blocksmissing repopulate: %w", err)
+	}
+	log.Infof("v5: marked %v blocks for re-download", records)
+
+	// 4. Bump version.
+	v := make([]byte, 8)
+	binary.BigEndian.PutUint64(v, 5)
 	return l.MetadataPut(ctx, versionKey, v)
 }

--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -668,51 +668,36 @@ func (l *ldb) v5(ctx context.Context) error {
 	log.Infof("Upgrading database from v4 to v5: " +
 		"wiping stripped block bodies and rebuilding blocksmissing")
 
-	// 1. Wipe the BlocksDB rawdb.  Close the handle, remove the
-	// on-disk directory tree, reopen to recreate an empty rawdb.
-	// rawdb.Open MkdirAlls the data dir and reopens leveldb for
-	// the index, so a single os.RemoveAll of the rawdb home is
-	// enough to clear both index and data sides at once.
-	bdb, ok := l.rawPool[level.BlocksDB]
-	if !ok || bdb == nil {
-		return fmt.Errorf("rawdb not found: %v", level.BlocksDB)
+	// 1. Close all database handles, delete the BlocksDB rawdb
+	// and BlocksMissingDB trees, then reopen everything via
+	// level.New.  Tables whose directories still exist come
+	// back with their data; deleted directories are recreated
+	// empty.  This avoids iterating BlocksMissing to batch-
+	// delete every key and keeps both the Database and ldb
+	// pools pointing at the same handles.
+	if err := l.Close(); err != nil {
+		return fmt.Errorf("close database: %w", err)
 	}
-	if err := bdb.Close(); err != nil {
-		return fmt.Errorf("close blocks rawdb: %w", err)
+	for _, sub := range []string{level.BlocksDB, level.BlocksMissingDB} {
+		target := filepath.Join(l.cfg.Home, sub)
+		rel, err := filepath.Rel(l.cfg.Home, target)
+		if err != nil || rel == "." || rel == ".." || filepath.IsAbs(rel) {
+			return fmt.Errorf("refusing to remove %v: not a child of %v",
+				target, l.cfg.Home)
+		}
+		if err := os.RemoveAll(target); err != nil {
+			return fmt.Errorf("remove %v: %w", sub, err)
+		}
 	}
-	blocksHome := filepath.Join(l.cfg.Home, level.BlocksDB)
-	if err := os.RemoveAll(blocksHome); err != nil {
-		return fmt.Errorf("remove blocks rawdb tree: %w", err)
+	ld, err := level.New(ctx, level.NewDefaultConfig(l.cfg.Home))
+	if err != nil {
+		return fmt.Errorf("reopen database: %w", err)
 	}
-	if err := bdb.Open(); err != nil {
-		return fmt.Errorf("reopen blocks rawdb: %w", err)
-	}
+	l.Database = ld
+	l.pool = ld.DB()
+	l.rawPool = ld.RawDB()
 
-	// 2. Clear BlocksMissingDB.  Iterate and batch-delete rather
-	// than removing the leveldb files; the pool still holds the
-	// open handle and we want it to stay usable in step 3.
-	bmDB, ok := l.pool[level.BlocksMissingDB]
-	if !ok || bmDB == nil {
-		return fmt.Errorf("db not found: %v", level.BlocksMissingDB)
-	}
-	clearBatch := new(leveldb.Batch)
-	clearIt := bmDB.NewIterator(nil, nil)
-	for clearIt.Next() {
-		// Copy the key because the iterator reuses its buffer
-		// across Next calls; leveldb.Batch stores a reference
-		// until Write.
-		k := append([]byte(nil), clearIt.Key()...)
-		clearBatch.Delete(k)
-	}
-	clearIt.Release()
-	if err := clearIt.Error(); err != nil {
-		return fmt.Errorf("blocksmissing iterator: %w", err)
-	}
-	if err := bmDB.Write(clearBatch, nil); err != nil {
-		return fmt.Errorf("blocksmissing clear: %w", err)
-	}
-
-	// 3. Repopulate BlocksMissingDB from BlockHeadersDB.  For
+	// 2. Repopulate BlocksMissingDB from BlockHeadersDB.  For
 	// every header row (key=hash[32], value starts with height
 	// in 8 BE bytes), insert a heightHashToKey entry exactly as
 	// BlockHeadersInsert would on first receipt.  BlocksMissing
@@ -720,6 +705,10 @@ func (l *ldb) v5(ctx context.Context) error {
 	bhsDB, ok := l.pool[level.BlockHeadersDB]
 	if !ok || bhsDB == nil {
 		return fmt.Errorf("db not found: %v", level.BlockHeadersDB)
+	}
+	bmDB, ok := l.pool[level.BlocksMissingDB]
+	if !ok || bmDB == nil {
+		return fmt.Errorf("db not found: %v", level.BlocksMissingDB)
 	}
 	bmBatch := new(leveldb.Batch)
 	var records int
@@ -752,7 +741,7 @@ func (l *ldb) v5(ctx context.Context) error {
 	}
 	log.Infof("v5: marked %v blocks for re-download", records)
 
-	// 4. Bump version.
+	// 3. Bump version.
 	v := make([]byte, 8)
 	binary.BigEndian.PutUint64(v, 5)
 	return l.MetadataPut(ctx, versionKey, v)

--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -675,6 +675,7 @@ func (l *ldb) v5(ctx context.Context) error {
 	// empty.  This avoids iterating BlocksMissing to batch-
 	// delete every key and keeps both the Database and ldb
 	// pools pointing at the same handles.
+	lcfg := l.Config()
 	if err := l.Close(); err != nil {
 		return fmt.Errorf("close database: %w", err)
 	}
@@ -692,7 +693,7 @@ func (l *ldb) v5(ctx context.Context) error {
 			return fmt.Errorf("remove %v: %w", sub, err)
 		}
 	}
-	ld, err := level.New(ctx, level.NewDefaultConfig(l.cfg.Home))
+	ld, err := level.New(ctx, &lcfg)
 	if err != nil {
 		return fmt.Errorf("reopen database: %w", err)
 	}

--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -678,11 +679,14 @@ func (l *ldb) v5(ctx context.Context) error {
 		return fmt.Errorf("close database: %w", err)
 	}
 	for _, sub := range []string{level.BlocksDB, level.BlocksMissingDB} {
-		target := filepath.Join(l.cfg.Home, sub)
-		rel, err := filepath.Rel(l.cfg.Home, target)
-		if err != nil || rel == "." || rel == ".." || filepath.IsAbs(rel) {
-			return fmt.Errorf("refusing to remove %v: not a child of %v",
-				target, l.cfg.Home)
+		home := filepath.Clean(l.cfg.Home)
+		target := filepath.Join(home, sub)
+		if !strings.HasPrefix(target, home+string(os.PathSeparator)) {
+			return fmt.Errorf("refusing to remove %q: not a child of %q",
+				target, home)
+		}
+		if fi, err := os.Lstat(target); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to remove %q: is a symlink", target)
 		}
 		if err := os.RemoveAll(target); err != nil {
 			return fmt.Errorf("remove %v: %w", sub, err)

--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -665,8 +665,7 @@ func (l *ldb) v5(ctx context.Context) error {
 	log.Tracef("v5")
 	defer log.Tracef("v5 exit")
 
-	log.Infof("Upgrading database from v4 to v5: " +
-		"wiping stripped block bodies and rebuilding blocksmissing")
+	log.Infof("Upgrading database from v4 to v5")
 
 	// 1. Close all database handles, delete the BlocksDB rawdb
 	// and BlocksMissingDB trees, then reopen everything via

--- a/service/tbc/peer/peer.go
+++ b/service/tbc/peer/peer.go
@@ -293,7 +293,12 @@ func (p *Peer) onInvHandler(ctx context.Context, msg wire.Message) error {
 	}
 
 	for _, v := range m.InvList {
-		id := tag(wire.CmdInv+"-"+v.Type.String(), v.Hash)
+		// Registrations in p.pending use the base (non-witness)
+		// InvType string so that a getdata asking for
+		// InvTypeWitnessBlock and the peer echoing that same
+		// type in a subsequent inv or notfound still pair up
+		// with the same pending key.  See GetData.
+		id := tag(wire.CmdInv+"-"+(v.Type&^wire.InvWitnessFlag).String(), v.Hash)
 		log.Tracef("onInvHandler: %v", id)
 		replyC, ok := p.pending[id]
 		if !ok {
@@ -326,7 +331,10 @@ func (p *Peer) onNotFoundHandler(ctx context.Context, msg wire.Message) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	for _, v := range m.InvList {
-		id := tag(wire.CmdInv+"-"+v.Type.String(), v.Hash)
+		// See onInvHandler: canonicalise to base InvType so a
+		// notfound echoing a witness-flagged type still lands
+		// on the pending registration made by GetData.
+		id := tag(wire.CmdInv+"-"+(v.Type&^wire.InvWitnessFlag).String(), v.Hash)
 		log.Debugf("onInvHandler: %v", id)
 		replyC, ok := p.pending[id]
 		if !ok {
@@ -488,8 +496,19 @@ func (p *Peer) GetData(ctx context.Context, vector *wire.InvVect) (any, error) {
 		return nil, err
 	}
 
-	// Send message to peer and receive response
-	id := tag(wire.CmdInv+"-"+vector.Type.String(), vector.Hash)
+	// Send message to peer and receive response.
+	//
+	// The pending-reply map is keyed by the base (non-witness)
+	// InvType string so that GetData(InvTypeWitnessBlock, h) and
+	// GetData(InvTypeBlock, h) both pair with a MsgBlock reply
+	// delivered by onBlockHandler — which has no way to tell
+	// from the reply alone which variant was requested: the
+	// wire command is CmdBlock either way.  Stripping
+	// InvWitnessFlag here keeps request and reply keyed the
+	// same way regardless of whether the caller asked for
+	// witness-inclusive serialisation.
+	baseType := vector.Type &^ wire.InvWitnessFlag
+	id := tag(wire.CmdInv+"-"+baseType.String(), vector.Hash)
 	msg, err := p.call(ctx, id, gd)
 	if err != nil {
 		return nil, err
@@ -532,7 +551,7 @@ func (p *Peer) GetBlock(ctx context.Context, blockHash *chainhash.Hash) (*wire.M
 	}
 
 	// Retrieve block.
-	blk, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeBlock, blockHash))
+	blk, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessBlock, blockHash))
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +567,7 @@ func (p *Peer) GetTx(ctx context.Context, txID *chainhash.Hash) (*wire.MsgTx, er
 	log.Tracef("GetTx %v", txID)
 	defer log.Tracef("GetTx %v exit", txID)
 
-	tx, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeTx, txID))
+	tx, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessTx, txID))
 	if err != nil {
 		return nil, err
 	}

--- a/service/tbc/peer/peer_witness_test.go
+++ b/service/tbc/peer/peer_witness_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package peer
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+
+	"github.com/hemilabs/heminetwork/v2/service/tbc/peer/rawpeer"
+)
+
+// newLoopbackPeer builds a Peer whose transport is the client end
+// of a net.Pipe.  The server end is returned so the caller can
+// read/write wire messages directly.  readLoop is started; callers
+// must cancel ctx to tear down.
+func newLoopbackPeer(t *testing.T, ctx context.Context) (*Peer, *rawpeer.RawPeer) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	clientRP, err := rawpeer.NewFromConn(clientConn, wire.TestNet3, wire.AddrV2Version, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverRP, err := rawpeer.NewFromConn(serverConn, wire.TestNet3, wire.AddrV2Version, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Peer{
+		wg:          new(sync.WaitGroup),
+		p:           clientRP,
+		chainParams: &chaincfg.TestNet3Params,
+		handlers:    make(map[string]func(context.Context, wire.Message) error, 16),
+		pending:     make(map[string]chan wire.Message, 64),
+	}
+	// Wire up the same default handlers New() installs.
+	p.setHandler(wire.CmdBlock, p.onBlockHandler)
+	p.setHandler(wire.CmdTx, p.onTxHandler)
+	p.setHandler(wire.CmdInv, p.onInvHandler)
+	p.setHandler(wire.CmdNotFound, p.onNotFoundHandler)
+
+	p.wg.Add(1)
+	go p.readLoop(ctx)
+
+	return p, serverRP
+}
+
+// TestGetDataWitnessBlock verifies that GetData with
+// InvTypeWitnessBlock (a) sends the witness InvType on the wire
+// and (b) correctly pairs the reply via the base-form pending
+// key so onBlockHandler can deliver it.
+func TestGetDataWitnessBlock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	p, srv := newLoopbackPeer(t, ctx)
+
+	// Build block first, derive its hash, then request that hash.
+	prev := chainhash.DoubleHashH([]byte("prev"))
+	bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
+	bh.Timestamp = time.Unix(0, 0)
+	block := wire.NewMsgBlock(bh)
+	blockHash := block.Header.BlockHash()
+
+	type result struct {
+		msg any
+		err error
+	}
+	resultC := make(chan result, 1)
+	go func() {
+		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessBlock, &blockHash))
+		resultC <- result{msg, err}
+	}()
+
+	// Server side: read the outbound MsgGetData.
+	msg, _, err := srv.Read(2 * time.Second)
+	if err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	gd, ok := msg.(*wire.MsgGetData)
+	if !ok {
+		t.Fatalf("expected MsgGetData, got %T", msg)
+	}
+	if len(gd.InvList) != 1 {
+		t.Fatalf("expected 1 inv, got %d", len(gd.InvList))
+	}
+	// The wire must carry the witness type — this is the fix.
+	if gd.InvList[0].Type != wire.InvTypeWitnessBlock {
+		t.Fatalf("expected InvTypeWitnessBlock on wire, got %v", gd.InvList[0].Type)
+	}
+
+	// Reply with the block.
+	if err := srv.Write(2*time.Second, block); err != nil {
+		t.Fatalf("server write block: %v", err)
+	}
+
+	r := <-resultC
+	if r.err != nil {
+		t.Fatalf("GetData: %v", r.err)
+	}
+	if _, ok := r.msg.(*wire.MsgBlock); !ok {
+		t.Fatalf("expected *wire.MsgBlock, got %T", r.msg)
+	}
+}
+
+// TestGetDataWitnessTx does the same for InvTypeWitnessTx.
+func TestGetDataWitnessTx(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	p, srv := newLoopbackPeer(t, ctx)
+
+	// Build tx first, derive its hash, then request that hash.
+	tx := wire.NewMsgTx(2)
+	prevHash := chainhash.DoubleHashH([]byte("prev-outpoint"))
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x6a}})
+	txHash := tx.TxHash()
+
+	type result struct {
+		msg any
+		err error
+	}
+	resultC := make(chan result, 1)
+	go func() {
+		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessTx, &txHash))
+		resultC <- result{msg, err}
+	}()
+
+	// Read the outbound MsgGetData.
+	msg, _, err := srv.Read(2 * time.Second)
+	if err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	gd, ok := msg.(*wire.MsgGetData)
+	if !ok {
+		t.Fatalf("expected MsgGetData, got %T", msg)
+	}
+	if gd.InvList[0].Type != wire.InvTypeWitnessTx {
+		t.Fatalf("expected InvTypeWitnessTx on wire, got %v", gd.InvList[0].Type)
+	}
+
+	// Reply with the tx.
+	if err := srv.Write(2*time.Second, tx); err != nil {
+		t.Fatalf("server write tx: %v", err)
+	}
+
+	r := <-resultC
+	if r.err != nil {
+		t.Fatalf("GetData: %v", r.err)
+	}
+	if _, ok := r.msg.(*wire.MsgTx); !ok {
+		t.Fatalf("expected *wire.MsgTx, got %T", r.msg)
+	}
+}
+
+// TestGetDataBaseBlockStillWorks confirms the base (non-witness)
+// InvType still pairs correctly — the strip is a no-op for
+// non-witness requests.
+func TestGetDataBaseBlockStillWorks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	p, srv := newLoopbackPeer(t, ctx)
+
+	prev := chainhash.DoubleHashH([]byte("base-prev"))
+	bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
+	bh.Timestamp = time.Unix(0, 0)
+	block := wire.NewMsgBlock(bh)
+	blockHash := block.Header.BlockHash()
+
+	type result struct {
+		msg any
+		err error
+	}
+	resultC := make(chan result, 1)
+	go func() {
+		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeBlock, &blockHash))
+		resultC <- result{msg, err}
+	}()
+
+	msg, _, err := srv.Read(2 * time.Second)
+	if err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	gd := msg.(*wire.MsgGetData)
+	if gd.InvList[0].Type != wire.InvTypeBlock {
+		t.Fatalf("expected InvTypeBlock on wire, got %v", gd.InvList[0].Type)
+	}
+
+	if err := srv.Write(2*time.Second, block); err != nil {
+		t.Fatalf("server write: %v", err)
+	}
+
+	r := <-resultC
+	if r.err != nil {
+		t.Fatalf("GetData: %v", r.err)
+	}
+}
+
+// TestGetDataNotFound confirms MsgNotFound replies are delivered
+// through the pending map correctly for witness-variant requests.
+func TestGetDataNotFound(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	p, srv := newLoopbackPeer(t, ctx)
+
+	hash := chainhash.DoubleHashH([]byte("missing-block"))
+
+	type result struct {
+		msg any
+		err error
+	}
+	resultC := make(chan result, 1)
+	go func() {
+		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessBlock, &hash))
+		resultC <- result{msg, err}
+	}()
+
+	// Read the outbound getdata.
+	if _, _, err := srv.Read(2 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reply with NotFound.
+	nf := wire.NewMsgNotFound()
+	if err := nf.AddInvVect(wire.NewInvVect(wire.InvTypeBlock, &hash)); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Write(2*time.Second, nf); err != nil {
+		t.Fatalf("server write notfound: %v", err)
+	}
+
+	r := <-resultC
+	if r.err != nil {
+		t.Fatalf("GetData: %v", r.err)
+	}
+	if _, ok := r.msg.(*wire.MsgNotFound); !ok {
+		t.Fatalf("expected *wire.MsgNotFound, got %T", r.msg)
+	}
+}

--- a/service/tbc/peer/peer_witness_test.go
+++ b/service/tbc/peer/peer_witness_test.go
@@ -58,6 +58,18 @@ func newLoopbackPeer(t *testing.T, ctx context.Context) (*Peer, *rawpeer.RawPeer
 	return p, serverRP
 }
 
+// srvReply writes a reply after a brief yield so call() in the
+// client goroutine enters its select before the handler's
+// non-blocking send fires.  net.Pipe is synchronous, so without
+// this the reply can arrive before the caller is ready.
+func srvReply(t *testing.T, srv *rawpeer.RawPeer, msg wire.Message) {
+	t.Helper()
+	time.Sleep(time.Millisecond)
+	if err := srv.Write(2*time.Second, msg); err != nil {
+		t.Fatalf("server write: %v", err)
+	}
+}
+
 // TestGetDataWitnessBlock verifies that GetData with
 // InvTypeWitnessBlock (a) sends the witness InvType on the wire
 // and (b) correctly pairs the reply via the base-form pending
@@ -103,9 +115,7 @@ func TestGetDataWitnessBlock(t *testing.T) {
 	}
 
 	// Reply with the block.
-	if err := srv.Write(2*time.Second, block); err != nil {
-		t.Fatalf("server write block: %v", err)
-	}
+	srvReply(t, srv, block)
 
 	r := <-resultC
 	if r.err != nil {
@@ -156,9 +166,7 @@ func TestGetDataWitnessTx(t *testing.T) {
 	}
 
 	// Reply with the tx.
-	if err := srv.Write(2*time.Second, tx); err != nil {
-		t.Fatalf("server write tx: %v", err)
-	}
+	srvReply(t, srv, tx)
 
 	r := <-resultC
 	if r.err != nil {
@@ -203,9 +211,7 @@ func TestGetDataBaseBlockStillWorks(t *testing.T) {
 		t.Fatalf("expected InvTypeBlock on wire, got %v", gd.InvList[0].Type)
 	}
 
-	if err := srv.Write(2*time.Second, block); err != nil {
-		t.Fatalf("server write: %v", err)
-	}
+	srvReply(t, srv, block)
 
 	r := <-resultC
 	if r.err != nil {
@@ -243,9 +249,7 @@ func TestGetDataNotFound(t *testing.T) {
 	if err := nf.AddInvVect(wire.NewInvVect(wire.InvTypeBlock, &hash)); err != nil {
 		t.Fatal(err)
 	}
-	if err := srv.Write(2*time.Second, nf); err != nil {
-		t.Fatalf("server write notfound: %v", err)
-	}
+	srvReply(t, srv, nf)
 
 	r := <-resultC
 	if r.err != nil {
@@ -253,5 +257,131 @@ func TestGetDataNotFound(t *testing.T) {
 	}
 	if _, ok := r.msg.(*wire.MsgNotFound); !ok {
 		t.Fatalf("expected *wire.MsgNotFound, got %T", r.msg)
+	}
+}
+
+// TestGetBlockWitness exercises the GetBlock wrapper end-to-end:
+// GetHeaders exchange followed by GetData with InvTypeWitnessBlock.
+func TestGetBlockWitness(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	p, srv := newLoopbackPeer(t, ctx)
+	// Also register the headers handler.
+	p.setHandler(wire.CmdHeaders, p.onHeadersHandler)
+
+	// Build a block.  GetBlock checks that
+	// headers.Headers[0].PrevBlock == blockHash, so we use the
+	// block's own hash as the "requested" hash and set up the
+	// header reply's PrevBlock to match.
+	prev := chainhash.DoubleHashH([]byte("getblock-prev"))
+	bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
+	bh.Timestamp = time.Unix(0, 0)
+	block := wire.NewMsgBlock(bh)
+	blockHash := block.Header.BlockHash()
+
+	// The header we reply with must have PrevBlock == blockHash.
+	replyHdr := wire.NewBlockHeader(0, &blockHash, &chainhash.Hash{}, 0, 1)
+	replyHdr.Timestamp = time.Unix(1, 0)
+
+	type result struct {
+		blk *wire.MsgBlock
+		err error
+	}
+	resultC := make(chan result, 1)
+	go func() {
+		blk, err := p.GetBlock(ctx, &blockHash)
+		resultC <- result{blk, err}
+	}()
+
+	// Step 1: server reads MsgGetHeaders, replies with one header.
+	msg, _, err := srv.Read(2 * time.Second)
+	if err != nil {
+		t.Fatalf("read getheaders: %v", err)
+	}
+	if _, ok := msg.(*wire.MsgGetHeaders); !ok {
+		t.Fatalf("expected MsgGetHeaders, got %T", msg)
+	}
+	headers := wire.NewMsgHeaders()
+	if err := headers.AddBlockHeader(replyHdr); err != nil {
+		t.Fatal(err)
+	}
+	srvReply(t, srv, headers)
+
+	// Step 2: server reads MsgGetData, verify witness type.
+	msg, _, err = srv.Read(2 * time.Second)
+	if err != nil {
+		t.Fatalf("read getdata: %v", err)
+	}
+	gd, ok := msg.(*wire.MsgGetData)
+	if !ok {
+		t.Fatalf("expected MsgGetData, got %T", msg)
+	}
+	if gd.InvList[0].Type != wire.InvTypeWitnessBlock {
+		t.Fatalf("GetBlock should request InvTypeWitnessBlock, got %v",
+			gd.InvList[0].Type)
+	}
+
+	// Reply with the block.
+	srvReply(t, srv, block)
+
+	r := <-resultC
+	if r.err != nil {
+		t.Fatalf("GetBlock: %v", r.err)
+	}
+	got := r.blk.Header.BlockHash()
+	if !got.IsEqual(&blockHash) {
+		t.Fatalf("block hash mismatch: %v != %v", got, blockHash)
+	}
+}
+
+// TestGetTxWitness exercises the GetTx wrapper, confirming it
+// sends InvTypeWitnessTx on the wire.
+func TestGetTxWitness(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	p, srv := newLoopbackPeer(t, ctx)
+
+	tx := wire.NewMsgTx(2)
+	prevHash := chainhash.DoubleHashH([]byte("gettx-prev"))
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x6a}})
+	txHash := tx.TxHash()
+
+	type result struct {
+		tx  *wire.MsgTx
+		err error
+	}
+	resultC := make(chan result, 1)
+	go func() {
+		got, err := p.GetTx(ctx, &txHash)
+		resultC <- result{got, err}
+	}()
+
+	msg, _, err := srv.Read(2 * time.Second)
+	if err != nil {
+		t.Fatalf("read getdata: %v", err)
+	}
+	gd, ok := msg.(*wire.MsgGetData)
+	if !ok {
+		t.Fatalf("expected MsgGetData, got %T", msg)
+	}
+	if gd.InvList[0].Type != wire.InvTypeWitnessTx {
+		t.Fatalf("GetTx should request InvTypeWitnessTx, got %v",
+			gd.InvList[0].Type)
+	}
+
+	srvReply(t, srv, tx)
+
+	r := <-resultC
+	if r.err != nil {
+		t.Fatalf("GetTx: %v", r.err)
+	}
+	got := r.tx.TxHash()
+	if !got.IsEqual(&txHash) {
+		t.Fatalf("tx hash mismatch")
 	}
 }

--- a/service/tbc/peer/peer_witness_test.go
+++ b/service/tbc/peer/peer_witness_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -58,14 +59,12 @@ func newLoopbackPeer(t *testing.T, ctx context.Context) (*Peer, *rawpeer.RawPeer
 	return p, serverRP
 }
 
-// srvReply writes a reply after a brief yield so call() in the
-// client goroutine enters its select before the handler's
-// non-blocking send fires.  net.Pipe is synchronous, so without
-// this the reply can arrive before the caller is ready.
+// srvReply waits for all goroutines in the synctest bubble to
+// block (ensuring call() is in its select), then writes the reply.
 func srvReply(t *testing.T, srv *rawpeer.RawPeer, msg wire.Message) {
 	t.Helper()
-	time.Sleep(time.Millisecond)
-	if err := srv.Write(2*time.Second, msg); err != nil {
+	synctest.Wait()
+	if err := srv.Write(0, msg); err != nil {
 		t.Fatalf("server write: %v", err)
 	}
 }
@@ -75,313 +74,325 @@ func srvReply(t *testing.T, srv *rawpeer.RawPeer, msg wire.Message) {
 // and (b) correctly pairs the reply via the base-form pending
 // key so onBlockHandler can deliver it.
 func TestGetDataWitnessBlock(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(t, ctx)
 
-	// Build block first, derive its hash, then request that hash.
-	prev := chainhash.DoubleHashH([]byte("prev"))
-	bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
-	bh.Timestamp = time.Unix(0, 0)
-	block := wire.NewMsgBlock(bh)
-	blockHash := block.Header.BlockHash()
+		// Build block first, derive its hash, then request that hash.
+		prev := chainhash.DoubleHashH([]byte("prev"))
+		bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
+		bh.Timestamp = time.Unix(0, 0)
+		block := wire.NewMsgBlock(bh)
+		blockHash := block.Header.BlockHash()
 
-	type result struct {
-		msg any
-		err error
-	}
-	resultC := make(chan result, 1)
-	go func() {
-		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessBlock, &blockHash))
-		resultC <- result{msg, err}
-	}()
+		type result struct {
+			msg any
+			err error
+		}
+		resultC := make(chan result, 1)
+		go func() {
+			msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessBlock, &blockHash))
+			resultC <- result{msg, err}
+		}()
 
-	// Server side: read the outbound MsgGetData.
-	msg, _, err := srv.Read(2 * time.Second)
-	if err != nil {
-		t.Fatalf("server read: %v", err)
-	}
-	gd, ok := msg.(*wire.MsgGetData)
-	if !ok {
-		t.Fatalf("expected MsgGetData, got %T", msg)
-	}
-	if len(gd.InvList) != 1 {
-		t.Fatalf("expected 1 inv, got %d", len(gd.InvList))
-	}
-	// The wire must carry the witness type — this is the fix.
-	if gd.InvList[0].Type != wire.InvTypeWitnessBlock {
-		t.Fatalf("expected InvTypeWitnessBlock on wire, got %v", gd.InvList[0].Type)
-	}
+		// Server side: read the outbound MsgGetData.
+		msg, _, err := srv.Read(0)
+		if err != nil {
+			t.Fatalf("server read: %v", err)
+		}
+		gd, ok := msg.(*wire.MsgGetData)
+		if !ok {
+			t.Fatalf("expected MsgGetData, got %T", msg)
+		}
+		if len(gd.InvList) != 1 {
+			t.Fatalf("expected 1 inv, got %d", len(gd.InvList))
+		}
+		// The wire must carry the witness type — this is the fix.
+		if gd.InvList[0].Type != wire.InvTypeWitnessBlock {
+			t.Fatalf("expected InvTypeWitnessBlock on wire, got %v", gd.InvList[0].Type)
+		}
 
-	// Reply with the block.
-	srvReply(t, srv, block)
+		// Reply with the block.
+		srvReply(t, srv, block)
 
-	r := <-resultC
-	if r.err != nil {
-		t.Fatalf("GetData: %v", r.err)
-	}
-	if _, ok := r.msg.(*wire.MsgBlock); !ok {
-		t.Fatalf("expected *wire.MsgBlock, got %T", r.msg)
-	}
+		r := <-resultC
+		if r.err != nil {
+			t.Fatalf("GetData: %v", r.err)
+		}
+		if _, ok := r.msg.(*wire.MsgBlock); !ok {
+			t.Fatalf("expected *wire.MsgBlock, got %T", r.msg)
+		}
+	})
 }
 
 // TestGetDataWitnessTx does the same for InvTypeWitnessTx.
 func TestGetDataWitnessTx(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(t, ctx)
 
-	// Build tx first, derive its hash, then request that hash.
-	tx := wire.NewMsgTx(2)
-	prevHash := chainhash.DoubleHashH([]byte("prev-outpoint"))
-	tx.AddTxIn(&wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+		// Build tx first, derive its hash, then request that hash.
+		tx := wire.NewMsgTx(2)
+		prevHash := chainhash.DoubleHashH([]byte("prev-outpoint"))
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+		})
+		tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x6a}})
+		txHash := tx.TxHash()
+
+		type result struct {
+			msg any
+			err error
+		}
+		resultC := make(chan result, 1)
+		go func() {
+			msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessTx, &txHash))
+			resultC <- result{msg, err}
+		}()
+
+		// Read the outbound MsgGetData.
+		msg, _, err := srv.Read(0)
+		if err != nil {
+			t.Fatalf("server read: %v", err)
+		}
+		gd, ok := msg.(*wire.MsgGetData)
+		if !ok {
+			t.Fatalf("expected MsgGetData, got %T", msg)
+		}
+		if gd.InvList[0].Type != wire.InvTypeWitnessTx {
+			t.Fatalf("expected InvTypeWitnessTx on wire, got %v", gd.InvList[0].Type)
+		}
+
+		// Reply with the tx.
+		srvReply(t, srv, tx)
+
+		r := <-resultC
+		if r.err != nil {
+			t.Fatalf("GetData: %v", r.err)
+		}
+		if _, ok := r.msg.(*wire.MsgTx); !ok {
+			t.Fatalf("expected *wire.MsgTx, got %T", r.msg)
+		}
 	})
-	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x6a}})
-	txHash := tx.TxHash()
-
-	type result struct {
-		msg any
-		err error
-	}
-	resultC := make(chan result, 1)
-	go func() {
-		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessTx, &txHash))
-		resultC <- result{msg, err}
-	}()
-
-	// Read the outbound MsgGetData.
-	msg, _, err := srv.Read(2 * time.Second)
-	if err != nil {
-		t.Fatalf("server read: %v", err)
-	}
-	gd, ok := msg.(*wire.MsgGetData)
-	if !ok {
-		t.Fatalf("expected MsgGetData, got %T", msg)
-	}
-	if gd.InvList[0].Type != wire.InvTypeWitnessTx {
-		t.Fatalf("expected InvTypeWitnessTx on wire, got %v", gd.InvList[0].Type)
-	}
-
-	// Reply with the tx.
-	srvReply(t, srv, tx)
-
-	r := <-resultC
-	if r.err != nil {
-		t.Fatalf("GetData: %v", r.err)
-	}
-	if _, ok := r.msg.(*wire.MsgTx); !ok {
-		t.Fatalf("expected *wire.MsgTx, got %T", r.msg)
-	}
 }
 
 // TestGetDataBaseBlockStillWorks confirms the base (non-witness)
 // InvType still pairs correctly — the strip is a no-op for
 // non-witness requests.
 func TestGetDataBaseBlockStillWorks(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(t, ctx)
 
-	prev := chainhash.DoubleHashH([]byte("base-prev"))
-	bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
-	bh.Timestamp = time.Unix(0, 0)
-	block := wire.NewMsgBlock(bh)
-	blockHash := block.Header.BlockHash()
+		prev := chainhash.DoubleHashH([]byte("base-prev"))
+		bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
+		bh.Timestamp = time.Unix(0, 0)
+		block := wire.NewMsgBlock(bh)
+		blockHash := block.Header.BlockHash()
 
-	type result struct {
-		msg any
-		err error
-	}
-	resultC := make(chan result, 1)
-	go func() {
-		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeBlock, &blockHash))
-		resultC <- result{msg, err}
-	}()
+		type result struct {
+			msg any
+			err error
+		}
+		resultC := make(chan result, 1)
+		go func() {
+			msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeBlock, &blockHash))
+			resultC <- result{msg, err}
+		}()
 
-	msg, _, err := srv.Read(2 * time.Second)
-	if err != nil {
-		t.Fatalf("server read: %v", err)
-	}
-	gd := msg.(*wire.MsgGetData)
-	if gd.InvList[0].Type != wire.InvTypeBlock {
-		t.Fatalf("expected InvTypeBlock on wire, got %v", gd.InvList[0].Type)
-	}
+		msg, _, err := srv.Read(0)
+		if err != nil {
+			t.Fatalf("server read: %v", err)
+		}
+		gd := msg.(*wire.MsgGetData)
+		if gd.InvList[0].Type != wire.InvTypeBlock {
+			t.Fatalf("expected InvTypeBlock on wire, got %v", gd.InvList[0].Type)
+		}
 
-	srvReply(t, srv, block)
+		srvReply(t, srv, block)
 
-	r := <-resultC
-	if r.err != nil {
-		t.Fatalf("GetData: %v", r.err)
-	}
+		r := <-resultC
+		if r.err != nil {
+			t.Fatalf("GetData: %v", r.err)
+		}
+	})
 }
 
 // TestGetDataNotFound confirms MsgNotFound replies are delivered
 // through the pending map correctly for witness-variant requests.
 func TestGetDataNotFound(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(t, ctx)
 
-	hash := chainhash.DoubleHashH([]byte("missing-block"))
+		hash := chainhash.DoubleHashH([]byte("missing-block"))
 
-	type result struct {
-		msg any
-		err error
-	}
-	resultC := make(chan result, 1)
-	go func() {
-		msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessBlock, &hash))
-		resultC <- result{msg, err}
-	}()
+		type result struct {
+			msg any
+			err error
+		}
+		resultC := make(chan result, 1)
+		go func() {
+			msg, err := p.GetData(ctx, wire.NewInvVect(wire.InvTypeWitnessBlock, &hash))
+			resultC <- result{msg, err}
+		}()
 
-	// Read the outbound getdata.
-	if _, _, err := srv.Read(2 * time.Second); err != nil {
-		t.Fatal(err)
-	}
+		// Read the outbound getdata.
+		if _, _, err := srv.Read(0); err != nil {
+			t.Fatal(err)
+		}
 
-	// Reply with NotFound.
-	nf := wire.NewMsgNotFound()
-	if err := nf.AddInvVect(wire.NewInvVect(wire.InvTypeBlock, &hash)); err != nil {
-		t.Fatal(err)
-	}
-	srvReply(t, srv, nf)
+		// Reply with NotFound.
+		nf := wire.NewMsgNotFound()
+		if err := nf.AddInvVect(wire.NewInvVect(wire.InvTypeBlock, &hash)); err != nil {
+			t.Fatal(err)
+		}
+		srvReply(t, srv, nf)
 
-	r := <-resultC
-	if r.err != nil {
-		t.Fatalf("GetData: %v", r.err)
-	}
-	if _, ok := r.msg.(*wire.MsgNotFound); !ok {
-		t.Fatalf("expected *wire.MsgNotFound, got %T", r.msg)
-	}
+		r := <-resultC
+		if r.err != nil {
+			t.Fatalf("GetData: %v", r.err)
+		}
+		if _, ok := r.msg.(*wire.MsgNotFound); !ok {
+			t.Fatalf("expected *wire.MsgNotFound, got %T", r.msg)
+		}
+	})
 }
 
 // TestGetBlockWitness exercises the GetBlock wrapper end-to-end:
 // GetHeaders exchange followed by GetData with InvTypeWitnessBlock.
 func TestGetBlockWitness(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	p, srv := newLoopbackPeer(t, ctx)
-	// Also register the headers handler.
-	p.setHandler(wire.CmdHeaders, p.onHeadersHandler)
+		p, srv := newLoopbackPeer(t, ctx)
+		// Also register the headers handler.
+		p.setHandler(wire.CmdHeaders, p.onHeadersHandler)
 
-	// Build a block.  GetBlock checks that
-	// headers.Headers[0].PrevBlock == blockHash, so we use the
-	// block's own hash as the "requested" hash and set up the
-	// header reply's PrevBlock to match.
-	prev := chainhash.DoubleHashH([]byte("getblock-prev"))
-	bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
-	bh.Timestamp = time.Unix(0, 0)
-	block := wire.NewMsgBlock(bh)
-	blockHash := block.Header.BlockHash()
+		// Build a block.  GetBlock checks that
+		// headers.Headers[0].PrevBlock == blockHash, so we use the
+		// block's own hash as the "requested" hash and set up the
+		// header reply's PrevBlock to match.
+		prev := chainhash.DoubleHashH([]byte("getblock-prev"))
+		bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
+		bh.Timestamp = time.Unix(0, 0)
+		block := wire.NewMsgBlock(bh)
+		blockHash := block.Header.BlockHash()
 
-	// The header we reply with must have PrevBlock == blockHash.
-	replyHdr := wire.NewBlockHeader(0, &blockHash, &chainhash.Hash{}, 0, 1)
-	replyHdr.Timestamp = time.Unix(1, 0)
+		// The header we reply with must have PrevBlock == blockHash.
+		replyHdr := wire.NewBlockHeader(0, &blockHash, &chainhash.Hash{}, 0, 1)
+		replyHdr.Timestamp = time.Unix(1, 0)
 
-	type result struct {
-		blk *wire.MsgBlock
-		err error
-	}
-	resultC := make(chan result, 1)
-	go func() {
-		blk, err := p.GetBlock(ctx, &blockHash)
-		resultC <- result{blk, err}
-	}()
+		type result struct {
+			blk *wire.MsgBlock
+			err error
+		}
+		resultC := make(chan result, 1)
+		go func() {
+			blk, err := p.GetBlock(ctx, &blockHash)
+			resultC <- result{blk, err}
+		}()
 
-	// Step 1: server reads MsgGetHeaders, replies with one header.
-	msg, _, err := srv.Read(2 * time.Second)
-	if err != nil {
-		t.Fatalf("read getheaders: %v", err)
-	}
-	if _, ok := msg.(*wire.MsgGetHeaders); !ok {
-		t.Fatalf("expected MsgGetHeaders, got %T", msg)
-	}
-	headers := wire.NewMsgHeaders()
-	if err := headers.AddBlockHeader(replyHdr); err != nil {
-		t.Fatal(err)
-	}
-	srvReply(t, srv, headers)
+		// Step 1: server reads MsgGetHeaders, replies with one header.
+		msg, _, err := srv.Read(0)
+		if err != nil {
+			t.Fatalf("read getheaders: %v", err)
+		}
+		if _, ok := msg.(*wire.MsgGetHeaders); !ok {
+			t.Fatalf("expected MsgGetHeaders, got %T", msg)
+		}
+		headers := wire.NewMsgHeaders()
+		if err := headers.AddBlockHeader(replyHdr); err != nil {
+			t.Fatal(err)
+		}
+		srvReply(t, srv, headers)
 
-	// Step 2: server reads MsgGetData, verify witness type.
-	msg, _, err = srv.Read(2 * time.Second)
-	if err != nil {
-		t.Fatalf("read getdata: %v", err)
-	}
-	gd, ok := msg.(*wire.MsgGetData)
-	if !ok {
-		t.Fatalf("expected MsgGetData, got %T", msg)
-	}
-	if gd.InvList[0].Type != wire.InvTypeWitnessBlock {
-		t.Fatalf("GetBlock should request InvTypeWitnessBlock, got %v",
-			gd.InvList[0].Type)
-	}
+		// Step 2: server reads MsgGetData, verify witness type.
+		msg, _, err = srv.Read(0)
+		if err != nil {
+			t.Fatalf("read getdata: %v", err)
+		}
+		gd, ok := msg.(*wire.MsgGetData)
+		if !ok {
+			t.Fatalf("expected MsgGetData, got %T", msg)
+		}
+		if gd.InvList[0].Type != wire.InvTypeWitnessBlock {
+			t.Fatalf("GetBlock should request InvTypeWitnessBlock, got %v",
+				gd.InvList[0].Type)
+		}
 
-	// Reply with the block.
-	srvReply(t, srv, block)
+		// Reply with the block.
+		srvReply(t, srv, block)
 
-	r := <-resultC
-	if r.err != nil {
-		t.Fatalf("GetBlock: %v", r.err)
-	}
-	got := r.blk.Header.BlockHash()
-	if !got.IsEqual(&blockHash) {
-		t.Fatalf("block hash mismatch: %v != %v", got, blockHash)
-	}
+		r := <-resultC
+		if r.err != nil {
+			t.Fatalf("GetBlock: %v", r.err)
+		}
+		got := r.blk.Header.BlockHash()
+		if !got.IsEqual(&blockHash) {
+			t.Fatalf("block hash mismatch: %v != %v", got, blockHash)
+		}
+	})
 }
 
 // TestGetTxWitness exercises the GetTx wrapper, confirming it
 // sends InvTypeWitnessTx on the wire.
 func TestGetTxWitness(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(t, ctx)
 
-	tx := wire.NewMsgTx(2)
-	prevHash := chainhash.DoubleHashH([]byte("gettx-prev"))
-	tx.AddTxIn(&wire.TxIn{
-		PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+		tx := wire.NewMsgTx(2)
+		prevHash := chainhash.DoubleHashH([]byte("gettx-prev"))
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Hash: prevHash, Index: 0},
+		})
+		tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x6a}})
+		txHash := tx.TxHash()
+
+		type result struct {
+			tx  *wire.MsgTx
+			err error
+		}
+		resultC := make(chan result, 1)
+		go func() {
+			got, err := p.GetTx(ctx, &txHash)
+			resultC <- result{got, err}
+		}()
+
+		msg, _, err := srv.Read(0)
+		if err != nil {
+			t.Fatalf("read getdata: %v", err)
+		}
+		gd, ok := msg.(*wire.MsgGetData)
+		if !ok {
+			t.Fatalf("expected MsgGetData, got %T", msg)
+		}
+		if gd.InvList[0].Type != wire.InvTypeWitnessTx {
+			t.Fatalf("GetTx should request InvTypeWitnessTx, got %v",
+				gd.InvList[0].Type)
+		}
+
+		srvReply(t, srv, tx)
+
+		r := <-resultC
+		if r.err != nil {
+			t.Fatalf("GetTx: %v", r.err)
+		}
+		got := r.tx.TxHash()
+		if !got.IsEqual(&txHash) {
+			t.Fatalf("tx hash mismatch")
+		}
 	})
-	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x6a}})
-	txHash := tx.TxHash()
-
-	type result struct {
-		tx  *wire.MsgTx
-		err error
-	}
-	resultC := make(chan result, 1)
-	go func() {
-		got, err := p.GetTx(ctx, &txHash)
-		resultC <- result{got, err}
-	}()
-
-	msg, _, err := srv.Read(2 * time.Second)
-	if err != nil {
-		t.Fatalf("read getdata: %v", err)
-	}
-	gd, ok := msg.(*wire.MsgGetData)
-	if !ok {
-		t.Fatalf("expected MsgGetData, got %T", msg)
-	}
-	if gd.InvList[0].Type != wire.InvTypeWitnessTx {
-		t.Fatalf("GetTx should request InvTypeWitnessTx, got %v",
-			gd.InvList[0].Type)
-	}
-
-	srvReply(t, srv, tx)
-
-	r := <-resultC
-	if r.err != nil {
-		t.Fatalf("GetTx: %v", r.err)
-	}
-	got := r.tx.TxHash()
-	if !got.IsEqual(&txHash) {
-		t.Fatalf("tx hash mismatch")
-	}
 }

--- a/service/tbc/peer/rawpeer/rawpeer.go
+++ b/service/tbc/peer/rawpeer/rawpeer.go
@@ -169,6 +169,12 @@ func (r *RawPeer) handshake(ctx context.Context, conn net.Conn) error {
 	us := &wire.NetAddress{Timestamp: time.Now()}
 	them := &wire.NetAddress{Timestamp: time.Now()}
 	msg := wire.NewMsgVersion(us, them, rand.Uint64(), 0)
+	// Advertise SFNodeWitness so remote peers include witness
+	// data in block and tx replies (BIP-144).  Without this flag
+	// peers treat us as a pre-segwit node and strip the witness
+	// before sending, so on-disk blocks never carry segwit
+	// signatures or tapscript data.
+	msg.Services = wire.SFNodeWitness
 	msg.UserAgent = fmt.Sprintf("/%v:%v/", version.Component, version.String())
 	msg.ProtocolVersion = int32(wire.AddrV2Version)
 	err := writeTimeout(defaultHandshakeTimeout, conn, msg, r.protocolVersion, r.network)

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1011,7 +1011,7 @@ func (s *Server) downloadBlock(ctx context.Context, p *rawpeer.RawPeer, ch chain
 	getData := wire.NewMsgGetData()
 	getData.InvList = append(getData.InvList,
 		&wire.InvVect{
-			Type: wire.InvTypeBlock,
+			Type: wire.InvTypeWitnessBlock,
 			Hash: ch,
 		})
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -180,8 +180,8 @@ func TestDbUpgradeFull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if version != 4 {
-		t.Fatalf("expected version 4, got %v", version)
+	if version != 5 {
+		t.Fatalf("expected version 5, got %v", version)
 	}
 
 	// version 2 checks
@@ -440,8 +440,8 @@ func TestDbUpgradeV4(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if version != 4 {
-		t.Fatalf("expected version 4, got %v", version)
+	if version != 5 {
+		t.Fatalf("expected version 5, got %v", version)
 	}
 
 	keystoneHashes := []string{

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -229,6 +229,20 @@ func TestDbUpgradeFull(t *testing.T) {
 	if !keystonebh.Hash.IsEqual(hash) {
 		t.Fatal("unexpected keystone hash")
 	}
+
+	// v5 post-upgrade assertions: the ladder ran v4->v5 as part
+	// of service startup above, and v5's contract is to wipe
+	// BlocksDB rawdb and rebuild BlocksMissingDB from the
+	// header chain so the sync loop re-downloads every known
+	// block with full witness data.  BlocksMissing is the
+	// public surface for the rebuilt table.
+	bm, err := s.g.db.BlocksMissing(ctx, 1024)
+	if err != nil {
+		t.Fatalf("BlocksMissing: %v", err)
+	}
+	if len(bm) < 2 {
+		t.Fatalf("v5: BlocksMissingDB has %d entries, want >= 2", len(bm))
+	}
 }
 
 func TestDbUpgradeV3(t *testing.T) {

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -408,7 +408,11 @@ func (b *btcNode) handleGetData(m *wire.MsgGetData) (*wire.MsgBlock, error) {
 	}
 
 	v := m.InvList[0]
-	if v.Type != wire.InvTypeBlock {
+	// Accept both base and witness-inclusive block-data requests.
+	// tbcd requests witness blocks post-BIP-144; the fake node
+	// stores full MsgBlocks either way, so returning the same
+	// block for both types matches what a real peer does.
+	if v.Type != wire.InvTypeBlock && v.Type != wire.InvTypeWitnessBlock {
 		return nil, fmt.Errorf("unsupported data type: %v", v.Type)
 	}
 

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -4126,7 +4126,7 @@ func TestIndexFakeHeaders(t *testing.T) {
 		// This is just for readability
 		isInvalidErr := func(err error) bool {
 			isNotOneOf := !testutil.ErrorIsOneOf(err,
-				[]error{context.Canceled, io.EOF, rawpeer.ErrNoConn},
+				[]error{net.ErrClosed, context.Canceled, io.EOF, rawpeer.ErrNoConn},
 			) && !errors.As(err, new(*net.OpError))
 
 			return isNotOneOf


### PR DESCRIPTION
tbcd was asking peers for blocks and txs using the base
(non-witness) inventory types, so under BIP-144 every reply
came back witness-stripped.  Every block body tbcd has on
disk since segwit activation is missing its witness data;
reading a tx back through the RPC shows txid == wtxid and
empty TxIn.Witness.

This PR switches the three outbound getdata call sites to
the witness variants and advertises SFNodeWitness in the
handshake.  The reply correlation continues to work because
GetData, onInvHandler, and onNotFoundHandler strip the
witness bit before tagging, keeping the pending-reply key
aligned with what the base-form inbound handlers expect.

The stored bodies are unrecoverable in place — the bytes
never arrived.  A v5 database upgrade wipes BlocksDB and
rebuilds BlocksMissingDB from the header chain so the normal
sync loop re-downloads every block with full witness data.
Headers, height-hash, transactions, outputs, keystones, and
indexer tips are witness-independent and left untouched;
re-processing the re-downloaded blocks produces identical
output, so indexers stay at their current heights.

Verified end-to-end on testnet4: after the fix, a reveal tx
at block 131115 comes back with a 3-element witness stack
and wtxid != txid, matching the reference node byte for byte.

First start on an existing home directory runs the upgrade
in place.  BlockByHash / TxById return NotFound for blocks
that have not yet been re-fetched during the resync window,
which is the same behaviour dependents already see during
cold IBD.

Operators should expect the BlocksDB to grow substantially after
the upgrade since witness data now lands on disk.  On testnet4
the blocks directory went from 3.3 G at v4 to 12 G at v5 (~3.6×),
and total home went from 9.1 G to 17 G.  Mainnet will be larger
in absolute terms, similar in ratio — post-segwit-adoption blocks
are mostly witness, especially after taproot.
