### PR TITLE
localnet: add snap synced node to localnet tests

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -236,6 +236,7 @@ services:
       HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
       # yamllint disable-line rule:line-length
       GETH_NODEKEYHEX: "76e3e48b25c512e1036069538041df813b759fc67d4756b80ace2586b123e913"
+      GETH_SYNCMODE: "full"
     working_dir: "/tmp"
     command:
       - "sh"
@@ -367,6 +368,7 @@ services:
       ADMIN_PRIVATE_KEY: "${ADMIN_PRIVATE_KEY}"
       OP_GETH_L1_RPC: "http://geth-l1:8545"
       HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
+      GETH_SYNCMODE: "full"
     working_dir: "/tmp"
     command:
       - "sh"
@@ -386,7 +388,106 @@ services:
       e2e:
     ports:
       - "18546:8546"
-      - "5555:5555"
+
+  op-node-non-sequencing-snap-sync:
+    image: optimism-stack:latest
+    depends_on:
+      op-geth-l2-non-sequencing-snap-sync:
+        condition: "service_healthy"
+    healthcheck:
+      start_period: 180s
+    command:
+      - "op-node/bin/op-node"
+      - "--l2=ws://op-geth-l2-non-sequencing-snap-sync:8551"
+      - "--l2.jwt-secret=/tmp/jwt.hex"
+      - "--verifier.l1-confs=0"
+      - "--rollup.config=/shared-dir/rollup.json"
+      - "--rpc.addr=0.0.0.0"
+      - "--rpc.port=8548"
+      - "--rpc.enable-admin"
+      - "--l1=http://geth-l1:8545"
+      - "--l1.rpckind=standard"
+      - "--l1.trustrpc"
+      - "--log.level=info"
+      - "--l1.trustrpc=true"
+      - "--l1.http-poll-interval=1s"
+      - "--p2p.priv.path=/tmp/op-node-priv-key.txt"
+      - "--p2p.sequencer.key=${ADMIN_PRIVATE_KEY}"
+      - "--p2p.static=/ip4/192.169.199.7/tcp/9222/p2p/16Uiu2HAmGCJv5C97ZcdMr6pCCQFqdNXvwE8k6RgTd7vWu4WtVUmr"
+      - "--log.level=debug"
+      - "--log.format=terminal"
+      - "--override.ecotone=1725868497"
+      - "--override.canyon=1725868497"
+      - "--override.delta=1725868497"
+      - "--override.pectrablobschedule=1744238662"
+      - "--override.isthmus=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.holocene=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.granite=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.fjord=${HVM_PHASE0_TIMESTAMP}"
+      - "--l1.beacon.ignore=true"
+      - "--rollup.l1-chain-config=/shared-dir/l1genesis.json"
+      - "--syncmode=execution-layer"
+    volumes:
+      - "shared-dir:/shared-dir"
+      - "./jwt.hex:/tmp/jwt.hex"
+    networks:
+      e2e:
+    ports:
+      - "28548:8548"
+
+  wait-for-finalized:
+    depends_on:
+      op-geth-l2-non-sequencing:
+        condition: "service_started"
+    image: optimism-stack:latest
+    deploy:
+      restart_policy:
+        condition: "on-failure"
+    volumes:
+      - ./finalized-exists.sh:/tmp/finalized-exists.sh
+    command:
+      - sh
+      - /tmp/finalized-exists.sh
+    environment:
+      ETH_RPC_URL: "http://op-geth-l2-non-sequencing:8546"
+    networks:
+      e2e:
+
+  op-geth-l2-non-sequencing-snap-sync:
+    image: optimism-stack:latest
+    depends_on:
+      wait-for-finalized:
+        condition: "service_completed_successfully"
+    healthcheck:
+      test: ["CMD-SHELL", "ls /tmp/datadir/geth.ipc"]
+      interval: 5s
+      retries: 300
+      start_period: 30s
+    environment:
+      ADMIN_PRIVATE_KEY: "${ADMIN_PRIVATE_KEY}"
+      OP_GETH_L1_RPC: "http://geth-l1:8545"
+      HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
+      GETH_SYNCMODE: "snap"
+    working_dir: "/tmp"
+    command:
+      - "sh"
+      - "/tmp/entrypointl2.sh"
+    volumes:
+      - "./e2e/keystore:/tmp/keystore:ro"
+      - "./e2e/passwords.txt:/tmp/passwords.txt:ro"
+      - "./jwt.hex:/tmp/jwt.hex:ro"
+      - "./entrypointl2.sh:/tmp/entrypointl2.sh"
+      - "./genesisl2.sh:/tmp/genesisl2.sh"
+      - "./output:/tmp/output"
+      - "shared-dir:/shared-dir"
+      - "./deploy-config.json:/git/optimism/packages/contracts-bedrock/deploy-config/devnetL1.json"
+      - "./prestate-proof.json:/git/optimism/op-program/bin/prestate-proof.json"
+      - {type: "tmpfs", target: "/tmp"}
+    networks:
+      e2e:
+    ports:
+      - "28546:8546"
+
 
   op-batcher:
     image: optimism-stack:latest

