### PR TITLE
synctest: add memory usage stats to logs

### DIFF
--- a/synctest/go.mod
+++ b/synctest/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.2
 require (
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/dustin/go-humanize v1.0.1
 	github.com/ethereum/go-ethereum v1.17.2
 	github.com/go-test/deep v1.1.1
 	github.com/hemilabs/heminetwork/v2 v2.0.0-rc.1.0.20260210123146-3d9f4a8d6010
@@ -45,7 +46,6 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.6 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/synctest/synctest.go
+++ b/synctest/synctest.go
@@ -19,6 +19,7 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/dustin/go-humanize"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -259,7 +260,7 @@ func notifySlackSuccess(ctx context.Context, c *config, controlHash *common.Hash
 	}
 }
 
-func generateMsgOptions(ctx context.Context, network string, syncmode string, l2BlockMsg string, syncInfo *tbc.SyncInfo) []slack.MsgOption {
+func generateMsgOptions(_ context.Context, network string, syncmode string, l2BlockMsg string, syncInfo *tbc.SyncInfo) []slack.MsgOption {
 	var color string
 	switch network {
 	case "mainnet":
@@ -477,6 +478,28 @@ func getLogsFromDocker(ctx context.Context) string {
 		if !isValidContainer {
 			continue
 		}
+
+		// Get memory stats
+		stream, err := dockerClient.ContainerStatsOneShot(ctx, c.ID)
+		if err != nil {
+			log.Warningf("could not get stats from running container %s: %s", c.ID, err)
+			return ""
+		}
+		defer stream.Body.Close()
+
+		var stats container.StatsResponse
+		dec := json.NewDecoder(stream.Body)
+		if err := dec.Decode(&stats); err != nil {
+			log.Warningf("could not decode stats for running container %s: %s", c.ID, err)
+			return ""
+		}
+		stream.Body.Close()
+
+		ms := stats.MemoryStats
+		memUsage := fmt.Sprintf("Memory Usage: Current: %s, Max: %s, Limit: %s",
+			humanize.Bytes(ms.Usage), humanize.Bytes(ms.MaxUsage), humanize.Bytes(ms.Limit))
+		logs = fmt.Sprintf("%s\n%s", logs, string(memUsage))
+
 		reader, err := dockerClient.ContainerLogs(ctx, c.ID, container.LogsOptions{
 			ShowStdout: true,
 			ShowStderr: true,

--- a/synctest/synctest.go
+++ b/synctest/synctest.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/dustin/go-humanize"
@@ -501,8 +500,6 @@ func getLogsFromDocker(ctx context.Context) string {
 			validName, humanize.Bytes(ms.Usage), humanize.Bytes(ms.MaxUsage),
 			humanize.Bytes(ms.Limit))
 		logs = fmt.Sprintf("%s\n%s", logs, string(memUsage))
-
-		spew.Dump(logs)
 
 		reader, err := dockerClient.ContainerLogs(ctx, c.ID, container.LogsOptions{
 			ShowStdout: true,

--- a/synctest/synctest.go
+++ b/synctest/synctest.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/dustin/go-humanize"
@@ -468,14 +469,14 @@ func getLogsFromDocker(ctx context.Context) string {
 
 	var logs string
 	for _, c := range containers {
-		var isValidContainer bool
+		var validName string
 		for _, name := range c.Names {
 			if strings.Contains(name, "op-geth") || strings.Contains(name, "op-node") {
-				isValidContainer = true
+				validName = name
 				break
 			}
 		}
-		if !isValidContainer {
+		if validName == "" {
 			continue
 		}
 
@@ -496,9 +497,12 @@ func getLogsFromDocker(ctx context.Context) string {
 		stream.Body.Close()
 
 		ms := stats.MemoryStats
-		memUsage := fmt.Sprintf("Memory Usage: Current: %s, Max: %s, Limit: %s",
-			humanize.Bytes(ms.Usage), humanize.Bytes(ms.MaxUsage), humanize.Bytes(ms.Limit))
+		memUsage := fmt.Sprintf("Memory Usage (%s) - Current: %s, Max: %s, Limit: %s",
+			validName, humanize.Bytes(ms.Usage), humanize.Bytes(ms.MaxUsage),
+			humanize.Bytes(ms.Limit))
 		logs = fmt.Sprintf("%s\n%s", logs, string(memUsage))
+
+		spew.Dump(logs)
 
 		reader, err := dockerClient.ContainerLogs(ctx, c.ID, container.LogsOptions{
 			ShowStdout: true,


### PR DESCRIPTION
**Summary**
Adds memory stats to the docker logs of `synctest` notification.

**Changes**
See title.
