### PR TITLE
.github: enable auto-merge for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,6 +41,12 @@
       matchUpdateTypes: ['pin', 'pinDigest'],
       commitMessageAction: 'pin',
     },
+    {
+      description: "Enable auto-merge on pull requests",
+      matchPackageNames: ["*"],
+      automerge: true,
+      automergeType: "pr",
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
**Summary**
Enable auto-merge for pull requests created by Renovate bot.
Saves me from having enable it one-by-one or merge each PR manually.

**Changes**
- Update `.github/renovate.json5` to add `automerge` setting