### PR TITLE
e2e: full sync node and large bitcoin re-org+block deletion in localnet

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -287,6 +287,7 @@ services:
       - "--p2p.no-discovery"
       - "--p2p.priv.path=/tmp/op-node-priv-key.txt"
       - "--p2p.sequencer.key=${ADMIN_PRIVATE_KEY}"
+      - "--p2p.ban.peers=false"
       - "--log.level=debug"
       - "--log.format=terminal"
       - "--override.ecotone=1725868497"
@@ -331,7 +332,6 @@ services:
       - "--log.level=info"
       - "--l1.trustrpc=true"
       - "--l1.http-poll-interval=1s"
-      - "--p2p.priv.path=/tmp/op-node-priv-key.txt"
       - "--p2p.sequencer.key=${ADMIN_PRIVATE_KEY}"
       - "--p2p.static=/ip4/192.169.199.7/tcp/9222/p2p/16Uiu2HAmGCJv5C97ZcdMr6pCCQFqdNXvwE8k6RgTd7vWu4WtVUmr"
       - "--log.level=debug"
@@ -396,6 +396,9 @@ services:
         condition: "service_healthy"
     healthcheck:
       start_period: 180s
+    deploy:
+      restart_policy:
+        condition: "on-failure"
     command:
       - "op-node/bin/op-node"
       - "--l2=ws://op-geth-l2-non-sequencing-snap-sync:8551"
@@ -411,7 +414,6 @@ services:
       - "--log.level=info"
       - "--l1.trustrpc=true"
       - "--l1.http-poll-interval=1s"
-      - "--p2p.priv.path=/tmp/op-node-priv-key.txt"
       - "--p2p.sequencer.key=${ADMIN_PRIVATE_KEY}"
       - "--p2p.static=/ip4/192.169.199.7/tcp/9222/p2p/16Uiu2HAmGCJv5C97ZcdMr6pCCQFqdNXvwE8k6RgTd7vWu4WtVUmr"
       - "--log.level=debug"
@@ -488,6 +490,88 @@ services:
     ports:
       - "28546:8546"
 
+  op-geth-l2-non-sequencing-full-sync:
+    image: optimism-stack:latest
+    depends_on:
+      bitcoind-invalidateblocks:
+        condition: "service_completed_successfully"
+    healthcheck:
+      test: ["CMD-SHELL", "ls /tmp/datadir/geth.ipc"]
+      interval: 5s
+      retries: 300
+      start_period: 30s
+    environment:
+      ADMIN_PRIVATE_KEY: "${ADMIN_PRIVATE_KEY}"
+      OP_GETH_L1_RPC: "http://geth-l1:8545"
+      HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
+      GETH_SYNCMODE: "full"
+    working_dir: "/tmp"
+    command:
+      - "sh"
+      - "/tmp/entrypointl2.sh"
+    volumes:
+      - "./e2e/keystore:/tmp/keystore:ro"
+      - "./e2e/passwords.txt:/tmp/passwords.txt:ro"
+      - "./jwt.hex:/tmp/jwt.hex:ro"
+      - "./entrypointl2.sh:/tmp/entrypointl2.sh"
+      - "./genesisl2.sh:/tmp/genesisl2.sh"
+      - "./output:/tmp/output"
+      - "shared-dir:/shared-dir"
+      - "./deploy-config.json:/git/optimism/packages/contracts-bedrock/deploy-config/devnetL1.json"
+      - "./prestate-proof.json:/git/optimism/op-program/bin/prestate-proof.json"
+      - {type: "tmpfs", target: "/tmp"}
+    networks:
+      e2e:
+    ports:
+      - "38546:8546"
+
+  op-node-non-sequencing-full-sync:
+    image: optimism-stack:latest
+    depends_on:
+      op-geth-l2-non-sequencing-full-sync:
+        condition: "service_healthy"
+    healthcheck:
+      start_period: 180s
+    deploy:
+      restart_policy:
+        condition: "on-failure"
+    command:
+      - "op-node/bin/op-node"
+      - "--l2=ws://op-geth-l2-non-sequencing-full-sync:8551"
+      - "--l2.jwt-secret=/tmp/jwt.hex"
+      - "--verifier.l1-confs=0"
+      - "--rollup.config=/shared-dir/rollup.json"
+      - "--rpc.addr=0.0.0.0"
+      - "--rpc.port=8548"
+      - "--rpc.enable-admin"
+      - "--l1=http://geth-l1:8545"
+      - "--l1.rpckind=standard"
+      - "--l1.trustrpc"
+      - "--log.level=info"
+      - "--l1.trustrpc=true"
+      - "--l1.http-poll-interval=1s"
+      - "--p2p.sequencer.key=${ADMIN_PRIVATE_KEY}"
+      - "--p2p.static=/ip4/192.169.199.7/tcp/9222/p2p/16Uiu2HAmGCJv5C97ZcdMr6pCCQFqdNXvwE8k6RgTd7vWu4WtVUmr"
+      - "--log.level=debug"
+      - "--log.format=terminal"
+      - "--override.ecotone=1725868497"
+      - "--override.canyon=1725868497"
+      - "--override.delta=1725868497"
+      - "--override.pectrablobschedule=1744238662"
+      - "--override.isthmus=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.holocene=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.granite=${HVM_PHASE0_TIMESTAMP}"
+      - "--override.fjord=${HVM_PHASE0_TIMESTAMP}"
+      - "--l1.beacon.ignore=true"
+      - "--rollup.l1-chain-config=/shared-dir/l1genesis.json"
+      - "--syncmode=consensus-layer"
+    volumes:
+      - "shared-dir:/shared-dir"
+      - "./jwt.hex:/tmp/jwt.hex"
+    networks:
+      e2e:
+    ports:
+      - "38548:8548"
 
   op-batcher:
     image: optimism-stack:latest

