### PR TITLE
tbc: fix fragile test TestIndexFakeHeaders

### DIFF
--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -4122,12 +4122,9 @@ func TestIndexFakeHeaders(t *testing.T) {
 		// This is just for readability
 		isInvalidErr := func(err error) bool {
 			isNotOneOf := !testutil.ErrorIsOneOf(err,
-				[]error{
-					context.Canceled,
-					io.EOF,
-					rawpeer.ErrNoConn,
-				},
+				[]error{context.Canceled, io.EOF, rawpeer.ErrNoConn},
 			) && !errors.As(err, new(*net.OpError))
+
 			return isNotOneOf
 		}
 		if err := n.Run(ctx); isInvalidErr(err) {

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -10,10 +10,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -4122,9 +4122,13 @@ func TestIndexFakeHeaders(t *testing.T) {
 		// This is just for readability
 		isInvalidErr := func(err error) bool {
 			isNotOneOf := !testutil.ErrorIsOneOf(err,
-				[]error{net.ErrClosed, context.Canceled, rawpeer.ErrNoConn},
-			)
-			return isNotOneOf && !strings.Contains(err.Error(), "connection reset by peer")
+				[]error{
+					context.Canceled,
+					io.EOF,
+					rawpeer.ErrNoConn,
+				},
+			) && !errors.As(err, new(*net.OpError))
+			return isNotOneOf
 		}
 		if err := n.Run(ctx); isInvalidErr(err) {
 			panic(err)


### PR DESCRIPTION
**Summary**
Addresses a fragility in `TestIndexFakeHeaders`, originally detected [here](https://github.com/hemilabs/heminetwork/actions/runs/24578322581/job/71869385146).

**NOTE**: The test was run [10000](https://github.com/hemilabs/heminetwork/actions/runs/24662396488) times for `go test` and [1000](https://github.com/hemilabs/heminetwork/actions/runs/24662958398) times for `go test --race`, passing successfully.

**Changes**
Excludes any errors of type `net.OpError` or `io.EOF` returned by the fake BTC node, which may occur due to an expected connection closure.