--- a/e2e/entrypointl2.sh
+++ b/e2e/entrypointl2.sh
@@ -27,7 +27,6 @@ BLOCKHEIGHT=$(curl --data-binary "{\"jsonrpc\": \"1.0\", \"id\": \"curltest\", \
 
 BLOCKHEADER=$(curl --data-binary "{\"jsonrpc\": \"1.0\", \"id\": \"curltest\", \"method\": \"getblockheader\", \"params\": [$BESTBLOCKHASH, false]}" -H 'content-type: text/plain;' http://user:password@bitcoind:18443/ | jq -r '.result')
 
-echo "setting hvm genesis to $BLOCKHEADER:$BLOCKHEIGHT"
 
 filecontents=$(cat << EOF
 [Node.P2P]
@@ -48,6 +47,22 @@ echo "will use toml file contents: $filecontents"
 
 echo $filecontents > ./config.toml
 
+genesis_header_file=/shared-dir/genesis-header.txt
+if [ -f "$genesis_header_file" ]; then
+    BLOCKHEADER="$(cat $genesis_header_file)"
+else
+    echo $BLOCKHEADER > $genesis_header_file
+fi
+
+genesis_height_file=/shared-dir/genesis-height.txt
+if [ -f "$genesis_height_file" ]; then
+    BLOCKHEIGHT="$(cat $genesis_height_file)"
+else
+    echo $BLOCKHEIGHT > $genesis_height_file
+fi
+
+echo "setting hvm genesis to $BLOCKHEADER:$BLOCKHEIGHT"
+
 /bin/geth \
  --keystore \
  /tmp/keystore \
@@ -65,7 +80,6 @@ echo $filecontents > ./config.toml
  --ws.origins="*"  \
  --http.api=web3,debug,eth,txpool,net,engine,miner,kss \
  --ws.api=debug,eth,txpool,net,engine,miner,kss \
- --syncmode=full  \
  --nodiscover  \
  --maxpeers=50 \
  --networkid=901 \

--- a/e2e/finalized-exists.sh
+++ b/e2e/finalized-exists.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+echo "will check for finalized block at $ETH_RPC_URL"
+
+if [ -z "$ETH_RPC_URL" ]; then
+echo "error: ETH_RPC_URL is not set" >&2
+exit 1
+fi
+                                                                                                                                                                                                                                                                            
+response=$(curl -sf -X POST "$ETH_RPC_URL" \
+-H "Content-Type: application/json" \
+-d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}')
+
+echo "received rpc response: $response"
+
+if [ $? -ne 0 ]; then
+echo "error: failed to reach RPC endpoint" >&2
+exit 1
+fi
+
+number=$(printf '%s' "$response" | grep -o '"number":"0x[0-9a-fA-F]*"' | grep -o '0x[0-9a-fA-F]*')
+
+if [ -z "$number" ] || [ "$number" = "0x0" ]; then
+echo "error: no finalized block with height > 0 found (got: ${number:-null})" >&2
+exit 1
+fi
+
+echo "finalized block: $number"
+exit 0
+

--- a/e2e/genesisl2.sh
+++ b/e2e/genesisl2.sh
@@ -106,6 +106,7 @@ cat l1allocs.json
 # to transact with the L1
 echo "$(jq '.alloc."0x78697c88847dfbbb40523e42c1f2e28a13a170be".balance = "0x999999999999999999"' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json
 echo "$(jq '.alloc."0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc".balance = "0x999999999999999999"' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json
+echo "$(jq '.alloc."0xf0faD6E77d55509484F93Ace13AAFa37138bc370".balance = "0x999999999999999999"' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json
 
 
 echo "$(jq --argjson timestamp "$(jq '.timestamp' /shared-dir/genesis.json)" '.timestamp = $timestamp' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json

--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -135,6 +135,7 @@ func privateKeyForTestByIndex(t *testing.T, index uint) string {
 	keys := []string{
 		"dfe61681b31b12b04f239bc0692965c61ffc79244ed9736ffa1a72d00a23a530", // sequencing
 		"8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba", // non-sequencing
+		"fbe93b7c626721b844ff03923c296c395e7729b81096a9a5c3d8a87b57e01db6",
 	}
 	if index >= uint(len(keys)) {
 		t.Fatalf("index %d exceeds available keys (max: %d)", index, len(keys)-1)
@@ -300,20 +301,23 @@ func TestMonitor(t *testing.T) {
 
 func TestL1L2Comms(t *testing.T) {
 	t.Parallel()
-	testL1L2Comms(t, l1Endpoint(), forkedL2Endpoint(), "http://localhost:18546")
+	testL1L2Comms(t, l1Endpoint(), forkedL2Endpoint(), "http://localhost:18546", "http://localhost:28546")
 }
 
-func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequencingEndpoint string) {
-	for i, sequencing := range []bool{true, false} {
-		var name string
-		if sequencing {
-			name = "testing sequencing client"
-		} else {
-			name = "testing non-sequencing client"
-		}
-		// Capture loop variables
-		i := i
-		sequencing := sequencing
+func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequencingEndpoint string, l2NonSequencingSnapSyncEndpoint string) {
+	// todo: combine these into a nice struct or something similar
+	testNames := []string{
+		"testing sequencing client",
+		"testing non-sequencing client",
+		"testing non-sequencing client with snap-sync",
+	}
+	tests := []bool{true, false, false}
+
+	const snapSyncNodeIndex = 2
+
+	for i, sequencing := range tests {
+		name := testNames[i]
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -332,7 +336,12 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 
 			l2ClientNonSequencing, err := ethclient.Dial(l2NonSequencingEndpoint)
 			if err != nil {
-				t.Fatalf("could not dial eth l1 %s", err)
+				t.Fatalf("could not dial eth l2 non sequencing %s", err)
+			}
+
+			l2ClientNonSequencingSnapSync, err := ethclient.Dial(l2NonSequencingSnapSyncEndpoint)
+			if err != nil {
+				t.Fatalf("could not dial eth l2 non sequencing snap sync %s", err)
 			}
 
 			// Use different private key for each subtest to avoid conflicts
@@ -348,6 +357,10 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 					t.Fatal("there is no non-sequencing client for testing a forked network")
 				}
 				l2ClientToUse = l2ClientNonSequencing
+
+				if i == snapSyncNodeIndex {
+					l2ClientToUse = l2ClientNonSequencingSnapSync
+				}
 			}
 
 			if testingReclaimFunds() {
@@ -379,7 +392,8 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 
 			opNodeSequencingEndpoint := "http://localhost:8548"
 			opNodeNonSequencingEndpoint := "http://localhost:18548"
-			assertOutputRootsAreTheSame(t, ctx, l2ClientToUse, opNodeSequencingEndpoint, opNodeNonSequencingEndpoint)
+			opNodeNonSequencingSnapSyncEndpoint := "http://localhost:28548"
+			assertOutputRootsAreTheSame(t, ctx, l2ClientToUse, opNodeSequencingEndpoint, opNodeNonSequencingEndpoint, opNodeNonSequencingSnapSyncEndpoint)
 			assertSafeAndFinalBlocksAreProgressing(t, ctx, l2ClientToUse)
 		})
 	}
@@ -929,6 +943,13 @@ func bridgeEthL1ToL2(t *testing.T, ctx context.Context, l1Client *ethclient.Clie
 	receiverAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
 
 	t.Logf("receiver address is %s", receiverAddress)
+
+	l1Balance, err := l1Client.BalanceAt(ctx, receiverAddress, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("the l1 balance for %s is %x", receiverAddress, l1Balance)
 
 	bridge, err := e2ebindings.NewL1StandardBridge(l1StandardBridge(t), l1Client)
 	if err != nil {
@@ -1839,7 +1860,8 @@ func bridgeERC20FromL2ToL1(t *testing.T, ctx context.Context, l1Address common.A
 
 		resolvedtx, err := gameContract.ResolveClaimTx(0)
 		if err != nil {
-			t.Fatal(err)
+			t.Logf("resolveClaimtx could not be retrieved, will retry")
+			continue
 		}
 
 		_, _, err = transactions.SendTx(ctx, l1Client, resolvedtx, privateKey)
@@ -1990,7 +2012,14 @@ func assertSafeAndFinalBlocksAreProgressing(t *testing.T, ctx context.Context, l
 	}
 }
 
-func assertOutputRootsAreTheSame(t *testing.T, ctx context.Context, l2Client *ethclient.Client, opNodeSequencingEndpoint string, opNodeNonSequencingEndpoint string) {
+func assertOutputRootsAreTheSame(
+	t *testing.T,
+	ctx context.Context,
+	l2Client *ethclient.Client,
+	opNodeSequencingEndpoint string,
+	opNodeNonSequencingEndpoint string,
+	opNodeNonSequencingSnapSyncEndpoint string,
+) {
 	bigTip, err := l2Client.HeaderByNumber(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("error getting l2 tip: %s", err)
@@ -1999,6 +2028,24 @@ func assertOutputRootsAreTheSame(t *testing.T, ctx context.Context, l2Client *et
 	tip := bigTip.Number.Uint64()
 
 	tip -= 5
+
+	// snap syncs do not store all of the output roots, but the most recent
+	// should be available and match other nodes.  100 is a safe number
+	// for example, you may see an error like this:
+	// {
+	// 	"jsonrpc": "2.0",
+	// 	"id": 1,
+	// 	"error": {
+	// 	  "code": -32000,
+	// 	  "message": "failed to get L2 output at block 0x78cfcb0adbb4053f7194910f9faf2a440fd95547171f8db6c42314fbd6f9661e:40: failed to get contract proof at block 0x78cfcb0adbb4053f7194910f9faf2a440fd95547171f8db6c42314fbd6f9661e: not supported"
+	// 	}
+	// }
+	// according to geth docs:
+	// eth_getProof for historical blocks is supported if history.trienode = N is configured, which enables retention of the required historical trie nodes.
+	// ...
+	// --history.state=0 is the key flag. When combined with --syncmode=full to perform a full sync from genesis, Geth will retain all the historical states.
+	// and we use --syncmode=snap (obviously) for our snap synced node
+	snapSyncMax := tip - 100
 
 	t.Logf("checking output roots from tip %d", tip)
 
@@ -2034,7 +2081,12 @@ func assertOutputRootsAreTheSame(t *testing.T, ctx context.Context, l2Client *et
 
 		res2, err := client.Post(opNodeNonSequencingEndpoint, "application/json", bytes.NewBuffer(jsonbody))
 		if err != nil {
-			t.Fatalf("error making request to sequencer endpoint: %s", err)
+			t.Fatalf("error making request to non sequencing endpoint: %s", err)
+		}
+
+		res3, err := client.Post(opNodeNonSequencingSnapSyncEndpoint, "application/json", bytes.NewBuffer(jsonbody))
+		if err != nil {
+			t.Fatalf("error making request to non sequencing snap sync endpoint: %s", err)
 		}
 
 		resBody, err := io.ReadAll(res.Body)
@@ -2047,8 +2099,14 @@ func assertOutputRootsAreTheSame(t *testing.T, ctx context.Context, l2Client *et
 			t.Fatalf("error reading response body from non-sequencer: %s", err)
 		}
 
+		resBody3, err := io.ReadAll(res3.Body)
+		if err != nil {
+			t.Fatalf("error reading response body from non-sequencer-snap-sync: %s", err)
+		}
+
 		res.Body.Close()
 		res2.Body.Close()
+		res3.Body.Close()
 
 		assertResultNotError := func(body *outputAtBlockResponse) error {
 			if body.Error != nil {
@@ -2060,12 +2118,17 @@ func assertOutputRootsAreTheSame(t *testing.T, ctx context.Context, l2Client *et
 
 		var outputAtBlockResponseOne outputAtBlockResponse
 		var outputAtBlockResponseTwo outputAtBlockResponse
+		var outputAtBlockResponseThree outputAtBlockResponse
 
 		if err := json.Unmarshal(resBody, &outputAtBlockResponseOne); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := json.Unmarshal(resBody2, &outputAtBlockResponseTwo); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := json.Unmarshal(resBody3, &outputAtBlockResponseThree); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2077,11 +2140,19 @@ func assertOutputRootsAreTheSame(t *testing.T, ctx context.Context, l2Client *et
 			t.Fatalf("error in response: %v", outputAtBlockResponseTwo.Error)
 		}
 
-		assertResultNotError(&outputAtBlockResponseOne)
-		assertResultNotError(&outputAtBlockResponseTwo)
+		// only check against snap sync if within snapSyncMax of the tip
+		if tip >= snapSyncMax {
+			if err := assertResultNotError(&outputAtBlockResponseThree); err != nil {
+				t.Fatalf("error in response: %v, will skip comparison", outputAtBlockResponseThree.Error)
+			}
+
+			if diff := deep.Equal(outputAtBlockResponseOne, outputAtBlockResponseThree); len(diff) > 0 {
+				t.Fatalf("output roots are not the same for sequencing and non-sequencing snap sync: %s", diff)
+			}
+		}
 
 		if diff := deep.Equal(outputAtBlockResponseOne, outputAtBlockResponseTwo); len(diff) > 0 {
-			t.Fatalf("output roots are not the same: %s", diff)
+			t.Fatalf("output roots are not the same for sequencing and non-sequencing: %s", diff)
 		}
 
 		tip--


### PR DESCRIPTION
**Summary**

* add snap sync node to localnet tests
  * op-geth sync mode = "snap"
  * op-node sync mode = "execution-layer"
* this node does not start until a finalized block exist in the chain.
* fixes https://github.com/hemilabs/heminetwork/issues/985

**Changes**
see summary