--- a/e2e/genesisl2.sh
+++ b/e2e/genesisl2.sh
@@ -107,6 +107,8 @@ cat l1allocs.json
 echo "$(jq '.alloc."0x78697c88847dfbbb40523e42c1f2e28a13a170be".balance = "0x999999999999999999"' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json
 echo "$(jq '.alloc."0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc".balance = "0x999999999999999999"' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json
 echo "$(jq '.alloc."0xf0faD6E77d55509484F93Ace13AAFa37138bc370".balance = "0x999999999999999999"' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json
+echo "$(jq '.alloc."0x5663a22EAF74371d1765FdA4635fa81ee1c88fa8".balance = "0x999999999999999999"' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json
+
 
 
 echo "$(jq --argjson timestamp "$(jq '.timestamp' /shared-dir/genesis.json)" '.timestamp = $timestamp' /shared-dir/l1genesis.json)" > /shared-dir/l1genesis.json

--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -136,6 +136,7 @@ func privateKeyForTestByIndex(t *testing.T, index uint) string {
 		"dfe61681b31b12b04f239bc0692965c61ffc79244ed9736ffa1a72d00a23a530", // sequencing
 		"8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba", // non-sequencing
 		"fbe93b7c626721b844ff03923c296c395e7729b81096a9a5c3d8a87b57e01db6",
+		"7acf6459a4bb83dc701a107c308dfadae7ee6afec508cdc3a6fcff2a02597d3a",
 	}
 	if index >= uint(len(keys)) {
 		t.Fatalf("index %d exceeds available keys (max: %d)", index, len(keys)-1)
@@ -233,10 +234,6 @@ func game(t *testing.T) common.Address {
 func TestMonitor(t *testing.T) {
 	t.Parallel()
 
-	// let localnet start, there are smarter ways to do this but this will work
-	// for now
-	time.Sleep(2 * time.Minute)
-
 	// somewhat arbitrary; we should be able to get to 24 pop txs mined in a
 	// reasonable amount of time
 	const expectedPopTxs = 24
@@ -301,24 +298,37 @@ func TestMonitor(t *testing.T) {
 
 func TestL1L2Comms(t *testing.T) {
 	t.Parallel()
-	testL1L2Comms(t, l1Endpoint(), forkedL2Endpoint(), "http://localhost:18546", "http://localhost:28546")
+	testL1L2Comms(t, l1Endpoint(), forkedL2Endpoint(), "http://localhost:18546", "http://localhost:28546", "http://localhost:38546")
 }
 
-func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequencingEndpoint string, l2NonSequencingSnapSyncEndpoint string) {
-	// todo: combine these into a nice struct or something similar
-	testNames := []string{
-		"testing sequencing client",
-		"testing non-sequencing client",
-		"testing non-sequencing client with snap-sync",
+func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequencingEndpoint string, l2NonSequencingSnapSyncEndpoint string, l2NonSequencingFullSyncEndpoint string) {
+	type testCase struct {
+		name       string
+		sequencing bool
+		snapSync   bool
+		fullSync   bool
 	}
-	tests := []bool{true, false, false}
 
-	const snapSyncNodeIndex = 2
+	tests := []testCase{
+		{
+			name:       "testing sequencing client",
+			sequencing: true,
+		},
+		{
+			name: "testing non-sequencing client",
+		},
+		{
+			name:     "testing non-sequencing client with snap-sync",
+			snapSync: true,
+		},
+		{
+			name:     "testing non-sequencing client with full-sync",
+			fullSync: true,
+		},
+	}
 
-	for i, sequencing := range tests {
-		name := testNames[i]
-
-		t.Run(name, func(t *testing.T) {
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Minute)
@@ -344,6 +354,11 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 				t.Fatalf("could not dial eth l2 non sequencing snap sync %s", err)
 			}
 
+			l2ClientNonSequencingFullSync, err := ethclient.Dial(l2NonSequencingFullSyncEndpoint)
+			if err != nil {
+				t.Fatalf("could not dial eth l2 non sequencing full sync %s", err)
+			}
+
 			// Use different private key for each subtest to avoid conflicts
 			privateKeyHex := privateKeyForTestByIndex(t, uint(i))
 			privateKey, err := crypto.HexToECDSA(privateKeyHex)
@@ -352,14 +367,18 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 			}
 
 			l2ClientToUse := l2Client
-			if !sequencing {
+			if !tc.sequencing {
 				if testingFork() {
 					t.Fatal("there is no non-sequencing client for testing a forked network")
 				}
 				l2ClientToUse = l2ClientNonSequencing
 
-				if i == snapSyncNodeIndex {
+				if tc.snapSync {
 					l2ClientToUse = l2ClientNonSequencingSnapSync
+				}
+
+				if tc.fullSync {
+					l2ClientToUse = l2ClientNonSequencingFullSync
 				}
 			}
 
@@ -393,7 +412,8 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 			opNodeSequencingEndpoint := "http://localhost:8548"
 			opNodeNonSequencingEndpoint := "http://localhost:18548"
 			opNodeNonSequencingSnapSyncEndpoint := "http://localhost:28548"
-			assertOutputRootsAreTheSame(t, ctx, l2ClientToUse, opNodeSequencingEndpoint, opNodeNonSequencingEndpoint, opNodeNonSequencingSnapSyncEndpoint)
+			opNodeNonSequencingFullSyncEndpoint := "http://localhost:38548"
+			assertOutputRootsAreTheSame(t, ctx, l2ClientToUse, opNodeSequencingEndpoint, opNodeNonSequencingEndpoint, opNodeNonSequencingSnapSyncEndpoint, opNodeNonSequencingFullSyncEndpoint)
 			assertSafeAndFinalBlocksAreProgressing(t, ctx, l2ClientToUse)
 		})
 	}
@@ -2022,6 +2042,7 @@ func assertOutputRootsAreTheSame(
 	opNodeSequencingEndpoint string,
 	opNodeNonSequencingEndpoint string,
 	opNodeNonSequencingSnapSyncEndpoint string,
+	opNodeNonSequencingFullSyncEndpoint string,
 ) {
 	bigTip, err := l2Client.HeaderByNumber(t.Context(), nil)
 	if err != nil {
@@ -2092,6 +2113,11 @@ func assertOutputRootsAreTheSame(
 			t.Fatalf("error making request to non sequencing snap sync endpoint: %s", err)
 		}
 
+		res4, err := client.Post(opNodeNonSequencingFullSyncEndpoint, "application/json", bytes.NewBuffer(jsonbody))
+		if err != nil {
+			t.Fatalf("error making request to non sequencing full sync endpoint: %s", err)
+		}
+
 		resBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("error reading response body from sequencer: %s", err)
@@ -2107,9 +2133,15 @@ func assertOutputRootsAreTheSame(
 			t.Fatalf("error reading response body from non-sequencer-snap-sync: %s", err)
 		}
 
+		resBody4, err := io.ReadAll(res4.Body)
+		if err != nil {
+			t.Fatalf("error reading response body from non-sequencer-full-sync: %s", err)
+		}
+
 		res.Body.Close()
 		res2.Body.Close()
 		res3.Body.Close()
+		res4.Body.Close()
 
 		assertResultNotError := func(body *outputAtBlockResponse) error {
 			if body.Error != nil {
@@ -2122,6 +2154,7 @@ func assertOutputRootsAreTheSame(
 		var outputAtBlockResponseOne outputAtBlockResponse
 		var outputAtBlockResponseTwo outputAtBlockResponse
 		var outputAtBlockResponseThree outputAtBlockResponse
+		var outputAtBlockResponseFour outputAtBlockResponse
 
 		if err := json.Unmarshal(resBody, &outputAtBlockResponseOne); err != nil {
 			t.Fatal(err)
@@ -2135,12 +2168,20 @@ func assertOutputRootsAreTheSame(
 			t.Fatal(err)
 		}
 
+		if err := json.Unmarshal(resBody4, &outputAtBlockResponseFour); err != nil {
+			t.Fatal(err)
+		}
+
 		if err := assertResultNotError(&outputAtBlockResponseOne); err != nil {
 			t.Fatalf("error in response: %v", outputAtBlockResponseOne.Error)
 		}
 
 		if err := assertResultNotError(&outputAtBlockResponseTwo); err != nil {
 			t.Fatalf("error in response: %v", outputAtBlockResponseTwo.Error)
+		}
+
+		if err := assertResultNotError(&outputAtBlockResponseFour); err != nil {
+			t.Fatalf("error in response: %v", outputAtBlockResponseFour.Error)
 		}
 
 		// only check against snap sync if within snapSyncMax of the tip
@@ -2156,6 +2197,10 @@ func assertOutputRootsAreTheSame(
 
 		if diff := deep.Equal(outputAtBlockResponseOne, outputAtBlockResponseTwo); len(diff) > 0 {
 			t.Fatalf("output roots are not the same for sequencing and non-sequencing: %s", diff)
+		}
+
+		if diff := deep.Equal(outputAtBlockResponseOne, outputAtBlockResponseFour); len(diff) > 0 {
+			t.Fatalf("output roots are not the same for sequencing and non-sequencing full syn: %s", diff)
 		}
 
 		tip--


### PR DESCRIPTION
**Summary**

* add a full sync node to localnet testing, this will wait for a finalized block before starting
* invalidate a block in the bitcoin chain then "prune" everything below tip, forcing nodes to get missing blocks from l2 peers

the invalidation and pruning functions like so:

* find the highest bitcoin attributes deposited transaction in the hemi chain
* use "invalidateblock" to re-org it off of the canonical chain
* "prune" all of the blocks below tip from the bitcoind node
* start the snap-sync and full-sync nodes, they _should_ have to fetch the block from the l2 since it was re-org'd off of the chain

fixes https://github.com/hemilabs/heminetwork/issues/989 and https://github.com/hemilabs/heminetwork/issues/988e2e: full sync node and large bitcoin re-org+block deletion in localnet
* add a full sync node to localnet testing, this will wait for a finalized block before starting
* invalidate a block in the bitcoin chain then "prune" everything below tip, forcing nodes to get missing blocks from l2 peers

the invalidation and pruning functions like so:

* find the highest bitcoin attributes deposited transaction in the hemi chain
* use "invalidateblock" to re-org it off of the canonical chain
* "prune" all of the blocks below tip from the bitcoind node
* start the snap-sync and full-sync nodes, they _should_ have to fetch the block from the l2 since it was re-org'd off of the chain

fixes https://github.com/hemilabs/heminetwork/issues/989 and https://github.com/hemilabs/heminetwork/issues/988

**Changes**
see summary
