### PR TITLE
tbc: add mempool UTXOs RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Continuum Transfuctioner protocol and daemon to handle threshold signatures ([#752](https://github.com/hemilabs/heminetwork/pull/752)).
 - Add Trust, rust version of TBC Headers only mode ([#970](https://github.com/hemilabs/heminetwork/pull/970))
 - Add Authenticated RPC route for administrative requests to TBC ([#1003](https://github.com/hemilabs/heminetwork/pull/1003)).
+- Add `MempoolUtxos` RPC command returning unspent mempool outputs matching a required set of script hashes
+  ([#987](https://github.com/hemilabs/heminetwork/pull/987)).
 
 ### Changed
 

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -26,15 +26,10 @@ const (
 	APIVersion = 1
 
 	// MaxResponseSize is the maximum serialized JSON response
-	// size for bulk RPC responses (e.g. blocks).  Must match the
-	// client's websocket ReadLimit.  The tbcgozer client sets
-	// ReadLimit to this value; other clients must set their read
-	// limit to at least this size.
-	//
-	// The previous default of 6 MiB was insufficient for worst-
-	// case blocks (4 MB raw, 8 MB hex-encoded via api.ByteSlice).
-	// 16 MiB accommodates the largest possible Bitcoin block with
-	// JSON overhead.
+	// size for bulk RPC responses (e.g. MempoolUtxos, blocks).
+	// Must match the client's websocket ReadLimit.  The tbcgozer
+	// client sets ReadLimit to this value; other clients must
+	// set their read limit to at least this size.
 	MaxResponseSize = 16 * (1 << 20) // 16 MiB
 
 	CmdPingRequest  = "tbcapi-ping-request"
@@ -102,6 +97,9 @@ const (
 
 	CmdMempoolInfoRequest  = "tbcapi-mempool-info-request"
 	CmdMempoolInfoResponse = "tbcapi-mempool-info-response"
+
+	CmdMempoolUtxosRequest  = "tbcapi-mempool-utxos-request"
+	CmdMempoolUtxosResponse = "tbcapi-mempool-utxos-response"
 
 	CmdKeystonesByHeightRequest  = "tbcapi-keystones-by-height-request"
 	CmdKeystonesByHeightResponse = "tbcapi-keystones-by-height-response"
@@ -429,6 +427,40 @@ type MempoolInfoResponse struct {
 	Error *protocol.Error `json:"error,omitempty"`
 }
 
+// MempoolUtxosRequest requests unspent outputs currently in the mempool
+// that match the provided script hashes.  ScriptHashes is required and
+// must contain at least one entry; each must be exactly 32 bytes
+// (sha256 of the output's pkScript).
+type MempoolUtxosRequest struct {
+	ScriptHashes []api.ByteSlice `json:"script_hashes"`
+}
+
+// MempoolUTXO is an output from an unconfirmed mempool transaction.
+type MempoolUTXO struct {
+	// TxId is the transaction hash containing this output.
+	TxId chainhash.Hash `json:"tx_id"`
+
+	// Value is the output amount in satoshis.
+	Value btcutil.Amount `json:"value"`
+
+	// OutIndex is the index of this output within the transaction.
+	OutIndex uint32 `json:"out_index"`
+
+	// ScriptHash is sha256 of the output's pkScript.  Callers
+	// match this against sha256(PayToAddrScript(addr)) to find
+	// outputs at a given address.
+	ScriptHash chainhash.Hash `json:"script_hash"`
+}
+
+// MempoolUtxosResponse contains unspent mempool outputs matching the
+// requested script hashes, plus all outpoints being spent by mempool
+// transactions.
+type MempoolUtxosResponse struct {
+	UTXOs          []*MempoolUTXO  `json:"utxos"`
+	SpentOutpoints []OutPoint      `json:"spent_outpoints"`
+	Error          *protocol.Error `json:"error,omitempty"`
+}
+
 type ZKValueAndScriptByOutpointRequest struct {
 	Outpoint OutPoint `json:"outpoint"`
 }
@@ -551,6 +583,8 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdFeeEstimateResponse:                      reflect.TypeFor[FeeEstimateResponse](),
 	CmdMempoolInfoRequest:                       reflect.TypeFor[MempoolInfoRequest](),
 	CmdMempoolInfoResponse:                      reflect.TypeFor[MempoolInfoResponse](),
+	CmdMempoolUtxosRequest:                      reflect.TypeFor[MempoolUtxosRequest](),
+	CmdMempoolUtxosResponse:                     reflect.TypeFor[MempoolUtxosResponse](),
 	CmdKeystonesByHeightRequest:                 reflect.TypeFor[KeystonesByHeightRequest](),
 	CmdKeystonesByHeightResponse:                reflect.TypeFor[KeystonesByHeightResponse](),
 	CmdZKValueAndScriptByOutpointRequest:        reflect.TypeFor[ZKValueAndScriptByOutpointRequest](),

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Copyright (c) 2024-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -24,6 +24,18 @@ import (
 
 const (
 	APIVersion = 1
+
+	// MaxResponseSize is the maximum serialized JSON response
+	// size for bulk RPC responses (e.g. blocks).  Must match the
+	// client's websocket ReadLimit.  The tbcgozer client sets
+	// ReadLimit to this value; other clients must set their read
+	// limit to at least this size.
+	//
+	// The previous default of 6 MiB was insufficient for worst-
+	// case blocks (4 MB raw, 8 MB hex-encoded via api.ByteSlice).
+	// 16 MiB accommodates the largest possible Bitcoin block with
+	// JSON overhead.
+	MaxResponseSize = 16 * (1 << 20) // 16 MiB
 
 	CmdPingRequest  = "tbcapi-ping-request"
 	CmdPingResponse = "tbcapi-ping-response"

--- a/bitcoin/wallet/gozer/blockstream/blockstream.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 
+	"github.com/hemilabs/heminetwork/v2/api"
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer"
@@ -193,6 +194,11 @@ func (bs *blockstreamGozer) UtxosByAddress(ctx context.Context, filterMempool bo
 		})
 	}
 	return urv, nil
+}
+
+// MempoolUtxos is not supported by the Blockstream backend.
+func (bs *blockstreamGozer) MempoolUtxos(_ context.Context, _ []api.ByteSlice) (*tbcapi.MempoolUtxosResponse, error) {
+	return nil, errors.New("mempool utxos not supported by blockstream")
 }
 
 func (bs *blockstreamGozer) BlocksByL2AbrevHashes(ctx context.Context, hashes []chainhash.Hash) *gozer.BlocksByL2AbrevHashesResponse {

--- a/bitcoin/wallet/gozer/filter_test.go
+++ b/bitcoin/wallet/gozer/filter_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package gozer
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+
+	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
+)
+
+func TestFilterSpent(t *testing.T) {
+	h1 := chainhash.HashH([]byte("tx1"))
+	h2 := chainhash.HashH([]byte("tx2"))
+	h3 := chainhash.HashH([]byte("tx3"))
+
+	utxos := []*tbcapi.MempoolUTXO{
+		{TxId: h1, OutIndex: 0, Value: 1000},
+		{TxId: h1, OutIndex: 1, Value: 2000},
+		{TxId: h2, OutIndex: 0, Value: 3000},
+		{TxId: h3, OutIndex: 0, Value: 4000},
+	}
+
+	t.Run("no spent", func(t *testing.T) {
+		result := FilterSpent(utxos, nil)
+		if len(result) != 4 {
+			t.Fatalf("got %d, want 4", len(result))
+		}
+	})
+
+	t.Run("one spent", func(t *testing.T) {
+		spent := []tbcapi.OutPoint{{Hash: h1, Index: 0}}
+		result := FilterSpent(utxos, spent)
+		if len(result) != 3 {
+			t.Fatalf("got %d, want 3", len(result))
+		}
+		for _, u := range result {
+			if u.TxId == h1 && u.OutIndex == 0 {
+				t.Fatal("spent utxo should be excluded")
+			}
+		}
+	})
+
+	t.Run("multiple spent", func(t *testing.T) {
+		spent := []tbcapi.OutPoint{
+			{Hash: h1, Index: 0},
+			{Hash: h2, Index: 0},
+		}
+		result := FilterSpent(utxos, spent)
+		if len(result) != 2 {
+			t.Fatalf("got %d, want 2", len(result))
+		}
+		var total int64
+		for _, u := range result {
+			total += int64(u.Value)
+		}
+		if total != 6000 {
+			t.Errorf("total = %d, want 6000", total)
+		}
+	})
+
+	t.Run("all spent", func(t *testing.T) {
+		spent := []tbcapi.OutPoint{
+			{Hash: h1, Index: 0},
+			{Hash: h1, Index: 1},
+			{Hash: h2, Index: 0},
+			{Hash: h3, Index: 0},
+		}
+		result := FilterSpent(utxos, spent)
+		if len(result) != 0 {
+			t.Fatalf("got %d, want 0", len(result))
+		}
+	})
+}

--- a/bitcoin/wallet/gozer/gozer.go
+++ b/bitcoin/wallet/gozer/gozer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -29,6 +29,7 @@ import (
 type Gozer interface {
 	FeeEstimates(ctx context.Context) ([]*tbcapi.FeeEstimate, error)
 	UtxosByAddress(ctx context.Context, filterMempool bool, addr btcutil.Address, start, count uint) ([]*tbcapi.UTXO, error)
+	MempoolUtxos(ctx context.Context, scriptHashes []api.ByteSlice) (*tbcapi.MempoolUtxosResponse, error)
 	BlocksByL2AbrevHashes(ctx context.Context, hashes []chainhash.Hash) *BlocksByL2AbrevHashesResponse
 	KeystonesByHeight(ctx context.Context, height uint32, depth int) (*KeystonesByHeightResponse, error)
 	BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.Hash, error)
@@ -142,4 +143,29 @@ type KeystonesByHeightResponse struct {
 	L2KeystoneAbrevs []*hemi.L2KeystoneAbrev `json:"l2_keystone_abrevs"`
 	BTCTipHeight     uint64                  `json:"btc_tip_height"`
 	Error            *protocol.Error         `json:"error,omitempty"`
+}
+
+// FilterSpent removes mempool UTXOs whose outpoint (TxId:OutIndex)
+// appears in the spent set.  Use this to exclude outputs that have
+// been spent by another mempool transaction (CPFP chains).
+func FilterSpent(utxos []*tbcapi.MempoolUTXO, spent []tbcapi.OutPoint) []*tbcapi.MempoolUTXO {
+	if len(spent) == 0 {
+		return utxos
+	}
+	type op struct {
+		Hash  chainhash.Hash
+		Index uint32
+	}
+	set := make(map[op]struct{}, len(spent))
+	for _, s := range spent {
+		set[op{Hash: s.Hash, Index: s.Index}] = struct{}{}
+	}
+	var out []*tbcapi.MempoolUTXO
+	for _, u := range utxos {
+		if _, ok := set[op{Hash: u.TxId, Index: u.OutIndex}]; ok {
+			continue
+		}
+		out = append(out, u)
+	}
+	return out
 }

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -378,7 +378,7 @@ func (t *tbcGozer) connectTBC(pctx context.Context, connected func()) error {
 	defer log.Tracef("connectTBC exit")
 
 	conn, err := protocol.NewConn(t.url, &protocol.ConnOptions{
-		ReadLimit: 6 * (1 << 20), // 6 MiB
+		ReadLimit: tbcapi.MaxResponseSize,
 	})
 	if err != nil {
 		return err

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/juju/loggo/v2"
 
+	"github.com/hemilabs/heminetwork/v2/api"
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer"
@@ -181,6 +182,28 @@ func (t *tbcGozer) UtxosByAddress(ctx context.Context, filterMempool bool, addr 
 	}
 
 	return buResp.UTXOs, nil
+}
+
+// MempoolUtxos returns unspent mempool outputs via the TBC websocket API.
+// scriptHashes is required — only outputs matching those script hashes
+// are returned.
+func (t *tbcGozer) MempoolUtxos(ctx context.Context, scriptHashes []api.ByteSlice) (*tbcapi.MempoolUtxosResponse, error) {
+	res, err := t.callTBC(ctx, DefaultRequestTimeout, &tbcapi.MempoolUtxosRequest{
+		ScriptHashes: scriptHashes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, ok := res.(*tbcapi.MempoolUtxosResponse)
+	if !ok {
+		return nil, fmt.Errorf("not a mempool utxos response %T", res)
+	}
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return resp, nil
 }
 
 func (t *tbcGozer) BlocksByL2AbrevHashes(ctx context.Context, hashes []chainhash.Hash) *gozer.BlocksByL2AbrevHashesResponse {

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -15,9 +15,13 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/juju/loggo/v2"
 
+	"github.com/hemilabs/heminetwork/v2/api"
 	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer"
+	"github.com/hemilabs/heminetwork/v2/database/tbcd"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil/mock"
 	"github.com/hemilabs/heminetwork/v2/service/tbc"
@@ -84,7 +88,7 @@ func TestTBCGozerConnection(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
-		case <-time.Tick(50 * time.Millisecond):
+		case <-time.After(50 * time.Millisecond):
 		}
 	}
 	t.Logf("gozer connected")
@@ -156,7 +160,7 @@ func TestTBCGozerCalls(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
-		case <-time.Tick(50 * time.Millisecond):
+		case <-time.After(50 * time.Millisecond):
 		}
 	}
 	t.Logf("gozer connected")
@@ -275,4 +279,122 @@ func TestTBCGozerCalls(t *testing.T) {
 	if cc != qd {
 		t.Fatalf("cc %v != qd %v", cc, qd)
 	}
+}
+
+func TestTBCGozerMempoolUtxos(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	kssMap, kssList := testutil.MakeSharedKeystones(5)
+	btcTip := uint(kssList[len(kssList)-1].L1BlockNumber)
+
+	mtbc := mock.NewMockTBC(ctx, nil, nil, kssMap, btcTip, 10)
+	defer mtbc.Shutdown()
+
+	DefaultRequestTimeout = 10 * time.Second
+	b := New("ws" + strings.TrimPrefix(mtbc.URL(), "http"))
+	if err := b.Run(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tg, ok := b.(*tbcGozer)
+	if !ok {
+		t.Fatal("expected gozer to be of type tbcGozer")
+	}
+
+	for !tg.Connected() {
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// Script used in the test transaction below.
+	testScript := []byte{
+		0x00, 0x14, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+		0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+	}
+	opTrueScript := []byte{0x51}
+	sh1 := tbcd.NewScriptHashFromScript(testScript)
+	sh2 := tbcd.NewScriptHashFromScript(opTrueScript)
+	allHashes := []api.ByteSlice{sh1[:], sh2[:]}
+
+	t.Run("empty mempool", func(t *testing.T) {
+		resp, err := b.MempoolUtxos(ctx, allHashes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.UTXOs) != 0 {
+			t.Errorf("got %d utxos, want 0", len(resp.UTXOs))
+		}
+		if len(resp.SpentOutpoints) != 0 {
+			t.Errorf("got %d spent, want 0", len(resp.SpentOutpoints))
+		}
+	})
+
+	// Broadcast a tx to populate the mempool.
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("funding")),
+			Index: 0,
+		},
+	})
+	tx.AddTxOut(wire.NewTxOut(50000, []byte{
+		0x00, 0x14, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+		0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+	}))
+	tx.AddTxOut(wire.NewTxOut(10000, []byte{0x51}))
+
+	if _, err := b.BroadcastTx(ctx, tx); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("after broadcast", func(t *testing.T) {
+		resp, err := b.MempoolUtxos(ctx, allHashes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.UTXOs) != 2 {
+			t.Fatalf("got %d utxos, want 2", len(resp.UTXOs))
+		}
+		if len(resp.SpentOutpoints) != 1 {
+			t.Fatalf("got %d spent, want 1", len(resp.SpentOutpoints))
+		}
+
+		// Verify values.
+		var total btcutil.Amount
+		for _, u := range resp.UTXOs {
+			total += u.Value
+		}
+		if total != 60000 {
+			t.Errorf("total = %d, want 60000", total)
+		}
+
+		// Verify script hashes are non-zero.
+		for _, u := range resp.UTXOs {
+			var zero chainhash.Hash
+			if u.ScriptHash == zero {
+				t.Error("script hash is zero")
+			}
+		}
+	})
+
+	t.Run("FilterSpent integration", func(t *testing.T) {
+		resp, err := b.MempoolUtxos(ctx, allHashes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// No outputs are spent by another mempool tx, so
+		// FilterSpent should return all of them.
+		filtered := gozer.FilterSpent(resp.UTXOs, resp.SpentOutpoints)
+		if len(filtered) != len(resp.UTXOs) {
+			t.Fatalf("FilterSpent: got %d, want %d",
+				len(filtered), len(resp.UTXOs))
+		}
+	})
 }

--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
@@ -151,8 +150,7 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 			break
 		}
 
-		opp := pl.Tx.TxIn[0].PreviousOutPoint
-		mptx := tbc.NewMempoolTx(*ch, map[wire.OutPoint]struct{}{opp: {}})
+		mptx := tbc.NewMempoolTx(pl.Tx)
 		err = mp.TxInsert(f.pctx, &mptx)
 		if err != nil {
 			panic(fmt.Errorf("mempool tx insert: %w", err))
@@ -241,6 +239,43 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 				L2KeystoneAbrevs: kssList,
 				BTCTipHeight:     uint64(f.btcTip),
 			}
+		}
+	case tbcapi.CmdMempoolUtxosRequest:
+		req := payload.(*tbcapi.MempoolUtxosRequest)
+		if len(req.ScriptHashes) == 0 {
+			resp = &tbcapi.MempoolUtxosResponse{
+				Error: protocol.RequestErrorf("script_hashes is required"),
+			}
+			break
+		}
+		filter := make(map[tbcd.ScriptHash]struct{}, len(req.ScriptHashes))
+		for _, raw := range req.ScriptHashes {
+			var sh tbcd.ScriptHash
+			copy(sh[:], raw)
+			filter[sh] = struct{}{}
+		}
+		utxos, shs, spent, err := mp.UnconfirmedUtxos(f.pctx)
+		if err != nil {
+			panic(fmt.Errorf("unconfirmed utxos: %w", err))
+		}
+		var mempoolUtxos []*tbcapi.MempoolUTXO
+		for i, sh := range shs {
+			if _, ok := filter[sh]; ok {
+				mempoolUtxos = append(mempoolUtxos, &tbcapi.MempoolUTXO{
+					TxId:       *utxos[i].ChainHash(),
+					Value:      btcutil.Amount(utxos[i].Value()),
+					OutIndex:   utxos[i].OutputIndex(),
+					ScriptHash: chainhash.Hash(sh),
+				})
+			}
+		}
+		spentOps := make([]tbcapi.OutPoint, len(spent))
+		for i, op := range spent {
+			spentOps[i] = tbcapi.OutPoint{Hash: op.Hash, Index: op.Index}
+		}
+		resp = &tbcapi.MempoolUtxosResponse{
+			UTXOs:          mempoolUtxos,
+			SpentOutpoints: spentOps,
 		}
 	default:
 		panic(fmt.Errorf("unknown command: %v", cmd))

--- a/service/tbc/mempool.go
+++ b/service/tbc/mempool.go
@@ -27,11 +27,18 @@ type MempoolTx struct {
 	size     int64                      // transaction virtual size
 	inValue  int64                      // total txin value
 	outValue int64                      // total txout value
-	txins    map[wire.OutPoint]struct{} // txins in transaction
+	tx       *wire.MsgTx                // full transaction
+	txins    map[wire.OutPoint]struct{} // spent outpoints for O(1) lookup
 }
 
-func NewMempoolTx(id chainhash.Hash, txins map[wire.OutPoint]struct{}) MempoolTx {
-	return MempoolTx{id: id, txins: txins}
+// NewMempoolTx creates a MempoolTx from a wire transaction, computing
+// the txid and building the spent-outpoint map for O(1) inMempool lookups.
+func NewMempoolTx(tx *wire.MsgTx) MempoolTx {
+	txins := make(map[wire.OutPoint]struct{}, len(tx.TxIn))
+	for _, txIn := range tx.TxIn {
+		txins[txIn.PreviousOutPoint] = struct{}{}
+	}
+	return MempoolTx{id: tx.TxHash(), tx: tx, txins: txins}
 }
 
 type Mempool struct {
@@ -55,12 +62,10 @@ func (m *Mempool) inMempool(utxo tbcd.Utxo) bool {
 	opp := wire.NewOutPoint(utxo.ChainHash(), utxo.OutputIndex())
 	op := *opp
 	for _, tx := range m.txs {
-		// Skip tx that aren't fully in the mempool yet.
-		if tx == nil {
+		if tx == nil || tx.tx == nil {
 			continue
 		}
 		if _, ok := tx.txins[op]; ok {
-			// Found in txins.
 			return true
 		}
 	}
@@ -93,6 +98,36 @@ func (m *Mempool) FilterUtxos(ctx context.Context, utxos []tbcd.Utxo) ([]tbcd.Ut
 	// }
 	// return out
 	return slices.DeleteFunc(utxos[:], m.inMempool), nil
+}
+
+// UnconfirmedUtxos returns all outputs from mempool transactions
+// with their script hashes, plus all outpoints being spent by
+// mempool transactions.
+func (m *Mempool) UnconfirmedUtxos(ctx context.Context) ([]tbcd.Utxo, []tbcd.ScriptHash, []wire.OutPoint, error) {
+	log.Tracef("UnconfirmedUtxos")
+	defer log.Tracef("UnconfirmedUtxos exit")
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	// Estimate 2 outputs and 2 inputs per tx on average.
+	est := len(m.txs) * 2
+	utxos := make([]tbcd.Utxo, 0, est)
+	shs := make([]tbcd.ScriptHash, 0, est)
+	spent := make([]wire.OutPoint, 0, est)
+	for _, mptx := range m.txs {
+		if mptx == nil || mptx.tx == nil {
+			continue
+		}
+		for i, out := range mptx.tx.TxOut {
+			utxos = append(utxos, tbcd.NewUtxo(mptx.id, uint64(out.Value), uint32(i)))
+			shs = append(shs, tbcd.NewScriptHashFromScript(out.PkScript))
+		}
+		for _, txIn := range mptx.tx.TxIn {
+			spent = append(spent, txIn.PreviousOutPoint)
+		}
+	}
+	return utxos, shs, spent, nil
 }
 
 func (m *Mempool) getDataConstruct(ctx context.Context) (*wire.MsgGetData, error) {

--- a/service/tbc/mempool.go
+++ b/service/tbc/mempool.go
@@ -72,6 +72,24 @@ func (m *Mempool) inMempool(utxo tbcd.Utxo) bool {
 	return false
 }
 
+// txOutByOutpoint looks up a transaction output in the mempool by
+// its outpoint (txid + output index).  This enables CPFP: a child
+// transaction can resolve its inputs from an unconfirmed parent
+// that is already in the mempool.
+func (m *Mempool) txOutByOutpoint(txid chainhash.Hash, index uint32) *wire.TxOut {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	mptx, ok := m.txs[txid]
+	if !ok || mptx == nil || mptx.tx == nil {
+		return nil
+	}
+	if int(index) >= len(mptx.tx.TxOut) {
+		return nil
+	}
+	return mptx.tx.TxOut[index]
+}
+
 func (m *Mempool) FilterUtxos(ctx context.Context, utxos []tbcd.Utxo) ([]tbcd.Utxo, error) {
 	log.Tracef("filterUtxos")
 	defer log.Tracef("filterUtxos exit")

--- a/service/tbc/mempool_test.go
+++ b/service/tbc/mempool_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-test/deep"
 
+	"github.com/hemilabs/heminetwork/v2/api"
+	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/database/tbcd"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil"
 )
@@ -281,11 +283,11 @@ func TestMempoolFiltering(t *testing.T) {
 
 		if len(utxos) > numToFilter {
 			opp := wire.NewOutPoint(ch, 0)
-			mptx := MempoolTx{
-				id:      *ch,
-				expires: time.Now().Add(1 * time.Hour),
-				txins:   map[wire.OutPoint]struct{}{*opp: {}},
-			}
+			msgTx := wire.NewMsgTx(2)
+			msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: *opp})
+			mptx := NewMempoolTx(msgTx)
+			mptx.id = *ch
+			mptx.expires = time.Now().Add(1 * time.Hour)
 			if err = mp.TxInsert(ctx, &mptx); err != nil {
 				t.Fatal(err)
 			}
@@ -321,11 +323,7 @@ func BenchmarkMempoolFilter(b *testing.B) {
 				txIdBytes := make([]byte, 32)
 				binary.BigEndian.PutUint32(txIdBytes[0:32], uint32(k))
 				txId := testutil.Bytes2Hash(txIdBytes)
-				mptx := MempoolTx{
-					id:      *txId,
-					expires: time.Now().Add(10 * time.Hour),
-					txins:   make(map[wire.OutPoint]struct{}),
-				}
+				msgTx := wire.NewMsgTx(2)
 				// Create utxo and add it to the MempoolTx
 				for i := range txInNum {
 					uniqueBytes := make([]byte, 32)
@@ -336,8 +334,11 @@ func BenchmarkMempoolFilter(b *testing.B) {
 					utxos = append(utxos, utxo)
 
 					opp := wire.NewOutPoint(utxo.ChainHash(), utxo.OutputIndex())
-					mptx.txins[*opp] = struct{}{}
+					msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: *opp})
 				}
+				mptx := NewMempoolTx(msgTx)
+				mptx.id = *txId
+				mptx.expires = time.Now().Add(10 * time.Hour)
 				if err = mp.TxInsert(b.Context(), &mptx); err != nil {
 					b.Fatal(err)
 				}
@@ -376,4 +377,569 @@ func createTxs(count int, expiration time.Time, increase time.Duration) []Mempoo
 	}
 
 	return txs
+}
+
+func TestUnconfirmedUtxos(t *testing.T) {
+	ctx := t.Context()
+
+	script1 := []byte{
+		0x00, 0x14, 0xca, 0xfe, 0xba, 0xbe, 0x01, 0x02,
+		0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+	script2 := []byte{
+		0x00, 0x14, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x02,
+		0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+	sh1 := tbcd.NewScriptHashFromScript(script1)
+	sh2 := tbcd.NewScriptHashFromScript(script2)
+
+	t.Run("empty mempool", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+		utxos, shs, _, err := mp.UnconfirmedUtxos(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(utxos) != 0 || len(shs) != 0 {
+			t.Fatalf("empty mempool: got %d utxos, %d shs", len(utxos), len(shs))
+		}
+	})
+
+	t.Run("returns all outputs with script hashes", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: *testutil.String2Hash("aa"), Index: 0,
+			},
+		})
+		tx.AddTxOut(wire.NewTxOut(50000, script1))
+		tx.AddTxOut(wire.NewTxOut(10000, script2))
+
+		err = mp.TxInsert(ctx, &MempoolTx{
+			id: tx.TxHash(), expires: time.Now().Add(time.Hour), tx: tx,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		utxos, shs, _, err := mp.UnconfirmedUtxos(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(utxos) != 2 {
+			t.Fatalf("got %d utxos, want 2", len(utxos))
+		}
+		if len(shs) != 2 {
+			t.Fatalf("got %d script hashes, want 2", len(shs))
+		}
+
+		// Verify script hashes match outputs.
+		found := map[tbcd.ScriptHash]uint64{}
+		for i, u := range utxos {
+			found[shs[i]] = u.Value()
+		}
+		if found[sh1] != 50000 {
+			t.Errorf("script1 value = %d, want 50000", found[sh1])
+		}
+		if found[sh2] != 10000 {
+			t.Errorf("script2 value = %d, want 10000", found[sh2])
+		}
+	})
+
+	t.Run("chain of unconfirmed txs returns all outputs and spent", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		txA := wire.NewMsgTx(2)
+		txA.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: *testutil.String2Hash("bb"), Index: 0,
+			},
+		})
+		txA.AddTxOut(wire.NewTxOut(30000, script1))
+		txAid := txA.TxHash()
+
+		err = mp.TxInsert(ctx, &MempoolTx{
+			id: txAid, expires: time.Now().Add(time.Hour), tx: txA,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// TX B spends TX A output 0.
+		txB := wire.NewMsgTx(2)
+		txB.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Hash: txAid, Index: 0},
+		})
+		txB.AddTxOut(wire.NewTxOut(29000, script2))
+
+		err = mp.TxInsert(ctx, &MempoolTx{
+			id: txB.TxHash(), expires: time.Now().Add(time.Hour), tx: txB,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		utxos, _, spent, err := mp.UnconfirmedUtxos(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Both outputs returned.
+		if len(utxos) != 2 {
+			t.Fatalf("got %d utxos, want 2", len(utxos))
+		}
+
+		// Spent outpoints include TX A:0 (spent by TX B) plus
+		// the external input spent by TX A.
+		if len(spent) != 2 {
+			t.Fatalf("got %d spent outpoints, want 2", len(spent))
+		}
+	})
+
+	t.Run("multiple txs aggregated", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := range 5 {
+			tx := wire.NewMsgTx(2)
+			tx.AddTxIn(&wire.TxIn{
+				PreviousOutPoint: wire.OutPoint{
+					Hash:  *testutil.String2Hash(fmt.Sprintf("%02x", i)),
+					Index: 0,
+				},
+			})
+			tx.AddTxOut(wire.NewTxOut(int64(1000*(i+1)), script1))
+
+			err = mp.TxInsert(ctx, &MempoolTx{
+				id: tx.TxHash(), expires: time.Now().Add(time.Hour), tx: tx,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		utxos, shs, _, err := mp.UnconfirmedUtxos(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(utxos) != 5 {
+			t.Fatalf("got %d utxos, want 5", len(utxos))
+		}
+
+		var total uint64
+		for i, u := range utxos {
+			total += u.Value()
+			if shs[i] != sh1 {
+				t.Errorf("utxo %d: wrong script hash", i)
+			}
+		}
+		wantTotal := uint64(1000 + 2000 + 3000 + 4000 + 5000)
+		if total != wantTotal {
+			t.Errorf("total = %d, want %d", total, wantTotal)
+		}
+	})
+
+	t.Run("nil tx entries skipped", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate an inv-only entry (tx not yet downloaded).
+		mp.txs[*testutil.String2Hash("cc")] = nil
+
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: *testutil.String2Hash("dd"), Index: 0,
+			},
+		})
+		tx.AddTxOut(wire.NewTxOut(7777, script1))
+
+		err = mp.TxInsert(ctx, &MempoolTx{
+			id: tx.TxHash(), expires: time.Now().Add(time.Hour), tx: tx,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		utxos, _, _, err := mp.UnconfirmedUtxos(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(utxos) != 1 {
+			t.Fatalf("got %d utxos, want 1", len(utxos))
+		}
+	})
+}
+
+func TestNewMempoolTx(t *testing.T) {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash: *testutil.String2Hash("aa"), Index: 0,
+		},
+	})
+	tx.AddTxOut(wire.NewTxOut(50000, []byte{0x51}))
+
+	mptx := NewMempoolTx(tx)
+	if mptx.id != tx.TxHash() {
+		t.Errorf("id mismatch: got %v, want %v", mptx.id, tx.TxHash())
+	}
+	if mptx.tx != tx {
+		t.Error("tx pointer not stored")
+	}
+}
+
+func TestMempoolUtxosServer(t *testing.T) {
+	ctx := t.Context()
+
+	script := []byte{
+		0x00, 0x14, 0xca, 0xfe, 0xba, 0xbe, 0x01, 0x02,
+		0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+
+	t.Run("mempool disabled", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := &Server{
+			cfg:     &Config{MempoolEnabled: false},
+			mempool: mp,
+		}
+
+		utxos, shs, spent, err := s.MempoolUtxos(ctx)
+		if err == nil {
+			t.Fatal("expected error when mempool disabled")
+		}
+		if utxos != nil || shs != nil || spent != nil {
+			t.Fatal("disabled mempool should return nil")
+		}
+	})
+
+	t.Run("returns all outputs with spent", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := &Server{
+			cfg:     &Config{MempoolEnabled: true},
+			mempool: mp,
+		}
+
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: *testutil.String2Hash("bb"), Index: 0,
+			},
+		})
+		tx.AddTxOut(wire.NewTxOut(42000, script))
+
+		err = mp.TxInsert(ctx, &MempoolTx{
+			id: tx.TxHash(), expires: time.Now().Add(time.Hour), tx: tx,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		utxos, shs, spent, err := s.MempoolUtxos(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(utxos) != 1 {
+			t.Fatalf("got %d utxos, want 1", len(utxos))
+		}
+		if utxos[0].Value() != 42000 {
+			t.Errorf("value = %d, want 42000", utxos[0].Value())
+		}
+		if shs[0] != tbcd.NewScriptHashFromScript(script) {
+			t.Error("script hash mismatch")
+		}
+		if len(spent) != 1 {
+			t.Fatalf("got %d spent, want 1", len(spent))
+		}
+		if spent[0].Hash != *testutil.String2Hash("bb") || spent[0].Index != 0 {
+			t.Error("spent outpoint mismatch")
+		}
+	})
+}
+
+func TestHandleMempoolUtxosRequest(t *testing.T) {
+	ctx := t.Context()
+
+	script := []byte{
+		0x00, 0x14, 0xde, 0xad, 0xbe, 0xef, 0x01, 0x02,
+		0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+
+	t.Run("mempool disabled returns error", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := &Server{
+			cfg:     &Config{MempoolEnabled: false},
+			mempool: mp,
+		}
+
+		resp, _ := s.handleMempoolUtxosRequest(ctx, &tbcapi.MempoolUtxosRequest{})
+		mResp, ok := resp.(*tbcapi.MempoolUtxosResponse)
+		if !ok {
+			t.Fatalf("wrong type: %T", resp)
+		}
+		if mResp.Error == nil {
+			t.Fatal("expected error for disabled mempool")
+		}
+	})
+
+	t.Run("returns filtered utxos and spent outpoints", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := &Server{
+			cfg:     &Config{MempoolEnabled: true},
+			mempool: mp,
+		}
+
+		tx := wire.NewMsgTx(2)
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{
+				Hash: *testutil.String2Hash("cc"), Index: 0,
+			},
+		})
+		tx.AddTxOut(wire.NewTxOut(99000, script))
+		tx.AddTxOut(wire.NewTxOut(1000, []byte{0x51}))
+
+		mptx := NewMempoolTx(tx)
+		mptx.expires = time.Now().Add(time.Hour)
+		if err := mp.TxInsert(ctx, &mptx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Filter for the known script only.
+		sh := tbcd.NewScriptHashFromScript(script)
+		resp, err := s.handleMempoolUtxosRequest(ctx, &tbcapi.MempoolUtxosRequest{
+			ScriptHashes: []api.ByteSlice{sh[:]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mResp, ok := resp.(*tbcapi.MempoolUtxosResponse)
+		if !ok {
+			t.Fatalf("wrong type: %T", resp)
+		}
+		if mResp.Error != nil {
+			t.Fatalf("unexpected error: %v", mResp.Error)
+		}
+		if len(mResp.UTXOs) != 1 {
+			t.Fatalf("got %d utxos, want 1 (only script match)", len(mResp.UTXOs))
+		}
+		if len(mResp.SpentOutpoints) != 1 {
+			t.Fatalf("got %d spent, want 1", len(mResp.SpentOutpoints))
+		}
+		if mResp.UTXOs[0].ScriptHash != chainhash.Hash(sh) {
+			t.Error("script hash mismatch")
+		}
+	})
+
+	t.Run("empty script hashes returns error", func(t *testing.T) {
+		mp, err := NewMempool()
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := &Server{
+			cfg:     &Config{MempoolEnabled: true},
+			mempool: mp,
+		}
+
+		resp, err := s.handleMempoolUtxosRequest(ctx, &tbcapi.MempoolUtxosRequest{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		mResp, ok := resp.(*tbcapi.MempoolUtxosResponse)
+		if !ok {
+			t.Fatalf("wrong type: %T", resp)
+		}
+		if mResp.Error == nil {
+			t.Fatal("expected error for empty script_hashes")
+		}
+	})
+}
+
+func TestInMempoolWithNilEntries(t *testing.T) {
+	ctx := t.Context()
+
+	mp, err := NewMempool()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate inv-only entry (tx announced but not downloaded).
+	mp.txs[*testutil.String2Hash("aa")] = nil
+
+	// Insert a real tx that spends outpoint bb:0.
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash: *testutil.String2Hash("bb"), Index: 0,
+		},
+	})
+	tx.AddTxOut(wire.NewTxOut(5000, []byte{0x51}))
+
+	mptx := NewMempoolTx(tx)
+	mptx.expires = time.Now().Add(time.Hour)
+	if err := mp.TxInsert(ctx, &mptx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also insert an entry with non-nil MempoolTx but nil tx field.
+	mp.mtx.Lock()
+	mp.txs[*testutil.String2Hash("cc")] = &MempoolTx{
+		id:      *testutil.String2Hash("cc"),
+		expires: time.Now().Add(time.Hour),
+		tx:      nil,
+	}
+	mp.mtx.Unlock()
+
+	// bb:0 is spent by the real tx.
+	utxoBB := tbcd.NewUtxo(*testutil.String2Hash("bb"), 10000, 0)
+	filtered, err := mp.FilterUtxos(ctx, []tbcd.Utxo{utxoBB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 0 {
+		t.Fatalf("bb:0 should be filtered out, got %d", len(filtered))
+	}
+
+	// dd:0 is NOT spent by anything.
+	utxoDD := tbcd.NewUtxo(*testutil.String2Hash("dd"), 20000, 0)
+	filtered, err = mp.FilterUtxos(ctx, []tbcd.Utxo{utxoDD})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("dd:0 should survive, got %d", len(filtered))
+	}
+
+	// UnconfirmedUtxos should skip nil entries.
+	utxos, _, _, err := mp.UnconfirmedUtxos(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(utxos) != 1 {
+		t.Fatalf("got %d utxos, want 1 (only real tx)", len(utxos))
+	}
+}
+
+func TestHandleMempoolInfoRequestWithStats(t *testing.T) {
+	ctx := t.Context()
+
+	mp, err := NewMempool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{
+		cfg:     &Config{MempoolEnabled: true},
+		mempool: mp,
+	}
+
+	// Empty mempool.
+	resp, err := s.handleMempoolInfoRequest(ctx, &tbcapi.MempoolInfoRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mResp := resp.(*tbcapi.MempoolInfoResponse)
+	if mResp.Error != nil {
+		t.Fatalf("unexpected error: %v", mResp.Error)
+	}
+	if mResp.TxNum != 0 {
+		t.Errorf("tx num = %d, want 0", mResp.TxNum)
+	}
+
+	// Insert a tx.
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash: *testutil.String2Hash("ee"), Index: 0,
+		},
+	})
+	tx.AddTxOut(wire.NewTxOut(1000, []byte{0x51}))
+
+	mptx := &MempoolTx{
+		id:      tx.TxHash(),
+		expires: time.Now().Add(time.Hour),
+		size:    250,
+		tx:      tx,
+	}
+	if err := mp.TxInsert(ctx, mptx); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = s.handleMempoolInfoRequest(ctx, &tbcapi.MempoolInfoRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mResp = resp.(*tbcapi.MempoolInfoResponse)
+	if mResp.TxNum != 1 {
+		t.Errorf("tx num = %d, want 1", mResp.TxNum)
+	}
+	if mResp.Size == 0 {
+		t.Error("size should be > 0")
+	}
+}
+
+func TestUnconfirmedUtxosNoOutputs(t *testing.T) {
+	ctx := t.Context()
+
+	mp, err := NewMempool()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tx with inputs but no outputs (degenerate but valid struct).
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash: *testutil.String2Hash("ff"), Index: 0,
+		},
+	})
+
+	err = mp.TxInsert(ctx, &MempoolTx{
+		id: tx.TxHash(), expires: time.Now().Add(time.Hour), tx: tx,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	utxos, shs, spent, err := mp.UnconfirmedUtxos(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(utxos) != 0 {
+		t.Errorf("got %d utxos, want 0", len(utxos))
+	}
+	if len(shs) != 0 {
+		t.Errorf("got %d shs, want 0", len(shs))
+	}
+	if len(spent) != 1 {
+		t.Errorf("got %d spent, want 1", len(spent))
+	}
 }

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Copyright (c) 2024-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -138,6 +138,10 @@ func (s *Server) getTBCAPICommandHandler(cmd protocol.Command, payload any) func
 	case tbcapi.CmdMempoolInfoRequest:
 		return func(ctx context.Context) (any, error) {
 			return s.handleMempoolInfoRequest(ctx, payload.(*tbcapi.MempoolInfoRequest))
+		}
+	case tbcapi.CmdMempoolUtxosRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleMempoolUtxosRequest(ctx, payload.(*tbcapi.MempoolUtxosRequest))
 		}
 	case tbcapi.CmdKeystonesByHeightRequest:
 		return func(ctx context.Context) (any, error) {
@@ -654,7 +658,7 @@ func (s *Server) handleKeystonesByHeightRequest(ctx context.Context, req *tbcapi
 	}, nil
 }
 
-func (s *Server) handleMempoolInfoRequest(_ context.Context, _ *tbcapi.MempoolInfoRequest) (any, error) {
+func (s *Server) handleMempoolInfoRequest(ctx context.Context, _ *tbcapi.MempoolInfoRequest) (any, error) {
 	log.Tracef("handleMempoolInfoRequest")
 	defer log.Tracef("handleMempoolInfoRequest exit")
 
@@ -666,9 +670,80 @@ func (s *Server) handleMempoolInfoRequest(_ context.Context, _ *tbcapi.MempoolIn
 		}, err
 	}
 
+	txNum, size := s.mempool.stats(ctx)
 	return &tbcapi.MempoolInfoResponse{
-		Size:  s.mempool.size,
-		TxNum: uint(len(s.mempool.txs)),
+		Size:  int64(size),
+		TxNum: uint(txNum),
+	}, nil
+}
+
+func (s *Server) handleMempoolUtxosRequest(ctx context.Context, req *tbcapi.MempoolUtxosRequest) (any, error) {
+	log.Tracef("handleMempoolUtxosRequest")
+	defer log.Tracef("handleMempoolUtxosRequest exit")
+
+	if !s.cfg.MempoolEnabled {
+		err := errors.New("mempool not enabled")
+		e := protocol.NewInternalError(err)
+		return &tbcapi.MempoolUtxosResponse{
+			Error: e.ProtocolError(),
+		}, err
+	}
+
+	// ScriptHashes is required.
+	if len(req.ScriptHashes) == 0 {
+		return &tbcapi.MempoolUtxosResponse{
+			Error: protocol.RequestErrorf("script_hashes is required"),
+		}, nil
+	}
+
+	// Build ScriptHash filter.
+	filter := make(map[tbcd.ScriptHash]struct{}, len(req.ScriptHashes))
+	for _, raw := range req.ScriptHashes {
+		if len(raw) != chainhash.HashSize {
+			return &tbcapi.MempoolUtxosResponse{
+				Error: protocol.RequestErrorf("invalid script hash length: got %d, want %d", len(raw), chainhash.HashSize),
+			}, nil
+		}
+		var sh tbcd.ScriptHash
+		copy(sh[:], raw)
+		filter[sh] = struct{}{}
+	}
+
+	utxos, shs, spent, err := s.MempoolUtxos(ctx)
+	if err != nil {
+		return &tbcapi.MempoolUtxosResponse{
+			Error: protocol.RequestErrorf("mempool utxos: %v", err),
+		}, nil
+	}
+
+	// Apply ScriptHash filter.
+	filtered := make([]tbcd.Utxo, 0, len(utxos)/2)
+	filteredShs := make([]tbcd.ScriptHash, 0, len(utxos)/2)
+	for i, sh := range shs {
+		if _, ok := filter[sh]; ok {
+			filtered = append(filtered, utxos[i])
+			filteredShs = append(filteredShs, sh)
+		}
+	}
+
+	out := make([]*tbcapi.MempoolUTXO, len(filtered))
+	for i, u := range filtered {
+		out[i] = &tbcapi.MempoolUTXO{
+			TxId:       *u.ChainHash(),
+			Value:      btcutil.Amount(u.Value()),
+			OutIndex:   u.OutputIndex(),
+			ScriptHash: chainhash.Hash(filteredShs[i]),
+		}
+	}
+
+	spentOps := make([]tbcapi.OutPoint, len(spent))
+	for i, op := range spent {
+		spentOps[i] = tbcapi.OutPoint{Hash: op.Hash, Index: op.Index}
+	}
+
+	return &tbcapi.MempoolUtxosResponse{
+		UTXOs:          out,
+		SpentOutpoints: spentOps,
 	}, nil
 }
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1242,7 +1242,7 @@ func (s *Server) handleTx(ctx context.Context, p *rawpeer.RawPeer, msg *wire.Msg
 		}
 	}
 
-	mptx, err := mempoolTxNew(ctx, s.g.db, utx)
+	mptx, err := mempoolTxNew(ctx, s.g.db, s.mempool, utx)
 	if err != nil {
 		return fmt.Errorf("new mempool tx: %w", err)
 	}
@@ -2370,8 +2370,9 @@ func (s *Server) TxBroadcast(ctx context.Context, tx *wire.MsgTx, force bool) (*
 
 	if s.cfg.MempoolEnabled {
 		// Add Tx to our own mempool instead of waiting for it to come
-		// over p2p.
-		mptx, err := mempoolTxNew(ctx, s.g.db, btcutil.NewTx(tx))
+		// over p2p.  Pass s.mempool so child transactions can resolve
+		// inputs from unconfirmed parents (CPFP chains).
+		mptx, err := mempoolTxNew(ctx, s.g.db, s.mempool, btcutil.NewTx(tx))
 		if err != nil {
 			log.Errorf("mempool tx: %w", err)
 		} else if err := s.mempool.TxInsert(ctx, mptx); err != nil {
@@ -2416,13 +2417,27 @@ func (s *Server) BlockHeaderByKeystoneIndex(ctx context.Context) (*tbcd.BlockHea
 	return s.g.db.BlockHeaderByKeystoneIndex(ctx)
 }
 
-func parseTx(ctx context.Context, db tbcd.Database, tx *wire.MsgTx) (int64, int64, error) {
+// parseTx computes the total input and output values for a
+// transaction.  Input values are looked up from the block database.
+// If mp is non-nil, unconfirmed parent outputs in the mempool are
+// also checked — this enables child-pays-for-parent (CPFP) chains
+// where a child transaction spends an output from a parent that
+// is still in the mempool.
+func parseTx(ctx context.Context, db tbcd.Database, mp *Mempool, tx *wire.MsgTx) (int64, int64, error) {
 	var iv, ov int64
 	for _, txIn := range tx.TxIn {
 		po := txIn.PreviousOutPoint
 		wtxo, err := txOutFromOutPoint(ctx,
 			db, tbcd.NewOutpoint(po.Hash, po.Index))
 		if err != nil {
+			// If the input isn't in the block database, check
+			// the mempool for an unconfirmed parent transaction.
+			if mp != nil {
+				if ptxo := mp.txOutByOutpoint(po.Hash, po.Index); ptxo != nil {
+					iv += ptxo.Value
+					continue
+				}
+			}
 			return 0, 0, err
 		}
 		iv += wtxo.Value
@@ -2435,9 +2450,9 @@ func parseTx(ctx context.Context, db tbcd.Database, tx *wire.MsgTx) (int64, int6
 	return iv, ov, nil
 }
 
-func mempoolTxNew(ctx context.Context, db tbcd.Database, utx *btcutil.Tx) (*MempoolTx, error) {
+func mempoolTxNew(ctx context.Context, db tbcd.Database, mp *Mempool, utx *btcutil.Tx) (*MempoolTx, error) {
 	// Create mempool tx
-	inValue, outValue, err := parseTx(ctx, db, utx.MsgTx())
+	inValue, outValue, err := parseTx(ctx, db, mp, utx.MsgTx())
 	if err != nil {
 		return nil, fmt.Errorf("cannot obtain values from tx: %w", err)
 	}
@@ -2483,7 +2498,7 @@ func (s *Server) FeesByBlockHash(ctx context.Context, hash chainhash.Hash) (*tbc
 			// Skip coinbase inputs
 			continue
 		}
-		mptx, err := mempoolTxNew(ctx, s.g.db, utx)
+		mptx, err := mempoolTxNew(ctx, s.g.db, nil, utx)
 		if err != nil {
 			return nil, fmt.Errorf("new mempool tx: %w", err)
 		}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2127,6 +2127,20 @@ func (s *Server) UtxosByAddress(ctx context.Context, filterMempool bool, encoded
 	return utxos, nil
 }
 
+// MempoolUtxos returns all unspent outputs from mempool transactions.
+// These are NOT safe to spend — use UtxosByAddress for building
+// transactions.
+func (s *Server) MempoolUtxos(ctx context.Context) ([]tbcd.Utxo, []tbcd.ScriptHash, []wire.OutPoint, error) {
+	log.Tracef("MempoolUtxos")
+	defer log.Tracef("MempoolUtxos exit")
+
+	if !s.cfg.MempoolEnabled {
+		return nil, nil, nil, errors.New("mempool not enabled")
+	}
+
+	return s.mempool.UnconfirmedUtxos(ctx)
+}
+
 func (s *Server) UtxosByScriptHash(ctx context.Context, hash tbcd.ScriptHash, start uint64, count uint64) ([]tbcd.Utxo, error) {
 	log.Tracef("UtxosByScriptHash")
 	defer log.Tracef("UtxosByScriptHash exit")
@@ -2402,41 +2416,44 @@ func (s *Server) BlockHeaderByKeystoneIndex(ctx context.Context) (*tbcd.BlockHea
 	return s.g.db.BlockHeaderByKeystoneIndex(ctx)
 }
 
-func parseTx(ctx context.Context, db tbcd.Database, tx *wire.MsgTx) (int64, int64, map[wire.OutPoint]struct{}, error) {
+func parseTx(ctx context.Context, db tbcd.Database, tx *wire.MsgTx) (int64, int64, error) {
 	var iv, ov int64
-	txins := make(map[wire.OutPoint]struct{}, len(tx.TxIn))
 	for _, txIn := range tx.TxIn {
 		po := txIn.PreviousOutPoint
 		wtxo, err := txOutFromOutPoint(ctx,
 			db, tbcd.NewOutpoint(po.Hash, po.Index))
 		if err != nil {
-			return 0, 0, nil, err
+			return 0, 0, err
 		}
 		iv += wtxo.Value
-
-		txins[po] = struct{}{}
 	}
 
 	for _, txOut := range tx.TxOut {
 		ov += txOut.Value
 	}
 
-	return iv, ov, txins, nil
+	return iv, ov, nil
 }
 
 func mempoolTxNew(ctx context.Context, db tbcd.Database, utx *btcutil.Tx) (*MempoolTx, error) {
 	// Create mempool tx
-	inValue, outValue, txins, err := parseTx(ctx, db, utx.MsgTx())
+	inValue, outValue, err := parseTx(ctx, db, utx.MsgTx())
 	if err != nil {
 		return nil, fmt.Errorf("cannot obtain values from tx: %w", err)
 	}
+	msg := utx.MsgTx()
+	txins := make(map[wire.OutPoint]struct{}, len(msg.TxIn))
+	for _, txIn := range msg.TxIn {
+		txins[txIn.PreviousOutPoint] = struct{}{}
+	}
 	return &MempoolTx{
-		id:       utx.MsgTx().TxHash(),
+		id:       msg.TxHash(),
 		weight:   blockchain.GetTransactionWeight(utx),
 		size:     btcmempool.GetTxVirtualSize(utx),
 		outValue: outValue,
 		inValue:  inValue,
 		expires:  time.Now().Add(defaultMempoolAge),
+		tx:       msg,
 		txins:    txins,
 	}, nil
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1876,7 +1876,10 @@ func (s *Server) handleGetData(ctx context.Context, p *rawpeer.RawPeer, msg *wir
 		switch v.Type {
 		case wire.InvTypeError:
 			log.Errorf("get data error: %v", v.Hash)
-		case wire.InvTypeTx:
+		case wire.InvTypeTx, wire.InvTypeWitnessTx:
+			// Bitcoin Core requests witness txs via InvTypeWitnessTx
+			// even when the INV used InvTypeTx.  Check broadcast map
+			// for both types.
 			s.mtx.RLock()
 			if tx, ok := s.broadcast[v.Hash]; ok {
 				log.Debugf("handleGetData %v", spew.Sdump(msg))
@@ -1893,8 +1896,6 @@ func (s *Server) handleGetData(ctx context.Context, p *rawpeer.RawPeer, msg *wir
 			log.Infof("get data filtered block: %v", v.Hash)
 		case wire.InvTypeWitnessBlock:
 			log.Infof("get data witness block: %v", v.Hash)
-		case wire.InvTypeWitnessTx:
-			log.Infof("get data witness tx: %v", v.Hash)
 		case wire.InvTypeFilteredWitnessBlock:
 			log.Infof("get data filtered witness block: %v", v.Hash)
 		default:


### PR DESCRIPTION
New MempoolUtxos RPC command returns all outputs from mempool transactions with their script hashes, plus all outpoints being spent by mempool transactions. Server returns everything; callers filter client-side.

MempoolTx stores the full *wire.MsgTx. The txins map is removed — inputs read directly from tx.TxIn. parseTx simplified.

FilterSpent utility in gozer package removes outputs whose outpoint appears in the spent set. Callers opt in to CPFP filtering when needed.

UtxosByAddress and filterMempool semantics unchanged.