### PR TITLE
tbc: add filtered transaction notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Authenticated RPC route for administrative requests to TBC ([#1003](https://github.com/hemilabs/heminetwork/pull/1003)).
 - Add `MempoolUtxos` RPC command returning unspent mempool outputs matching a required set of script hashes
   ([#987](https://github.com/hemilabs/heminetwork/pull/987)).
-- Add filtered transaction notifications to TBC for commerce (TxWatch/TxUnwatch API).
+- Add filtered transaction notifications to TBC for commerce (TxWatch/TxUnwatch API)
+  ([#986](https://github.com/hemilabs/heminetwork/pull/986)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Authenticated RPC route for administrative requests to TBC ([#1003](https://github.com/hemilabs/heminetwork/pull/1003)).
 - Add `MempoolUtxos` RPC command returning unspent mempool outputs matching a required set of script hashes
   ([#987](https://github.com/hemilabs/heminetwork/pull/987)).
+- Add filtered transaction notifications to TBC for commerce (TxWatch/TxUnwatch API).
 
 ### Changed
 

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -118,6 +118,13 @@ const (
 
 	CmdZKSpendableOutputsRequest  = "tbcapi-zk-spendable-outputs-request"
 	CmdZKSpendableOutputsResponse = "tbcapi-zk-spendable-outputs-response"
+
+	CmdTxWatchRequest    = "tbcapi-tx-watch-request"
+	CmdTxWatchResponse   = "tbcapi-tx-watch-response"
+	CmdTxUnwatchRequest  = "tbcapi-tx-unwatch-request"
+	CmdTxUnwatchResponse = "tbcapi-tx-unwatch-response"
+
+	CmdTxNotification = "tbcapi-tx-notification"
 )
 
 var (
@@ -538,6 +545,48 @@ type ZKSpendableOutputsResponse struct {
 	Error            *protocol.Error     `json:"error,omitempty"`
 }
 
+// TxWatchRequest registers ScriptHashes for tx notifications on
+// the current websocket session.
+type TxWatchRequest struct {
+	ScriptHashes []api.ByteSlice `json:"script_hashes"`
+}
+
+// TxWatchResponse is the response for TxWatchRequest.
+type TxWatchResponse struct {
+	Error *protocol.Error `json:"error,omitempty"`
+}
+
+// TxUnwatchRequest deregisters ScriptHashes from tx notifications.
+type TxUnwatchRequest struct {
+	ScriptHashes []api.ByteSlice `json:"script_hashes"`
+}
+
+// TxUnwatchResponse is the response for TxUnwatchRequest.
+type TxUnwatchResponse struct {
+	Error *protocol.Error `json:"error,omitempty"`
+}
+
+// TxNotificationType identifies the kind of transaction notification.
+type TxNotificationType string
+
+const (
+	// TxNotificationMempool indicates the transaction entered the mempool.
+	TxNotificationMempool TxNotificationType = "tx_mempool"
+
+	// TxNotificationConfirmed indicates the transaction was confirmed
+	// in a block.
+	TxNotificationConfirmed TxNotificationType = "tx_confirmed"
+)
+
+// TxNotification is an unsolicited push from server to client when
+// a watched transaction hits the mempool or is confirmed in a block.
+type TxNotification struct {
+	Type      TxNotificationType `json:"type"`
+	TxID      string             `json:"tx_id"`
+	Timestamp int64              `json:"timestamp"`
+	Metadata  map[string]string  `json:"metadata,omitempty"`
+}
+
 var commands = map[protocol.Command]reflect.Type{
 	CmdPingRequest:                              reflect.TypeFor[PingRequest](),
 	CmdPingResponse:                             reflect.TypeFor[PingResponse](),
@@ -597,6 +646,11 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdZKSpendingOutpointsResponse:              reflect.TypeFor[ZKSpendingOutpointsResponse](),
 	CmdZKSpendableOutputsRequest:                reflect.TypeFor[ZKSpendableOutputsRequest](),
 	CmdZKSpendableOutputsResponse:               reflect.TypeFor[ZKSpendableOutputsResponse](),
+	CmdTxWatchRequest:                           reflect.TypeFor[TxWatchRequest](),
+	CmdTxWatchResponse:                          reflect.TypeFor[TxWatchResponse](),
+	CmdTxUnwatchRequest:                         reflect.TypeFor[TxUnwatchRequest](),
+	CmdTxUnwatchResponse:                        reflect.TypeFor[TxUnwatchResponse](),
+	CmdTxNotification:                           reflect.TypeFor[TxNotification](),
 }
 
 type tbcAPI struct{}

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Copyright (c) 2024-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -20,9 +20,14 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 	"github.com/go-test/deep"
 
+	"github.com/hemilabs/heminetwork/v2/api"
 	"github.com/hemilabs/heminetwork/v2/api/bfgapi"
+	"github.com/hemilabs/heminetwork/v2/api/protocol"
+	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer/tbcgozer"
 	"github.com/hemilabs/heminetwork/v2/database/tbcd"
 	"github.com/hemilabs/heminetwork/v2/database/tbcd/level"
@@ -652,4 +657,93 @@ func TestGetFinalitiesByL2KeystoneBFGNotFoundOpGeth(t *testing.T) {
 	}
 
 	t.Logf("received body in response: %s", body)
+}
+
+func TestTxWatchUnwatchE2E(t *testing.T) {
+	ctx, cancel := defaultTestContext(t)
+	defer cancel()
+
+	levelDbHome := t.TempDir()
+	tbcServer, tbcUrl := createTbcServer(ctx, t, levelDbHome)
+	_ = tbcServer
+
+	// Connect a websocket client to tbcd.
+	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.CloseNow()
+
+	// Read the initial ping.
+	var pingMsg protocol.Message
+	if err := wsjson.Read(ctx, c, &pingMsg); err != nil {
+		t.Fatal(err)
+	}
+	if pingMsg.Header.Command != tbcapi.CmdPingRequest {
+		t.Fatalf("expected ping, got %s", pingMsg.Header.Command)
+	}
+
+	wsConn := protocol.NewWSConn(c)
+
+	// Create a script hash to watch (P2WPKH-style).
+	watchedScript := []byte{
+		0x00, 0x14,
+		0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c,
+	}
+	sh := tbcd.NewScriptHashFromScript(watchedScript)
+
+	// Send TxWatch request.
+	err = tbcapi.Write(ctx, wsConn, "e2e-watch-1", tbcapi.TxWatchRequest{
+		ScriptHashes: []api.ByteSlice{sh[:]},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read TxWatch response.
+	var watchResp protocol.Message
+	if err := wsjson.Read(ctx, c, &watchResp); err != nil {
+		t.Fatal(err)
+	}
+	if watchResp.Header.Command != tbcapi.CmdTxWatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxWatchResponse, watchResp.Header.Command)
+	}
+	t.Logf("TxWatch response received: %s", watchResp.Header.Command)
+
+	// Send TxUnwatch request.
+	err = tbcapi.Write(ctx, wsConn, "e2e-unwatch-1", tbcapi.TxUnwatchRequest{
+		ScriptHashes: []api.ByteSlice{sh[:]},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read TxUnwatch response.
+	var unwatchResp protocol.Message
+	if err := wsjson.Read(ctx, c, &unwatchResp); err != nil {
+		t.Fatal(err)
+	}
+	if unwatchResp.Header.Command != tbcapi.CmdTxUnwatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxUnwatchResponse, unwatchResp.Header.Command)
+	}
+	t.Logf("TxUnwatch response received: %s", unwatchResp.Header.Command)
+
+	// Verify the round-trip worked with no errors.
+	var watchResult tbcapi.TxWatchResponse
+	if err := json.Unmarshal(watchResp.Payload, &watchResult); err != nil {
+		t.Fatal(err)
+	}
+	if watchResult.Error != nil {
+		t.Fatalf("TxWatch returned error: %v", watchResult.Error)
+	}
+
+	var unwatchResult tbcapi.TxUnwatchResponse
+	if err := json.Unmarshal(unwatchResp.Payload, &unwatchResult); err != nil {
+		t.Fatal(err)
+	}
+	if unwatchResult.Error != nil {
+		t.Fatalf("TxUnwatch returned error: %v", unwatchResult.Error)
+	}
 }

--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -277,6 +277,10 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 			UTXOs:          mempoolUtxos,
 			SpentOutpoints: spentOps,
 		}
+	case tbcapi.CmdTxWatchRequest:
+		resp = &tbcapi.TxWatchResponse{}
+	case tbcapi.CmdTxUnwatchRequest:
+		resp = &tbcapi.TxUnwatchResponse{}
 	default:
 		panic(fmt.Errorf("unknown command: %v", cmd))
 	}

--- a/service/tbc/notifier.go
+++ b/service/tbc/notifier.go
@@ -9,19 +9,37 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+
+	"github.com/hemilabs/heminetwork/v2/database/tbcd"
 )
 
+// maxWatchScripts is the maximum number of ScriptHashes a single
+// listener may watch.  Prevents unbounded memory growth from a
+// malicious client sending large TxWatch requests.
+const maxWatchScripts = 1024
+
+// Notification types.
+const (
+	NtfnTypeBlockInsert       = "block_insert"
+	NtfnTypeBlockheaderInsert = "blockheader_insert"
+	NtfnTypeTxMempool         = "tx_mempool"
+	NtfnTypeTxConfirmed       = "tx_confirmed"
+)
+
+// Notification represents an event delivered to subscribers.
 type Notification struct {
-	Type      string    `json:"type"`
-	ID        string    `json:"id"`
-	Timestamp time.Time `json:"timestamp"`
-	Msg       string    `json:"msg"`
-	Error     error     `json:"error,omitempty"`
+	Type      string            `json:"type"`
+	ID        string            `json:"id"`
+	Timestamp time.Time         `json:"timestamp"`
+	Msg       string            `json:"msg"`
+	Error     error             `json:"error,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
 }
 
 func (n Notification) Is(target Notification) bool {
@@ -32,18 +50,36 @@ func (n Notification) String() string {
 	return fmt.Sprintf("[%v] %s %s: %s", n.Timestamp, n.Type, n.ID, n.Msg)
 }
 
+// ScriptHash extracts the script hash from the notification metadata.
+// Returns false if the metadata is missing, malformed, or wrong length.
+func (n Notification) ScriptHash() (tbcd.ScriptHash, bool) {
+	v, ok := n.Metadata["script_hash"]
+	if !ok {
+		return tbcd.ScriptHash{}, false
+	}
+	b, err := hex.DecodeString(v)
+	if err != nil || len(b) != len(tbcd.ScriptHash{}) {
+		return tbcd.ScriptHash{}, false
+	}
+	var sh tbcd.ScriptHash
+	copy(sh[:], b)
+	return sh, true
+}
+
+// NotificationBlock creates a block insertion notification.
 func NotificationBlock(hash chainhash.Hash) Notification {
 	return Notification{
-		Type:      "block_insert",
+		Type:      NtfnTypeBlockInsert,
 		ID:        hash.String(),
 		Msg:       "block inserted: " + hash.String(),
 		Timestamp: time.Now(),
 	}
 }
 
+// NotificationBlockheader creates a block header insertion notification.
 func NotificationBlockheader(hash chainhash.Hash) Notification {
 	return Notification{
-		Type:      "blockheader_insert",
+		Type:      NtfnTypeBlockheaderInsert,
 		ID:        hash.String(),
 		Msg:       "blockheader inserted: " + hash.String(),
 		Timestamp: time.Now(),
@@ -68,6 +104,34 @@ func NotificationService(serviceID string, status string) Notification {
 	}
 }
 
+// NotificationTxMempool creates a notification for a mempool transaction
+// whose output matches the given ScriptHash.
+func NotificationTxMempool(txid chainhash.Hash, sh tbcd.ScriptHash) Notification {
+	return Notification{
+		Type:      NtfnTypeTxMempool,
+		ID:        txid.String(),
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"script_hash": hex.EncodeToString(sh[:]),
+		},
+	}
+}
+
+// NotificationTxConfirmed creates a notification for a transaction confirmed
+// in a block whose output matches the given ScriptHash.
+func NotificationTxConfirmed(txid chainhash.Hash, blockHash chainhash.Hash, height int64, sh tbcd.ScriptHash) Notification {
+	return Notification{
+		Type:      NtfnTypeTxConfirmed,
+		ID:        txid.String(),
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"block_hash":   blockHash.String(),
+			"block_height": strconv.FormatInt(height, 10),
+			"script_hash":  hex.EncodeToString(sh[:]),
+		},
+	}
+}
+
 type Notifier struct {
 	mtx sync.Mutex
 
@@ -87,10 +151,72 @@ type Listener struct {
 
 	ctx         context.Context
 	unsubscribe func()
+
+	// watchScripts is the set of ScriptHashes this listener cares
+	// about for tx_mempool and tx_confirmed notifications.
+	// nil means no filtering — receive all notifications.
+	watchMtx     sync.RWMutex
+	watchScripts map[tbcd.ScriptHash]struct{}
 }
 
 func (l *Listener) Unsubscribe() {
 	l.unsubscribe()
+}
+
+// Watch adds ScriptHashes to this listener's watch set.  Once a
+// watch set exists, tx_mempool and tx_confirmed notifications are
+// only delivered if the notification's ScriptHash is in the set.
+// Block and blockheader notifications are always delivered.
+// Returns an error if adding the scripts would exceed maxWatchScripts.
+func (l *Listener) Watch(scripts []tbcd.ScriptHash) error {
+	l.watchMtx.Lock()
+	defer l.watchMtx.Unlock()
+	if l.watchScripts == nil {
+		l.watchScripts = make(map[tbcd.ScriptHash]struct{}, len(scripts))
+	}
+	if len(l.watchScripts)+len(scripts) > maxWatchScripts {
+		return fmt.Errorf("watch set would exceed maximum of %d", maxWatchScripts)
+	}
+	for _, sh := range scripts {
+		l.watchScripts[sh] = struct{}{}
+	}
+	return nil
+}
+
+// Unwatch removes ScriptHashes from this listener's watch set.
+func (l *Listener) Unwatch(scripts []tbcd.ScriptHash) {
+	l.watchMtx.Lock()
+	defer l.watchMtx.Unlock()
+	for _, sh := range scripts {
+		delete(l.watchScripts, sh)
+	}
+}
+
+// accepts returns true if the listener should receive the given
+// notification.  Block/blockheader notifications are always accepted.
+// tx_mempool and tx_confirmed are only accepted if either the listener
+// has no watch filter (watchScripts == nil) or the notification's
+// ScriptHash is in the watch set.
+func (l *Listener) accepts(n Notification) bool {
+	switch n.Type {
+	case NtfnTypeTxMempool, NtfnTypeTxConfirmed:
+	default:
+		return true
+	}
+
+	l.watchMtx.RLock()
+	defer l.watchMtx.RUnlock()
+
+	if l.watchScripts == nil {
+		return true
+	}
+
+	sh, ok := n.ScriptHash()
+	if !ok {
+		return false
+	}
+	_, found := l.watchScripts[sh]
+	return found
 }
 
 // Listen blocks until either a message is received by the listener, or
@@ -157,14 +283,17 @@ func (n *Notifier) Subscribe(pctx context.Context, capacity uint64) (*Listener, 
 	}
 }
 
-// Notify sends a notification to every listener. If the Notifier
-// is blocking, it blocks until every listener can receive the
-// notification.
+// Notify sends a notification to every listener that accepts it.
+// If the Notifier is blocking, it blocks until every accepting
+// listener can receive the notification.
 func (n *Notifier) Notify(ctx context.Context, message Notification) error {
 	n.mtx.Lock()
 	defer n.mtx.Unlock()
 
 	for _, l := range n.listeners {
+		if !l.accepts(message) {
+			continue
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/service/tbc/notifier_watch_test.go
+++ b/service/tbc/notifier_watch_test.go
@@ -1,0 +1,738 @@
+// Copyright (c) 2026 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package tbc
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+
+	"github.com/hemilabs/heminetwork/v2/database/tbcd"
+)
+
+// --- Positive tests ---
+
+func TestWatchDeliversMatchingMempool(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	sh := tbcd.NewScriptHashFromScript([]byte("merchant-addr"))
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+
+	txid := chainhash.Hash{0x01}
+	if err := n.Notify(ctx, NotificationTxMempool(txid, sh)); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeTxMempool {
+		t.Fatalf("expected tx_mempool, got %s", msg.Type)
+	}
+	if msg.ID != txid.String() {
+		t.Fatalf("expected txid %s, got %s", txid, msg.ID)
+	}
+	gotSH, ok := msg.ScriptHash()
+	if !ok {
+		t.Fatal("ScriptHash() returned false on tx_mempool notification")
+	}
+	if gotSH != sh {
+		t.Fatalf("script hash mismatch: %x != %x", gotSH, sh)
+	}
+}
+
+func TestWatchDeliversMatchingConfirmed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	sh := tbcd.NewScriptHashFromScript([]byte("merchant-addr"))
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+
+	txid := chainhash.Hash{0x02}
+	blockHash := chainhash.Hash{0x03}
+	height := int64(800000)
+	if err := n.Notify(ctx, NotificationTxConfirmed(txid, blockHash, height, sh)); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeTxConfirmed {
+		t.Fatalf("expected tx_confirmed, got %s", msg.Type)
+	}
+	if msg.ID != txid.String() {
+		t.Fatalf("expected txid %s, got %s", txid, msg.ID)
+	}
+	if msg.Metadata["block_hash"] != blockHash.String() {
+		t.Fatalf("block_hash mismatch: %s", msg.Metadata["block_hash"])
+	}
+	if msg.Metadata["block_height"] != "800000" {
+		t.Fatalf("block_height mismatch: %s", msg.Metadata["block_height"])
+	}
+}
+
+func TestBlockInsertAlwaysDeliveredWithFilter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	// Set a watch filter — block_insert must still get through.
+	sh := tbcd.NewScriptHashFromScript([]byte("addr"))
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+
+	bh := chainhash.Hash{0x10}
+	if err := n.Notify(ctx, NotificationBlock(bh)); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockInsert {
+		t.Fatalf("expected block_insert, got %s", msg.Type)
+	}
+}
+
+func TestBlockheaderInsertAlwaysDeliveredWithFilter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	sh := tbcd.NewScriptHashFromScript([]byte("addr"))
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+
+	bh := chainhash.Hash{0x11}
+	if err := n.Notify(ctx, NotificationBlockheader(bh)); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockheaderInsert {
+		t.Fatalf("expected blockheader_insert, got %s", msg.Type)
+	}
+}
+
+func TestNoFilterReceivesAll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	// No Watch() — should receive everything including tx notifications.
+	sh := tbcd.NewScriptHashFromScript([]byte("whatever"))
+	types := []Notification{
+		NotificationBlock(chainhash.Hash{0x01}),
+		NotificationBlockheader(chainhash.Hash{0x02}),
+		NotificationTxMempool(chainhash.Hash{0x03}, sh),
+		NotificationTxConfirmed(chainhash.Hash{0x04}, chainhash.Hash{0x05}, 1, sh),
+	}
+	for _, nt := range types {
+		if err := n.Notify(ctx, nt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i, expected := range types {
+		msg, err := l.Listen(ctx)
+		if err != nil {
+			t.Fatalf("notification %d: %v", i, err)
+		}
+		if msg.Type != expected.Type {
+			t.Fatalf("notification %d: expected %s, got %s", i, expected.Type, msg.Type)
+		}
+	}
+}
+
+func TestWatchMultipleScriptHashes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	shA := tbcd.NewScriptHashFromScript([]byte("addr-A"))
+	shB := tbcd.NewScriptHashFromScript([]byte("addr-B"))
+	shC := tbcd.NewScriptHashFromScript([]byte("addr-C"))
+	if err := l.Watch([]tbcd.ScriptHash{shA, shB}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A — deliver
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, shA)); err != nil {
+		t.Fatal(err)
+	}
+	// C — drop (unwatched)
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x02}, shC)); err != nil {
+		t.Fatal(err)
+	}
+	// B — deliver
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x03}, shB)); err != nil {
+		t.Fatal(err)
+	}
+	// sentinel
+	if err := n.Notify(ctx, NotificationBlock(chainhash.Hash{0xff})); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.ID != (chainhash.Hash{0x01}).String() {
+		t.Fatalf("expected 0x01 (shA), got %s", msg.ID)
+	}
+	msg, err = l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.ID != (chainhash.Hash{0x03}).String() {
+		t.Fatalf("expected 0x03 (shB), got %s — shC was not filtered", msg.ID)
+	}
+	msg, err = l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockInsert {
+		t.Fatalf("expected sentinel block_insert, got %s", msg.Type)
+	}
+}
+
+func TestMultipleListenersDifferentWatchSets(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+
+	l1, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l1.Unsubscribe()
+
+	l2, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l2.Unsubscribe()
+
+	shA := tbcd.NewScriptHashFromScript([]byte("addr-A"))
+	shB := tbcd.NewScriptHashFromScript([]byte("addr-B"))
+
+	if err := l1.Watch([]tbcd.ScriptHash{shA}); err != nil {
+		t.Fatal(err)
+	}
+	if err := l2.Watch([]tbcd.ScriptHash{shB}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Notify shA — l1 receives, l2 does not.
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, shA)); err != nil {
+		t.Fatal(err)
+	}
+	// Notify shB — l2 receives, l1 does not.
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x02}, shB)); err != nil {
+		t.Fatal(err)
+	}
+	// sentinel for both
+	if err := n.Notify(ctx, NotificationBlock(chainhash.Hash{0xff})); err != nil {
+		t.Fatal(err)
+	}
+
+	// l1 should get shA then block
+	msg, err := l1.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.ID != (chainhash.Hash{0x01}).String() {
+		t.Fatalf("l1: expected 0x01 (shA), got %s", msg.ID)
+	}
+	msg, err = l1.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockInsert {
+		t.Fatalf("l1: expected sentinel, got %s %s", msg.Type, msg.ID)
+	}
+
+	// l2 should get shB then block
+	msg, err = l2.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.ID != (chainhash.Hash{0x02}).String() {
+		t.Fatalf("l2: expected 0x02 (shB), got %s", msg.ID)
+	}
+	msg, err = l2.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockInsert {
+		t.Fatalf("l2: expected sentinel, got %s %s", msg.Type, msg.ID)
+	}
+}
+
+func TestWatchUnwatchRewatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	sh := tbcd.NewScriptHashFromScript([]byte("addr"))
+
+	// Watch → deliver
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, sh)); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeTxMempool {
+		t.Fatalf("phase 1: expected tx_mempool, got %s", msg.Type)
+	}
+
+	// Unwatch → drop, use sentinel to verify
+	l.Unwatch([]tbcd.ScriptHash{sh})
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x02}, sh)); err != nil {
+		t.Fatal(err)
+	}
+	if err := n.Notify(ctx, NotificationBlock(chainhash.Hash{0xaa})); err != nil {
+		t.Fatal(err)
+	}
+	msg, err = l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockInsert {
+		t.Fatalf("phase 2: expected block_insert (drop), got %s", msg.Type)
+	}
+
+	// Re-watch → deliver again
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x03}, sh)); err != nil {
+		t.Fatal(err)
+	}
+	msg, err = l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeTxMempool {
+		t.Fatalf("phase 3: expected tx_mempool after re-watch, got %s", msg.Type)
+	}
+}
+
+// --- Negative tests ---
+
+func TestWatchFilterDropsUnwatched(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	watched := tbcd.NewScriptHashFromScript([]byte("watched"))
+	unwatched := tbcd.NewScriptHashFromScript([]byte("unwatched"))
+	if err := l.Watch([]tbcd.ScriptHash{watched}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send unwatched then sentinel
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, unwatched)); err != nil {
+		t.Fatal(err)
+	}
+	if err := n.Notify(ctx, NotificationTxConfirmed(chainhash.Hash{0x02}, chainhash.Hash{0x03}, 1, unwatched)); err != nil {
+		t.Fatal(err)
+	}
+	if err := n.Notify(ctx, NotificationBlock(chainhash.Hash{0xff})); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockInsert {
+		t.Fatalf("expected sentinel (both tx notifications should be dropped), got %s", msg.Type)
+	}
+}
+
+func TestUnwatchNeverWatched(t *testing.T) {
+	// Unwatching a script hash that was never watched should be a silent no-op.
+	n := NewNotifier(true)
+	ctx := context.Background()
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	sh := tbcd.NewScriptHashFromScript([]byte("never-watched"))
+	if err := l.Watch([]tbcd.ScriptHash{tbcd.NewScriptHashFromScript([]byte("other"))}); err != nil {
+		t.Fatal(err)
+	}
+	l.Unwatch([]tbcd.ScriptHash{sh}) // should not panic or error
+}
+
+func TestWatchDuplicateIdempotent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	sh := tbcd.NewScriptHashFromScript([]byte("addr"))
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil { // duplicate — should be idempotent
+		t.Fatal(err)
+	}
+	if err := l.Watch([]tbcd.ScriptHash{sh}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, sh)); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should get exactly one delivery, not three.
+	if msg.Type != NtfnTypeTxMempool {
+		t.Fatalf("expected tx_mempool, got %s", msg.Type)
+	}
+}
+
+func TestWatchEmptyListInitializesFilter(t *testing.T) {
+	// Watch([]) should initialize the filter map (non-nil) but with
+	// zero entries, meaning all tx notifications get dropped.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	n := NewNotifier(true)
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	if err := l.Watch([]tbcd.ScriptHash{}); err != nil { // empty list
+		t.Fatal(err)
+	}
+
+	sh := tbcd.NewScriptHashFromScript([]byte("any"))
+	if err := n.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, sh)); err != nil {
+		t.Fatal(err)
+	}
+	if err := n.Notify(ctx, NotificationBlock(chainhash.Hash{0xff})); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := l.Listen(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg.Type != NtfnTypeBlockInsert {
+		t.Fatalf("empty watch list should drop all tx notifications, got %s", msg.Type)
+	}
+}
+
+func TestAcceptsCorruptMetadata(t *testing.T) {
+	l := &Listener{
+		watchScripts: map[tbcd.ScriptHash]struct{}{
+			tbcd.NewScriptHashFromScript([]byte("x")): {},
+		},
+	}
+
+	// No metadata at all — should reject.
+	n1 := Notification{Type: NtfnTypeTxMempool}
+	if l.accepts(n1) {
+		t.Fatal("accepted tx_mempool with no metadata")
+	}
+
+	// Metadata with bad hex — should reject.
+	n2 := Notification{
+		Type:     NtfnTypeTxMempool,
+		Metadata: map[string]string{"script_hash": "not-hex!"},
+	}
+	if l.accepts(n2) {
+		t.Fatal("accepted tx_mempool with invalid hex")
+	}
+
+	// Metadata with wrong length hex — should reject.
+	n3 := Notification{
+		Type:     NtfnTypeTxMempool,
+		Metadata: map[string]string{"script_hash": "aabb"},
+	}
+	if l.accepts(n3) {
+		t.Fatal("accepted tx_mempool with truncated script hash")
+	}
+
+	// Metadata with valid hex but non-matching hash — should reject.
+	wrongSH := tbcd.NewScriptHashFromScript([]byte("y"))
+	n4 := Notification{
+		Type:     NtfnTypeTxConfirmed,
+		Metadata: map[string]string{"script_hash": hex.EncodeToString(wrongSH[:])},
+	}
+	if l.accepts(n4) {
+		t.Fatal("accepted tx_confirmed with non-matching script hash")
+	}
+
+	// Unknown notification type — should always accept (passthrough).
+	n5 := Notification{Type: "some_future_type"}
+	if !l.accepts(n5) {
+		t.Fatal("rejected unknown notification type — should passthrough")
+	}
+}
+
+func TestScriptHashParsingEdgeCases(t *testing.T) {
+	// No metadata.
+	n1 := Notification{Type: NtfnTypeTxMempool}
+	if _, ok := n1.ScriptHash(); ok {
+		t.Fatal("ScriptHash() should return false with no metadata")
+	}
+
+	// Empty script_hash value.
+	n2 := Notification{
+		Type:     NtfnTypeTxMempool,
+		Metadata: map[string]string{"script_hash": ""},
+	}
+	if _, ok := n2.ScriptHash(); ok {
+		t.Fatal("ScriptHash() should return false with empty string")
+	}
+
+	// Odd-length hex.
+	n3 := Notification{
+		Type:     NtfnTypeTxMempool,
+		Metadata: map[string]string{"script_hash": "abc"},
+	}
+	if _, ok := n3.ScriptHash(); ok {
+		t.Fatal("ScriptHash() should return false with odd hex")
+	}
+
+	// Correct length, valid hex — should work.
+	sh := tbcd.NewScriptHashFromScript([]byte("test"))
+	n4 := Notification{
+		Type:     NtfnTypeTxMempool,
+		Metadata: map[string]string{"script_hash": hex.EncodeToString(sh[:])},
+	}
+	got, ok := n4.ScriptHash()
+	if !ok {
+		t.Fatal("ScriptHash() should return true for valid data")
+	}
+	if got != sh {
+		t.Fatalf("ScriptHash mismatch: %x != %x", got, sh)
+	}
+}
+
+func TestConstructorMetadataIntegrity(t *testing.T) {
+	txid := chainhash.Hash{0x30}
+	blockHash := chainhash.Hash{0x31}
+	sh := tbcd.NewScriptHashFromScript([]byte("merchant"))
+	height := int64(850000)
+
+	// tx_mempool
+	nm := NotificationTxMempool(txid, sh)
+	if nm.Type != NtfnTypeTxMempool {
+		t.Fatalf("expected tx_mempool, got %s", nm.Type)
+	}
+	if nm.ID != txid.String() {
+		t.Fatalf("txid mismatch")
+	}
+	gotSH, ok := nm.ScriptHash()
+	if !ok || gotSH != sh {
+		t.Fatal("ScriptHash round-trip failed for tx_mempool")
+	}
+
+	// tx_confirmed
+	nc := NotificationTxConfirmed(txid, blockHash, height, sh)
+	if nc.Type != NtfnTypeTxConfirmed {
+		t.Fatalf("expected tx_confirmed, got %s", nc.Type)
+	}
+	if nc.Metadata["block_hash"] != blockHash.String() {
+		t.Fatal("block_hash mismatch")
+	}
+	if nc.Metadata["block_height"] != "850000" {
+		t.Fatal("block_height mismatch")
+	}
+	gotSH, ok = nc.ScriptHash()
+	if !ok || gotSH != sh {
+		t.Fatal("ScriptHash round-trip failed for tx_confirmed")
+	}
+}
+
+func TestWatchExceedsLimit(t *testing.T) {
+	n := NewNotifier(true)
+	ctx := context.Background()
+	l, err := n.Subscribe(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	// Fill to the limit.
+	scripts := make([]tbcd.ScriptHash, maxWatchScripts)
+	for i := range scripts {
+		scripts[i] = tbcd.NewScriptHashFromScript([]byte(fmt.Sprintf("addr-%d", i)))
+	}
+	if err := l.Watch(scripts); err != nil {
+		t.Fatalf("watch up to limit should succeed: %v", err)
+	}
+
+	// One more should fail.
+	extra := tbcd.NewScriptHashFromScript([]byte("one-too-many"))
+	if err := l.Watch([]tbcd.ScriptHash{extra}); err == nil {
+		t.Fatal("watch beyond limit should return error")
+	}
+}
+
+// --- Fuzz tests ---
+
+func FuzzScriptHashParsing(f *testing.F) {
+	// Seed with valid, empty, truncated, and garbage.
+	sh := tbcd.NewScriptHashFromScript([]byte("seed"))
+	f.Add(hex.EncodeToString(sh[:]))
+	f.Add("")
+	f.Add("aabb")
+	f.Add("not-hex!")
+	f.Add("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+	f.Add(hex.EncodeToString(make([]byte, 31))) // one byte short
+	f.Add(hex.EncodeToString(make([]byte, 33))) // one byte long
+
+	f.Fuzz(func(t *testing.T, input string) {
+		n := Notification{
+			Type:     NtfnTypeTxMempool,
+			Metadata: map[string]string{"script_hash": input},
+		}
+		gotSH, ok := n.ScriptHash()
+
+		// Verify: if ok is true, the result must be a valid 32-byte hash
+		// that round-trips back to the input hex.
+		if ok {
+			if len(gotSH) != 32 {
+				t.Fatalf("ScriptHash returned ok=true but len=%d", len(gotSH))
+			}
+			// hex.EncodeToString always returns lowercase;
+			// the input may have uppercase, so normalize.
+			roundTrip := hex.EncodeToString(gotSH[:])
+			if roundTrip != strings.ToLower(input) {
+				t.Fatalf("round-trip mismatch: %q != %q", roundTrip, strings.ToLower(input))
+			}
+		}
+
+		// Verify: accepts() must not panic regardless of input.
+		l := &Listener{
+			watchScripts: map[tbcd.ScriptHash]struct{}{
+				tbcd.NewScriptHashFromScript([]byte("x")): {},
+			},
+		}
+		_ = l.accepts(n) // must not panic
+	})
+}
+
+func FuzzNotificationAccepts(f *testing.F) {
+	f.Add(NtfnTypeTxMempool, "script_hash", "deadbeef")
+	f.Add(NtfnTypeTxConfirmed, "script_hash", "")
+	f.Add(NtfnTypeBlockInsert, "", "")
+	f.Add(NtfnTypeBlockheaderInsert, "", "")
+	f.Add("", "", "")
+	f.Add(NtfnTypeTxMempool, "wrong_key", "aabbccdd")
+
+	f.Fuzz(func(t *testing.T, nType, metaKey, metaVal string) {
+		n := Notification{Type: nType}
+		if metaKey != "" {
+			n.Metadata = map[string]string{metaKey: metaVal}
+		}
+
+		// With nil watchScripts — must not panic, must accept everything.
+		l1 := &Listener{}
+		if !l1.accepts(n) {
+			// nil watchScripts should accept all notifications.
+			if nType != NtfnTypeTxMempool && nType != NtfnTypeTxConfirmed {
+				t.Fatalf("nil watchScripts rejected type %q", nType)
+			}
+			// For tx types with nil watchScripts, accepts returns true,
+			// so this branch shouldn't be hit.
+		}
+
+		// With non-nil watchScripts — must not panic.
+		l2 := &Listener{
+			watchScripts: map[tbcd.ScriptHash]struct{}{},
+		}
+		_ = l2.accepts(n) // must not panic
+	})
+}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -1351,6 +1351,7 @@ func (s *Server) pushNotifications(ctx context.Context, ws *tbcWs, l *Listener) 
 	for {
 		n, err := l.Listen(ctx)
 		if err != nil {
+			log.Errorf("tx notification listen: %v", err)
 			return
 		}
 
@@ -1369,7 +1370,7 @@ func (s *Server) pushNotifications(ctx context.Context, ws *tbcWs, l *Listener) 
 		pushID := "ntfy-" + hex.EncodeToString(buf)
 
 		if err := tbcapi.Write(ctx, ws.conn, pushID, ntfy); err != nil {
-			log.Debugf("push notification write: %v", err)
+			log.Errorf("push notification write: %v", err)
 			return
 		}
 	}

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -47,6 +47,9 @@ type tbcWs struct {
 	conn           *protocol.WSConn
 	sessionID      string
 	requestContext context.Context
+
+	listenerMtx sync.Mutex
+	listener    *Listener // created on first TxWatch, cancelled on disconnect
 }
 
 func (s *Server) getTBCAPICommandHandler(cmd protocol.Command, payload any) func(ctx context.Context) (any, error) {
@@ -197,9 +200,23 @@ func (s *Server) handleWebsocketRead(ctx context.Context, ws *tbcWs) {
 
 		handler := s.getTBCAPICommandHandler(cmd, payload)
 		if handler == nil {
-			log.Errorf("handleWebsocketRead %s %s %s: %v",
-				ws.addr, cmd, id, "unknown command")
-			return
+			// TxWatch and TxUnwatch need the websocket connection
+			// for listener management, so they bypass the handler
+			// table.
+			switch cmd {
+			case tbcapi.CmdTxWatchRequest:
+				handler = func(ctx context.Context) (any, error) {
+					return s.handleTxWatchRequest(ctx, ws, payload.(*tbcapi.TxWatchRequest))
+				}
+			case tbcapi.CmdTxUnwatchRequest:
+				handler = func(ctx context.Context) (any, error) {
+					return s.handleTxUnwatchRequest(ctx, ws, payload.(*tbcapi.TxUnwatchRequest))
+				}
+			default:
+				log.Errorf("handleWebsocketRead %s %s %s: %v",
+					ws.addr, cmd, id, "unknown command")
+				return
+			}
 		}
 
 		go s.handleRequest(ctx, ws, id, cmd, handler)
@@ -1176,6 +1193,13 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 	// Wait for termination
 	ws.wg.Wait()
 
+	// Clean up tx notification listener if one was created.
+	ws.listenerMtx.Lock()
+	if ws.listener != nil {
+		ws.listener.Unsubscribe()
+	}
+	ws.listenerMtx.Unlock()
+
 	log.Infof("RPC connection terminated from %v", r.RemoteAddr)
 }
 
@@ -1286,4 +1310,132 @@ func wireTxToTBC(w *wire.MsgTx) *tbcapi.Tx {
 	}
 
 	return tx
+}
+
+// ensureListener creates a Listener for the websocket session if one
+// does not already exist, and starts the notification push goroutine.
+// The listener is bound to the websocket session's lifetime context,
+// not the individual request context, so it survives beyond handler return.
+func (s *Server) ensureListener(_ context.Context, ws *tbcWs) (*Listener, error) {
+	ws.listenerMtx.Lock()
+	defer ws.listenerMtx.Unlock()
+
+	if ws.listener != nil {
+		return ws.listener, nil
+	}
+
+	// Use the session context (ws.requestContext), not the handler's
+	// request-scoped context.  The handler context has a 10-second
+	// timeout that would cancel the listener when the handler returns.
+	l, err := s.notifier.Subscribe(ws.requestContext, 128)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe: %w", err)
+	}
+	ws.listener = l
+
+	// Push notifications to the websocket client.
+	ws.wg.Add(1)
+	go s.pushNotifications(ws.requestContext, ws, l)
+
+	return l, nil
+}
+
+// pushNotifications reads from the listener and writes unsolicited
+// notification messages to the websocket.
+func (s *Server) pushNotifications(ctx context.Context, ws *tbcWs, l *Listener) {
+	defer ws.wg.Done()
+
+	log.Tracef("pushNotifications: %v", ws.addr)
+	defer log.Tracef("pushNotifications exit: %v", ws.addr)
+
+	for {
+		n, err := l.Listen(ctx)
+		if err != nil {
+			return
+		}
+
+		ntfy := &tbcapi.TxNotification{
+			Type:      tbcapi.TxNotificationType(n.Type),
+			TxID:      n.ID,
+			Timestamp: n.Timestamp.Unix(),
+			Metadata:  n.Metadata,
+		}
+
+		// Generate a unique message ID for the push.
+		buf := make([]byte, 8)
+		// rand.Read uses the OS CSPRNG which never returns an error
+		// on supported platforms (Linux, macOS, Windows).
+		_, _ = rand.Read(buf)
+		pushID := "ntfy-" + hex.EncodeToString(buf)
+
+		if err := tbcapi.Write(ctx, ws.conn, pushID, ntfy); err != nil {
+			log.Debugf("push notification write: %v", err)
+			return
+		}
+	}
+}
+
+// parseScriptHashes validates and converts raw byte slices to ScriptHashes.
+func parseScriptHashes(raw []api.ByteSlice) ([]tbcd.ScriptHash, error) {
+	scripts := make([]tbcd.ScriptHash, 0, len(raw))
+	for _, b := range raw {
+		if len(b) != len(tbcd.ScriptHash{}) {
+			return nil, fmt.Errorf("invalid script hash length: %d", len(b))
+		}
+		var sh tbcd.ScriptHash
+		copy(sh[:], b)
+		scripts = append(scripts, sh)
+	}
+	return scripts, nil
+}
+
+func (s *Server) handleTxWatchRequest(ctx context.Context, ws *tbcWs, req *tbcapi.TxWatchRequest) (any, error) {
+	log.Tracef("handleTxWatchRequest: %v", ws.addr)
+	defer log.Tracef("handleTxWatchRequest exit: %v", ws.addr)
+
+	l, err := s.ensureListener(ctx, ws)
+	if err != nil {
+		return &tbcapi.TxWatchResponse{
+			Error: protocol.RequestErrorf("watch: %v", err),
+		}, nil
+	}
+
+	scripts, err := parseScriptHashes(req.ScriptHashes)
+	if err != nil {
+		return &tbcapi.TxWatchResponse{
+			Error: protocol.RequestErrorf("%v", err),
+		}, nil
+	}
+
+	if err := l.Watch(scripts); err != nil {
+		return &tbcapi.TxWatchResponse{
+			Error: protocol.RequestErrorf("%v", err),
+		}, nil
+	}
+
+	return &tbcapi.TxWatchResponse{}, nil
+}
+
+func (s *Server) handleTxUnwatchRequest(ctx context.Context, ws *tbcWs, req *tbcapi.TxUnwatchRequest) (any, error) {
+	log.Tracef("handleTxUnwatchRequest: %v", ws.addr)
+	defer log.Tracef("handleTxUnwatchRequest exit: %v", ws.addr)
+
+	ws.listenerMtx.Lock()
+	l := ws.listener
+	ws.listenerMtx.Unlock()
+
+	if l == nil {
+		return &tbcapi.TxUnwatchResponse{}, nil
+	}
+
+	scripts, err := parseScriptHashes(req.ScriptHashes)
+	if err != nil {
+		return &tbcapi.TxUnwatchResponse{
+			Error: protocol.RequestErrorf("%v", err),
+		}, nil
+	}
+
+	l.Unwatch(scripts)
+
+	return &tbcapi.TxUnwatchResponse{}, nil
 }

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -2303,3 +2303,599 @@ func TestNotFoundError(t *testing.T) {
 		})
 	}
 }
+
+func TestTxWatchNotification(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	var dupErr database.DuplicateError
+
+	cfg := &Config{
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		BlockheaderCacheSize:    "1mb",
+		BlockSanity:             false,
+		HemiIndex:               true,
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            1000,
+		MempoolEnabled:          true,
+		Network:                 networkLocalnet,
+		ListenAddress:           "127.0.0.1:0",
+		PrometheusListenAddress: "",
+		Seeds:                   []string{"192.0.2.1:8333"},
+		NotificationBlocking:    true,
+	}
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe to internal notifications to know when the server
+	// is ready (genesis block inserted).
+	l, err := s.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, dupErr) {
+			panic(err)
+		}
+	}()
+
+	// Wait for genesis block notification.
+	for {
+		msg, err := l.Listen(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg.Is(NotificationBlock(chainhash.Hash{})) {
+			break
+		}
+	}
+	l.Unsubscribe()
+
+	// Wait for HTTP to be listening.
+	var tbcAddr string
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+		if addr := s.HTTPAddress(); addr != nil {
+			tbcAddr = addr.String()
+			break
+		}
+	}
+
+	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+
+	// Connect websocket client.
+	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.CloseNow()
+
+	assertPing(ctx, t, c, tbcapi.CmdPingRequest)
+
+	tws := &tbcWs{
+		conn: protocol.NewWSConn(c),
+	}
+
+	// Create a script hash to watch.
+	watchedScript := []byte{
+		0x00, 0x14, // witness v0 keyhash
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14,
+	}
+	watchedSH := tbcd.NewScriptHashFromScript(watchedScript)
+
+	// Send TxWatch request.
+	if err := tbcapi.Write(ctx, tws.conn, "watch-1", tbcapi.TxWatchRequest{
+		ScriptHashes: []api.ByteSlice{watchedSH[:]},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read TxWatch response.
+	var watchResp protocol.Message
+	if err := wsjson.Read(ctx, c, &watchResp); err != nil {
+		t.Fatal(err)
+	}
+	if watchResp.Header.Command != tbcapi.CmdTxWatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxWatchResponse, watchResp.Header.Command)
+	}
+
+	// Inject a notification through the server's notifier to simulate
+	// a mempool tx matching the watched script hash.
+	fakeTxid := chainhash.Hash{0xaa, 0xbb, 0xcc}
+	if err := s.notifier.Notify(ctx, NotificationTxMempool(fakeTxid, watchedSH)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the push notification from the websocket.
+	var ntfy protocol.Message
+	if err := wsjson.Read(ctx, c, &ntfy); err != nil {
+		t.Fatal(err)
+	}
+	if ntfy.Header.Command != tbcapi.CmdTxNotification {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxNotification, ntfy.Header.Command)
+	}
+
+	var txn tbcapi.TxNotification
+	if err := json.Unmarshal(ntfy.Payload, &txn); err != nil {
+		t.Fatal(err)
+	}
+	if txn.Type != NtfnTypeTxMempool {
+		t.Fatalf("expected type tx_mempool, got %s", txn.Type)
+	}
+	if txn.TxID != fakeTxid.String() {
+		t.Fatalf("expected txid %s, got %s", fakeTxid, txn.TxID)
+	}
+}
+
+func TestTxWatchFilterDrop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	var dupErr database.DuplicateError
+
+	cfg := &Config{
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		BlockheaderCacheSize:    "1mb",
+		BlockSanity:             false,
+		HemiIndex:               true,
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            1000,
+		MempoolEnabled:          true,
+		Network:                 networkLocalnet,
+		ListenAddress:           "127.0.0.1:0",
+		PrometheusListenAddress: "",
+		Seeds:                   []string{"192.0.2.1:8333"},
+		NotificationBlocking:    true,
+	}
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := s.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, dupErr) {
+			panic(err)
+		}
+	}()
+
+	for {
+		msg, err := l.Listen(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg.Is(NotificationBlock(chainhash.Hash{})) {
+			break
+		}
+	}
+	l.Unsubscribe()
+
+	var tbcAddr string
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+		if addr := s.HTTPAddress(); addr != nil {
+			tbcAddr = addr.String()
+			break
+		}
+	}
+
+	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+
+	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.CloseNow()
+
+	assertPing(ctx, t, c, tbcapi.CmdPingRequest)
+
+	tws := &tbcWs{
+		conn: protocol.NewWSConn(c),
+	}
+
+	// Watch for script hash A.
+	shA := tbcd.NewScriptHashFromScript([]byte("address-A"))
+	shB := tbcd.NewScriptHashFromScript([]byte("address-B"))
+
+	if err := tbcapi.Write(ctx, tws.conn, "watch-1", tbcapi.TxWatchRequest{
+		ScriptHashes: []api.ByteSlice{shA[:]},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var watchResp protocol.Message
+	if err := wsjson.Read(ctx, c, &watchResp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send a notification for unwatched shB — should be filtered out.
+	if err := s.notifier.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, shB)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send a notification for watched shA — should arrive.
+	if err := s.notifier.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x02}, shA)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read — we should get shA's notification, not shB's.
+	var ntfy protocol.Message
+	if err := wsjson.Read(ctx, c, &ntfy); err != nil {
+		t.Fatal(err)
+	}
+	if ntfy.Header.Command != tbcapi.CmdTxNotification {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxNotification, ntfy.Header.Command)
+	}
+
+	var txn tbcapi.TxNotification
+	if err := json.Unmarshal(ntfy.Payload, &txn); err != nil {
+		t.Fatal(err)
+	}
+	if txn.TxID != (chainhash.Hash{0x02}).String() {
+		t.Fatalf("expected txid for shA (0x02), got %s — filter did not drop shB", txn.TxID)
+	}
+}
+
+// txWatchTestServer creates a tbcd server for tx watch tests and returns
+// the server, a connected websocket, and a cleanup function.
+func txWatchTestServer(t *testing.T) (*Server, *websocket.Conn, *tbcWs) {
+	t.Helper()
+
+	ctx := t.Context()
+	var dupErr database.DuplicateError
+
+	cfg := &Config{
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		BlockheaderCacheSize:    "1mb",
+		BlockSanity:             false,
+		HemiIndex:               true,
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            1000,
+		MempoolEnabled:          true,
+		Network:                 networkLocalnet,
+		ListenAddress:           "127.0.0.1:0",
+		PrometheusListenAddress: "",
+		Seeds:                   []string{"192.0.2.1:8333"},
+		NotificationBlocking:    true,
+	}
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := s.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, dupErr) {
+			panic(err)
+		}
+	}()
+
+	for {
+		msg, err := l.Listen(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg.Is(NotificationBlock(chainhash.Hash{})) {
+			break
+		}
+	}
+	l.Unsubscribe()
+
+	var tbcAddr string
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+		if addr := s.HTTPAddress(); addr != nil {
+			tbcAddr = addr.String()
+			break
+		}
+	}
+
+	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.CloseNow() })
+
+	assertPing(ctx, t, c, tbcapi.CmdPingRequest)
+
+	tws := &tbcWs{conn: protocol.NewWSConn(c)}
+	return s, c, tws
+}
+
+func TestTxUnwatchThroughWebsocket(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	s, c, tws := txWatchTestServer(t)
+
+	sh := tbcd.NewScriptHashFromScript([]byte("merchant-addr"))
+
+	// Watch first.
+	if err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
+		ScriptHashes: []api.ByteSlice{sh[:]},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var resp protocol.Message
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Header.Command != tbcapi.CmdTxWatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxWatchResponse, resp.Header.Command)
+	}
+
+	// Unwatch.
+	if err := tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
+		ScriptHashes: []api.ByteSlice{sh[:]},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Header.Command != tbcapi.CmdTxUnwatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxUnwatchResponse, resp.Header.Command)
+	}
+	var unwatchResult tbcapi.TxUnwatchResponse
+	if err := json.Unmarshal(resp.Payload, &unwatchResult); err != nil {
+		t.Fatal(err)
+	}
+	if unwatchResult.Error != nil {
+		t.Fatalf("unwatch returned error: %v", unwatchResult.Error)
+	}
+
+	// Verify the unwatch took effect: notification for sh should be dropped.
+	if err := s.notifier.Notify(ctx, NotificationTxMempool(chainhash.Hash{0x01}, sh)); err != nil {
+		t.Fatal(err)
+	}
+	// Send a block as sentinel — if we get the block next, the tx was dropped.
+	if err := s.notifier.Notify(ctx, NotificationBlock(chainhash.Hash{0xff})); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+	// The push goroutine serializes all notifications as TxNotification.
+	// Check the payload Type field to verify we got the block sentinel,
+	// not the tx notification that should have been filtered out.
+	var ntfy tbcapi.TxNotification
+	if err := json.Unmarshal(resp.Payload, &ntfy); err != nil {
+		t.Fatal(err)
+	}
+	if ntfy.Type == NtfnTypeTxMempool {
+		t.Fatal("received tx_mempool after unwatch — filter did not remove script hash")
+	}
+	if ntfy.Type != NtfnTypeBlockInsert {
+		t.Fatalf("expected block_insert sentinel, got %s", ntfy.Type)
+	}
+}
+
+func TestTxUnwatchBeforeWatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	_, c, tws := txWatchTestServer(t)
+
+	// Unwatch without ever calling Watch — should succeed with no error.
+	sh := tbcd.NewScriptHashFromScript([]byte("never-watched"))
+	if err := tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
+		ScriptHashes: []api.ByteSlice{sh[:]},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var resp protocol.Message
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Header.Command != tbcapi.CmdTxUnwatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxUnwatchResponse, resp.Header.Command)
+	}
+	var result tbcapi.TxUnwatchResponse
+	if err := json.Unmarshal(resp.Payload, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Error != nil {
+		t.Fatalf("unwatch before watch returned error: %v", result.Error)
+	}
+}
+
+func TestTxWatchBadScriptHashLength(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	_, c, tws := txWatchTestServer(t)
+
+	// Send a script hash that's too short (16 bytes instead of 32).
+	if err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
+		ScriptHashes: []api.ByteSlice{make([]byte, 16)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var resp protocol.Message
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Header.Command != tbcapi.CmdTxWatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxWatchResponse, resp.Header.Command)
+	}
+	var result tbcapi.TxWatchResponse
+	if err := json.Unmarshal(resp.Payload, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Error == nil {
+		t.Fatal("expected error for bad script hash length, got nil")
+	}
+}
+
+func TestTxUnwatchBadScriptHashLength(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	_, c, tws := txWatchTestServer(t)
+
+	// Watch first so the listener exists.
+	sh := tbcd.NewScriptHashFromScript([]byte("addr"))
+	if err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
+		ScriptHashes: []api.ByteSlice{sh[:]},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var resp protocol.Message
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unwatch with bad length.
+	if err := tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
+		ScriptHashes: []api.ByteSlice{make([]byte, 5)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Header.Command != tbcapi.CmdTxUnwatchResponse {
+		t.Fatalf("expected %s, got %s", tbcapi.CmdTxUnwatchResponse, resp.Header.Command)
+	}
+	var result tbcapi.TxUnwatchResponse
+	if err := json.Unmarshal(resp.Payload, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Error == nil {
+		t.Fatal("expected error for bad unwatch script hash length, got nil")
+	}
+}
+
+func TestTxWatchExceedsLimitThroughWebsocket(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	_, c, tws := txWatchTestServer(t)
+
+	// Fill the watch set to the limit in batches (websocket has a
+	// 32KB frame limit, so we can't send all 1024 hashes at once).
+	const batch = 100
+	sent := 0
+	for sent < maxWatchScripts {
+		n := batch
+		if sent+n > maxWatchScripts {
+			n = maxWatchScripts - sent
+		}
+		hashes := make([]api.ByteSlice, n)
+		for i := range hashes {
+			sh := tbcd.NewScriptHashFromScript([]byte(fmt.Sprintf("addr-%d", sent+i)))
+			hashes[i] = sh[:]
+		}
+		id := fmt.Sprintf("w%d", sent)
+		if err := tbcapi.Write(ctx, tws.conn, id, tbcapi.TxWatchRequest{
+			ScriptHashes: hashes,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		var resp protocol.Message
+		if err := wsjson.Read(ctx, c, &resp); err != nil {
+			t.Fatal(err)
+		}
+		var result tbcapi.TxWatchResponse
+		if err := json.Unmarshal(resp.Payload, &result); err != nil {
+			t.Fatal(err)
+		}
+		if result.Error != nil {
+			t.Fatalf("batch at offset %d should succeed: %v", sent, result.Error)
+		}
+		sent += n
+	}
+
+	// One more should exceed the limit.
+	extra := tbcd.NewScriptHashFromScript([]byte("one-too-many"))
+	if err := tbcapi.Write(ctx, tws.conn, "overflow", tbcapi.TxWatchRequest{
+		ScriptHashes: []api.ByteSlice{extra[:]},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var resp protocol.Message
+	if err := wsjson.Read(ctx, c, &resp); err != nil {
+		t.Fatal(err)
+	}
+	var result tbcapi.TxWatchResponse
+	if err := json.Unmarshal(resp.Payload, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Error == nil {
+		t.Fatal("expected error for exceeding watch limit, got nil")
+	}
+}
+
+func TestNotifyTxOutputsNoListeners(t *testing.T) {
+	ctx := t.Context()
+	s := &Server{
+		notifier: NewNotifier(false),
+	}
+	// No listeners — should return immediately without panic.
+	tx := &wire.MsgTx{
+		TxOut: []*wire.TxOut{
+			{PkScript: []byte{0x00, 0x14, 0x01}},
+		},
+	}
+	s.notifyTxOutputs(ctx, tx, tx.TxHash(), NotificationTxMempool)
+}
+
+func TestNotifyTxOutputsContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	s := &Server{
+		notifier: NewNotifier(true),
+	}
+
+	l, err := s.notifier.Subscribe(ctx, 1) // capacity 1 — will block on second
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	tx := &wire.MsgTx{
+		TxOut: []*wire.TxOut{
+			{PkScript: []byte{0x00, 0x14, 0x01}},
+			{PkScript: []byte{0x00, 0x14, 0x02}},
+		},
+	}
+
+	// Cancel context before notification — Notify should fail.
+	cancel()
+	s.notifyTxOutputs(ctx, tx, tx.TxHash(), NotificationTxMempool)
+	// Should not panic; the error path logs and returns.
+}

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -109,9 +109,10 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRawRequest{
 		Height: 55,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -180,9 +181,10 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 55,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -244,9 +246,10 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlockHeadersByHeightRequest{
 		Height: 550,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -540,9 +543,10 @@ func TestBalanceByAddress(t *testing.T) {
 				}
 				indexAll(ctx, t, tbcServer)
 
-				if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
+				err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BalanceByAddressRequest{
 					Address: tti.address(),
-				}); err != nil {
+				})
+				if err != nil {
 					t.Fatal(err)
 				}
 
@@ -762,11 +766,12 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UTXOsByAddressRawRequest{
+			err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UTXOsByAddressRawRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
-			}); err != nil {
+			})
+			if err != nil {
 				t.Fatal(err)
 			}
 
@@ -971,11 +976,12 @@ func TestUtxosByAddress(t *testing.T) {
 			}
 			indexAll(ctx, t, tbcServer)
 
-			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UTXOsByAddressRequest{
+			err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.UTXOsByAddressRequest{
 				Address: tti.address(),
 				Start:   uint(tti.start),
 				Count:   uint(tti.limit),
-			}); err != nil {
+			})
+			if err != nil {
 				t.Fatal(err)
 			}
 
@@ -1049,9 +1055,10 @@ func TestTxByIdRaw(t *testing.T) {
 
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxID: *txId,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1132,9 +1139,10 @@ func TestTxByIdRawInvalid(t *testing.T) {
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
 	txId[0]++
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxID: *txId,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1221,9 +1229,10 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
 	txId[len(txId)-1] = 8
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
 		TxID: *txId,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1296,9 +1305,10 @@ func TestTxById(t *testing.T) {
 	indexAll(ctx, t, tbcServer)
 
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxID: *txId,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1375,9 +1385,10 @@ func TestTxByIdInvalid(t *testing.T) {
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
 	txId[0]++
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxID: *txId,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1854,9 +1865,10 @@ func TestTxByIdNotFound(t *testing.T) {
 	txId := getRandomTxId(ctx, t, bitcoindContainer)
 	txId[len(txId)-1] = 8
 
-	if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
 		TxID: *txId,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -1984,9 +1996,10 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlocksByL2AbrevHashesRequest{
+			err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.BlocksByL2AbrevHashesRequest{
 				L2KeystoneAbrevHashes: []chainhash.Hash{*tti.l2KeystoneAbrevHash},
-			}); err != nil {
+			})
+			if err != nil {
 				t.Fatal(err)
 			}
 
@@ -2396,9 +2409,10 @@ func TestTxWatchNotification(t *testing.T) {
 	watchedSH := tbcd.NewScriptHashFromScript(watchedScript)
 
 	// Send TxWatch request.
-	if err := tbcapi.Write(ctx, tws.conn, "watch-1", tbcapi.TxWatchRequest{
+	err = tbcapi.Write(ctx, tws.conn, "watch-1", tbcapi.TxWatchRequest{
 		ScriptHashes: []api.ByteSlice{watchedSH[:]},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -2520,9 +2534,10 @@ func TestTxWatchFilterDrop(t *testing.T) {
 	shA := tbcd.NewScriptHashFromScript([]byte("address-A"))
 	shB := tbcd.NewScriptHashFromScript([]byte("address-B"))
 
-	if err := tbcapi.Write(ctx, tws.conn, "watch-1", tbcapi.TxWatchRequest{
+	err = tbcapi.Write(ctx, tws.conn, "watch-1", tbcapi.TxWatchRequest{
 		ScriptHashes: []api.ByteSlice{shA[:]},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -2645,9 +2660,10 @@ func TestTxUnwatchThroughWebsocket(t *testing.T) {
 	sh := tbcd.NewScriptHashFromScript([]byte("merchant-addr"))
 
 	// Watch first.
-	if err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
+	err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
 		ScriptHashes: []api.ByteSlice{sh[:]},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	var resp protocol.Message
@@ -2659,9 +2675,10 @@ func TestTxUnwatchThroughWebsocket(t *testing.T) {
 	}
 
 	// Unwatch.
-	if err := tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
+	err = tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
 		ScriptHashes: []api.ByteSlice{sh[:]},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	if err := wsjson.Read(ctx, c, &resp); err != nil {
@@ -2712,9 +2729,10 @@ func TestTxUnwatchBeforeWatch(t *testing.T) {
 
 	// Unwatch without ever calling Watch — should succeed with no error.
 	sh := tbcd.NewScriptHashFromScript([]byte("never-watched"))
-	if err := tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
+	err := tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
 		ScriptHashes: []api.ByteSlice{sh[:]},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	var resp protocol.Message
@@ -2740,9 +2758,10 @@ func TestTxWatchBadScriptHashLength(t *testing.T) {
 	_, c, tws := txWatchTestServer(t)
 
 	// Send a script hash that's too short (16 bytes instead of 32).
-	if err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
+	err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
 		ScriptHashes: []api.ByteSlice{make([]byte, 16)},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	var resp protocol.Message
@@ -2769,9 +2788,10 @@ func TestTxUnwatchBadScriptHashLength(t *testing.T) {
 
 	// Watch first so the listener exists.
 	sh := tbcd.NewScriptHashFromScript([]byte("addr"))
-	if err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
+	err := tbcapi.Write(ctx, tws.conn, "w1", tbcapi.TxWatchRequest{
 		ScriptHashes: []api.ByteSlice{sh[:]},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	var resp protocol.Message
@@ -2780,9 +2800,10 @@ func TestTxUnwatchBadScriptHashLength(t *testing.T) {
 	}
 
 	// Unwatch with bad length.
-	if err := tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
+	err = tbcapi.Write(ctx, tws.conn, "u1", tbcapi.TxUnwatchRequest{
 		ScriptHashes: []api.ByteSlice{make([]byte, 5)},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	if err := wsjson.Read(ctx, c, &resp); err != nil {
@@ -2821,9 +2842,10 @@ func TestTxWatchExceedsLimitThroughWebsocket(t *testing.T) {
 			hashes[i] = sh[:]
 		}
 		id := fmt.Sprintf("w%d", sent)
-		if err := tbcapi.Write(ctx, tws.conn, id, tbcapi.TxWatchRequest{
+		err := tbcapi.Write(ctx, tws.conn, id, tbcapi.TxWatchRequest{
 			ScriptHashes: hashes,
-		}); err != nil {
+		})
+		if err != nil {
 			t.Fatal(err)
 		}
 		var resp protocol.Message
@@ -2842,9 +2864,10 @@ func TestTxWatchExceedsLimitThroughWebsocket(t *testing.T) {
 
 	// One more should exceed the limit.
 	extra := tbcd.NewScriptHashFromScript([]byte("one-too-many"))
-	if err := tbcapi.Write(ctx, tws.conn, "overflow", tbcapi.TxWatchRequest{
+	err := tbcapi.Write(ctx, tws.conn, "overflow", tbcapi.TxWatchRequest{
 		ScriptHashes: []api.ByteSlice{extra[:]},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	var resp protocol.Message

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Copyright (c) 2024-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -1246,7 +1246,33 @@ func (s *Server) handleTx(ctx context.Context, p *rawpeer.RawPeer, msg *wire.Msg
 	if err != nil {
 		return fmt.Errorf("new mempool tx: %w", err)
 	}
-	return s.mempool.TxInsert(ctx, mptx)
+	if err := s.mempool.TxInsert(ctx, mptx); err != nil {
+		return err
+	}
+
+	s.notifyTxOutputs(ctx, msg, msg.TxHash(), NotificationTxMempool)
+
+	return nil
+}
+
+// notifyTxOutputs fires a notification for each TxOut in tx, using the
+// provided constructor function.  The constructor is either
+// NotificationTxMempool or a closure wrapping NotificationTxConfirmed.
+// Only fires if there are active listeners.
+func (s *Server) notifyTxOutputs(ctx context.Context, tx *wire.MsgTx, txid chainhash.Hash, mkNote func(chainhash.Hash, tbcd.ScriptHash) Notification) {
+	if !s.notifier.HasListeners() {
+		return
+	}
+	for _, txOut := range tx.TxOut {
+		if txscript.IsUnspendable(txOut.PkScript) {
+			continue
+		}
+		sh := tbcd.NewScriptHashFromScript(txOut.PkScript)
+		if err := s.notifier.Notify(ctx, mkNote(txid, sh)); err != nil {
+			log.Debugf("notify tx output: %v", err)
+			return
+		}
+	}
 }
 
 func (s *Server) syncBlocks(ctx context.Context) {
@@ -1752,6 +1778,18 @@ func (s *Server) handleBlock(ctx context.Context, p *rawpeer.RawPeer, msg *wire.
 		}
 	}
 	s.mtx.Unlock()
+
+	// Notify listeners about confirmed transactions.
+	if s.notifier.HasListeners() {
+		blockHash := *block.Hash()
+		for _, tx := range msg.Transactions {
+			txid := tx.TxHash()
+			mkNote := func(id chainhash.Hash, sh tbcd.ScriptHash) Notification {
+				return NotificationTxConfirmed(id, blockHash, height, sh)
+			}
+			s.notifyTxOutputs(ctx, tx, txid, mkNote)
+		}
+	}
 
 	// Reap txs from mempool for blocks that are within defaultMempoolAge.
 	// Sync flag is always false here so don't check it, just remove tx's
@@ -2378,6 +2416,8 @@ func (s *Server) TxBroadcast(ctx context.Context, tx *wire.MsgTx, force bool) (*
 			log.Errorf("mempool tx: %w", err)
 		} else if err := s.mempool.TxInsert(ctx, mptx); err != nil {
 			log.Errorf("broadcast mempool tx: %w", err)
+		} else {
+			s.notifyTxOutputs(ctx, tx, txHash, NotificationTxMempool)
 		}
 	}
 


### PR DESCRIPTION
Add per-listener ScriptHash watch filters to the tbcd notification system. Clients connect via websocket, call TxWatch with a list of script hashes (addresses), and receive push notifications when matching transactions hit the mempool or are confirmed in a block.

This is the notification layer instead of polling UTXOsByAddress.