### PR TITLE
.golangci: enable perfsprint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,7 @@ linters:
     - "nilerr" # Finds the code that returns nil even if it checks that the error is not nil.
     - "noctx" # Finds http requests without context.Context.
     - "nolintlint" # Reports ill-formed or insufficient nolint directives.
+    - "perfsprint" # Finds uses of formatting that can be replaced with a faster alternative.
     - "prealloc" # Finds slice declarations that could potentially be pre-allocated.
     - "predeclared" # Find code that shadows one of Go's predeclared identifiers.
     - "promlinter" # Check Prometheus metrics naming via promlint.
@@ -57,9 +58,6 @@ linters:
         - "XXX"
         - "TODO"
         - "FIXME"
-    gomoddirectives:
-      replace-allow-list:
-        - "github.com/coder/websocket" # Currently uses our fork with a bug fix.
     nolintlint:
       # Require an explanation after each nolint directive.
       # Explanation format example: '//nolint:ineffassign // Explanation goes here.'
@@ -103,6 +101,7 @@ linters:
 
 formatters:
   enable:
+    - "goimports"
     - "gci" # Enforces package import order, making it deterministic.
     - "gofumpt" # An extended version of go fmt.
   settings:

--- a/api/protocol/protocol.go
+++ b/api/protocol/protocol.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -538,7 +539,7 @@ func (ac *Conn) Call(ctx context.Context, api API, payload any) (Command, string
 	log.Tracef("Call: %T", payload)
 	defer log.Tracef("Call exit: %T", payload)
 
-	msgID := fmt.Sprintf("%d", ac.nextMsgID())
+	msgID := strconv.FormatUint(ac.nextMsgID(), 10)
 	resultCh := make(chan *readResult, 1)
 
 	ac.Lock()

--- a/bitcoin/wallet/gozer/blockstream/blockstream.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -74,10 +74,10 @@ func (bs *blockstreamGozer) BestHeightHashTime(ctx context.Context) (uint64, *ch
 		if ts, ok := t.(float64); ok && ts > 0 {
 			timestamp = time.Unix(int64(ts), 0)
 		} else {
-			return 0, nil, timestamp, fmt.Errorf("invalid timestamp")
+			return 0, nil, timestamp, errors.New("invalid timestamp")
 		}
 	} else {
-		return 0, nil, timestamp, fmt.Errorf("invalid timestamp")
+		return 0, nil, timestamp, errors.New("invalid timestamp")
 	}
 	if h, ok := bi["height"]; ok {
 		if height, ok := h.(float64); ok && height >= 0 {
@@ -85,7 +85,7 @@ func (bs *blockstreamGozer) BestHeightHashTime(ctx context.Context) (uint64, *ch
 		}
 	}
 
-	return 0, nil, time.Time{}, fmt.Errorf("invalid height")
+	return 0, nil, time.Time{}, errors.New("invalid height")
 }
 
 func (bs *blockstreamGozer) FeeEstimates(ctx context.Context) ([]*tbcapi.FeeEstimate, error) {

--- a/bitcoin/wallet/gozer/blockstream/blockstream_test.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream_test.go
@@ -7,7 +7,6 @@ package blockstream
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -67,7 +66,7 @@ func mockHttpServer() *httptest.Server {
 			if _, err := w.Write([]byte(response)); err != nil {
 				panic(err)
 			}
-		case r.URL.Path == fmt.Sprintf("/block/%s", fakeHash):
+		case r.URL.Path == "/block/"+fakeHash:
 			response := map[string]any{
 				"height":    uint64(10),
 				"timestamp": int64(15),

--- a/bitcoin/wallet/vinzclortho/vinzclortho.go
+++ b/bitcoin/wallet/vinzclortho/vinzclortho.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -78,14 +78,14 @@ func (vc *VinzClortho) Unlock(secret string) error {
 	vc.mtx.Lock()
 	defer vc.mtx.Unlock()
 	if vc.master != nil {
-		return fmt.Errorf("wallet already unlocked")
+		return errors.New("wallet already unlocked")
 	}
 
 	switch {
 	case strings.HasPrefix(secret, "0x"):
 		secret = secret[2:]
 	case strings.HasPrefix(secret, "xpub"):
-		return fmt.Errorf("not an extended private key")
+		return errors.New("not an extended private key")
 	case strings.HasPrefix(secret, "xprv"):
 		var err error
 		vc.master, err = hdkeychain.NewKeyFromString(secret)
@@ -190,12 +190,12 @@ func (vc *VinzClortho) DerivePath(path string) (*hdkeychain.ExtendedKey, error) 
 
 	p := strings.Split(path, "/")
 	if len(p) < 2 {
-		return nil, fmt.Errorf("invalid path")
+		return nil, errors.New("invalid path")
 	}
 
 	// p[0] must be m
 	if p[0] != "m" {
-		return nil, fmt.Errorf("invalid path prefix")
+		return nil, errors.New("invalid path prefix")
 	}
 
 	// p[1] is the account key and subsequent p elements are children.

--- a/cmd/btctool/blockstream/blockstream.go
+++ b/cmd/btctool/blockstream/blockstream.go
@@ -7,6 +7,7 @@ package blockstream
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -57,7 +58,7 @@ func Tip(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("parse int: %w", err)
 	}
 	if height < 0 {
-		return 0, fmt.Errorf("parse uint: unexpected negative value")
+		return 0, errors.New("parse uint: unexpected negative value")
 	}
 
 	return int(height), nil

--- a/cmd/btctool/btctool/btctool.go
+++ b/cmd/btctool/btctool/btctool.go
@@ -7,13 +7,14 @@ package btctool
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hemilabs/heminetwork/v2/cmd/btctool/bdf"
 	"github.com/hemilabs/heminetwork/v2/cmd/btctool/blockstream"
 )
 
 func GetAndStoreBlockHeader(ctx context.Context, height int, dir string) (string, error) {
-	hash, err := blockstream.BlockHeightHash(ctx, fmt.Sprintf("%v", height))
+	hash, err := blockstream.BlockHeightHash(ctx, strconv.Itoa(height))
 	if err != nil {
 		return "", fmt.Errorf("retrieve block by hash %v: %w", height, err)
 	}

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -265,7 +265,7 @@ func hproxyctl(pctx context.Context, flags []string) error {
 		}
 		hvm := args["hvm"]
 		if hvm == "" {
-			return fmt.Errorf("hvm must be set")
+			return errors.New("hvm must be set")
 		}
 		hvms := strings.Split(hvm, ",")
 		r := make([]map[string]any, len(hvms))
@@ -321,7 +321,7 @@ func hproxyctl(pctx context.Context, flags []string) error {
 		}
 		hvm := args["hvm"]
 		if hvm == "" {
-			return fmt.Errorf("hvm must be set")
+			return errors.New("hvm must be set")
 		}
 		hvms := strings.Split(hvm, ",")
 		r := make([]map[string]any, len(hvms))
@@ -989,10 +989,10 @@ func tbcdb(pctx context.Context, flags []string) error {
 		}
 
 	case "dumpmetadata":
-		return fmt.Errorf("fixme dumpmetadata")
+		return errors.New("fixme dumpmetadata")
 
 	case "dumpoutputs":
-		return fmt.Errorf("fixme dumpoutputs")
+		return errors.New("fixme dumpoutputs")
 		// s.DBClose()
 
 		// levelDBHome := "~/.tbcd" // XXX
@@ -1204,7 +1204,7 @@ func p2p(flags []string) error {
 
 	addr := args["addr"]
 	if addr == "" {
-		return fmt.Errorf("addr required")
+		return errors.New("addr required")
 	}
 
 	var network wire.BitcoinNet

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1112,7 +1112,7 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 		// This should never happen, one of the above three conditions must be true.
 		// Do this before the end of function so we don't apply database changes.
 		return tbcd.RTInvalid, nil,
-			fmt.Errorf("block headers remove: none of the chain geometry checks applies to this removal")
+			errors.New("block headers remove: none of the chain geometry checks applies to this removal")
 	}
 
 	// </MAXMADNESS>

--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -76,7 +76,7 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 			panic(fmt.Errorf("handleWebsocketRead: %w", err))
 		}
 		if errors.Is(err, io.EOF) {
-			panic(fmt.Errorf("handleWebsocketRead: EOF"))
+			panic(errors.New("handleWebsocketRead: EOF"))
 		}
 
 		return "", fmt.Errorf("handleWebsocketRead: %w", err)

--- a/service/bfg/bfg.go
+++ b/service/bfg/bfg.go
@@ -168,7 +168,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		}
 	case bitcoinSourceTBC:
 		if s.cfg.BitcoinURL == "" {
-			return nil, fmt.Errorf("invalid bitcoin url")
+			return nil, errors.New("invalid bitcoin url")
 		}
 		s.gozer = tbcgozer.New(s.cfg.BitcoinURL)
 	default:
@@ -183,7 +183,7 @@ func (s *Server) geth() (*ethclient.Client, error) {
 	geth := s.opgethClient
 	s.mtx.RUnlock()
 	if geth == nil {
-		return nil, fmt.Errorf("not connected")
+		return nil, errors.New("not connected")
 	}
 	return geth, nil
 }

--- a/service/continuum/protocol.go
+++ b/service/continuum/protocol.go
@@ -437,7 +437,7 @@ func NewSecretFromString(secret string) (*Secret, error) {
 	}
 	// This may not always be the case and may need to be a range.
 	if len(s) != 32 {
-		return nil, fmt.Errorf("invalid key")
+		return nil, errors.New("invalid key")
 	}
 	return NewSecretFromPrivate(secp256k1.PrivKeyFromBytes(s)), nil
 }
@@ -921,7 +921,7 @@ func (t *Transport) read(timeout time.Duration) (*Header, any, error) {
 // Read reads and decrypts the next command from the connection stream. It
 // returns the header and command.
 func (t *Transport) Read() (any, any, error) {
-	return nil, nil, fmt.Errorf("nope")
+	return nil, nil, errors.New("nope")
 }
 
 // write encrypts the passed in cleartext and writes it to the connection

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -83,7 +83,7 @@ type ForbiddenMethodError struct {
 }
 
 func (fme ForbiddenMethodError) Error() string {
-	return fmt.Sprintf("method not allowed: %s", fme.method)
+	return "method not allowed: " + fme.method
 }
 
 func (fme ForbiddenMethodError) Is(target error) bool {

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -243,7 +243,7 @@ func NewServer(cfg *Config) (*Server, error) {
 	switch s.cfg.BitcoinSource {
 	case bitcoinSourceTBC:
 		if s.cfg.BitcoinURL == "" {
-			return nil, fmt.Errorf("invalid bitcoin url")
+			return nil, errors.New("invalid bitcoin url")
 		}
 		s.gozer = tbcgozer.New(s.cfg.BitcoinURL)
 	case bitcoinSourceBlockstream:
@@ -368,7 +368,7 @@ func (s *Server) latestKeystones(ctx context.Context, count int) (*gethapi.L2Key
 		return nil, fmt.Errorf("opgeth rpc: %w", err)
 	}
 	if len(kr.L2Keystones) <= 0 {
-		return nil, fmt.Errorf("no keystones")
+		return nil, errors.New("no keystones")
 	}
 	return &kr, nil
 }

--- a/service/tbc/geometry.go
+++ b/service/tbc/geometry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -320,7 +320,7 @@ func findCommonParent(ctx context.Context, g geometryParams, bhX, bhY *tbcd.Bloc
 			if h != 0 {
 				panic("height 0 not genesis")
 			}
-			return nil, fmt.Errorf("genesis")
+			return nil, errors.New("genesis")
 		}
 
 		// See if all blockheaders share a common parent.

--- a/service/tbc/peer/peer.go
+++ b/service/tbc/peer/peer.go
@@ -94,7 +94,7 @@ func newInvalidTypeError(msg any, expected ...string) error {
 func (e *InvalidTypeError) Error() string {
 	switch {
 	case len(e.expected) == 0:
-		return fmt.Sprintf("invalid type: %s", e.actual)
+		return "invalid type: " + e.actual
 	case len(e.expected) == 1:
 		return fmt.Sprintf("invalid type: %s, expected %s",
 			e.actual, e.expected[0])
@@ -471,7 +471,7 @@ func (p *Peer) FeeFilter() (*wire.MsgFeeFilter, error) {
 	defer p.mtx.Unlock()
 
 	if p.feeFilterLast == nil {
-		return nil, fmt.Errorf("no fee filter received")
+		return nil, errors.New("no fee filter received")
 	}
 
 	ff := *p.feeFilterLast

--- a/service/tbc/peer/rawpeer/rawpeer.go
+++ b/service/tbc/peer/rawpeer/rawpeer.go
@@ -215,7 +215,7 @@ func (r *RawPeer) handshake(ctx context.Context, conn net.Conn) error {
 	expire := time.Now().Add(defaultHandshakeTimeout)
 	for {
 		if time.Now().After(expire) {
-			return fmt.Errorf("timeout")
+			return errors.New("timeout")
 		}
 		msg, err := readTimeout(defaultHandshakeTimeout, conn, r.protocolVersion, r.network)
 		if errors.Is(err, wire.ErrUnknownMessage) {

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -1261,7 +1262,7 @@ func wireBlockHeaderToTBC(bh *wire.BlockHeader) *tbcapi.BlockHeader {
 		PrevHash:   bh.PrevBlock,
 		MerkleRoot: bh.MerkleRoot,
 		Timestamp:  bh.Timestamp.Unix(),
-		Bits:       fmt.Sprintf("%x", bh.Bits),
+		Bits:       strconv.FormatUint(uint64(bh.Bits), 16),
 		Nonce:      bh.Nonce,
 	}
 }

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -120,7 +120,7 @@ func (e *ExternalHeaderNotAllowedError) Error() string {
 	if e.Op == "" {
 		return "not allowed in external-header mode"
 	}
-	return fmt.Sprintf("%s: not allowed in external-header mode", e.Op)
+	return e.Op + ": not allowed in external-header mode"
 }
 
 // Is allows errors.Is(err, &ExternalHeaderNotAllowedError{}) to match by type.
@@ -620,7 +620,7 @@ func (s *Server) handlePeer(ctx context.Context, p *rawpeer.RawPeer) error {
 	if uint64(remoteVersion.LastBlock) < bhb.Height {
 		// Disconnect for now. We only want more or less synced peers.
 		readError = err
-		return fmt.Errorf("remote peer height below ours")
+		return errors.New("remote peer height below ours")
 	} else {
 		err := s.getHeadersByHeights(ctx, p,
 			bhb.Height, bhb.Height-1000, bhb.Height-1999,

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -612,7 +612,7 @@ func TestForksWithGen(t *testing.T) {
 						"-regtest=1",
 						"-named",
 						"sendtoaddress",
-						fmt.Sprintf("address=%s", otherAddress.EncodeAddress()),
+						"address=" + otherAddress.EncodeAddress(),
 						"conf_target=1",
 						"amount=7",
 						"avoid_reuse=false",
@@ -725,7 +725,7 @@ func TestForksWithGen(t *testing.T) {
 							"-regtest=1",
 							"-named",
 							"sendtoaddress",
-							fmt.Sprintf("address=%s", otherAddress.EncodeAddress()),
+							"address=" + otherAddress.EncodeAddress(),
 							"conf_target=1",
 							"amount=3",
 							"subtractfeefromamount=true",
@@ -743,7 +743,7 @@ func TestForksWithGen(t *testing.T) {
 							"bitcoin-cli",
 							"-regtest=1",
 							"-generate",
-							fmt.Sprintf("%d", i*2+1),
+							strconv.Itoa(i*2 + 1),
 						})
 					if err != nil {
 						t.Fatal(err)
@@ -779,7 +779,7 @@ func TestForksWithGen(t *testing.T) {
 							"-regtest=1",
 							"-named",
 							"sendtoaddress",
-							fmt.Sprintf("address=%s", otherAddress.EncodeAddress()),
+							"address=" + otherAddress.EncodeAddress(),
 							"conf_target=1",
 							"amount=2",
 							"subtractfeefromamount=true",
@@ -797,7 +797,7 @@ func TestForksWithGen(t *testing.T) {
 							"bitcoin-cli",
 							"-regtest=1",
 							"-generate",
-							fmt.Sprintf("%d", i*2+2),
+							strconv.Itoa(i*2 + 2),
 						})
 					if err != nil {
 						t.Fatal(err)
@@ -827,7 +827,7 @@ func TestForksWithGen(t *testing.T) {
 						"-regtest=1",
 						"-named",
 						"sendtoaddress",
-						fmt.Sprintf("address=%s", otherAddress.EncodeAddress()),
+						"address=" + otherAddress.EncodeAddress(),
 						"conf_target=1",
 						"amount=7",
 						"avoid_reuse=false",
@@ -937,7 +937,7 @@ func TestForksWithGen(t *testing.T) {
 						"-regtest=1",
 						"-named",
 						"sendtoaddress",
-						fmt.Sprintf("address=%s", otherAddress.EncodeAddress()),
+						"address=" + otherAddress.EncodeAddress(),
 						"conf_target=1",
 						"amount=7",
 						"avoid_reuse=false",
@@ -1137,7 +1137,7 @@ func createBitcoind(ctx context.Context, t *testing.T) testcontainers.Container 
 		t.Fatal("failed to generate random id:", err)
 	}
 
-	name := fmt.Sprintf("bitcoind-%s", id)
+	name := "bitcoind-" + id
 	req := testcontainers.ContainerRequest{
 		Image:        "kylemanna/bitcoind",
 		Cmd:          []string{"bitcoind", "-regtest=1", "-debug=1", "-rpcallowip=0.0.0.0/0", "-rpcbind=0.0.0.0:18443", "-txindex=1", "-noonion", "-listenonion=0", "-fallbackfee=0.01", "-peerbloomfilters=1", "-debug"},
@@ -1196,7 +1196,7 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 			"bitcoin-cli",
 			"-regtest=1",
 			"getblockhash",
-			fmt.Sprintf("%d", 1),
+			strconv.Itoa(1),
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -1251,7 +1251,7 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 	cfg.Network = networkLocalnet
 	cfg.ListenAddress = "127.0.0.1:0"
 	cfg.Seeds = []string{
-		fmt.Sprintf("127.0.0.1:%s", mappedPeerPort.Port()),
+		"127.0.0.1:" + mappedPeerPort.Port(),
 	}
 
 	tbcServer, err := NewServer(cfg)
@@ -1392,7 +1392,7 @@ func bitcoindBlockAtHeight(ctx context.Context, t *testing.T, bitcoindContainer 
 		"bitcoin-cli",
 		"-regtest=1",
 		"getblockhash",
-		fmt.Sprintf("%d", height),
+		strconv.FormatUint(height, 10),
 	})
 	if err != nil {
 		t.Fatal(fmt.Errorf("bitcoin-cli getblockhash %d: %w", height, err))


### PR DESCRIPTION
**Summary**
Enable `perfsprint` linter in golangci-lint (https://github.com/catenacyber/perfsprint).

This linter replaces unnecessary use of formatting functions with more performant alternatives.

Additionally, add `goimports` to `formatters` to auto-add missing imports. `perfsprint` may change used package (e.g. `fmt` -> `strconv`) without adding the corresponding import, so `goimports` will auto fix this (may require running `make lint` twice in some cases).

**Changes**
- Add `perfsprint` linter to `.golangci.yaml`
- Add `goimports` formatter to `.golangci.yaml`
- Remove unused `gomoddirectives` setting in `.golangci.yaml`
- Apply changes from `perfsprint` linter.