### PR TITLE
e2e: update retry logic around eth bridging to include sending tx

### DIFF
--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -1005,14 +1005,13 @@ func bridgeEthL1ToL2(t *testing.T, ctx context.Context, l1Client *ethclient.Clie
 
 		t.Logf("receipt for tx.  gas used: %d, block number: %d, status %d", receipt.GasUsed, receipt.BlockNumber, receipt.Status)
 		break
-	}
 
-	if testingFork() {
-		waitSequencerWindowSizeForFork(t)
-	}
-	for {
+		if testingFork() {
+			waitSequencerWindowSizeForFork(t)
+		}
+
 		select {
-		case <-time.After(1 * time.Second):
+		case <-time.After(5 * time.Second):
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
@@ -1032,9 +1031,13 @@ func bridgeEthL1ToL2(t *testing.T, ctx context.Context, l1Client *ethclient.Clie
 		if balance.Cmp(value) < 0 {
 			t.Logf("unexpected balance: %s", balance)
 			continue
+		} else {
+			break
 		}
 
-		break
+		if i == abort {
+			t.Fatal("retries exceeded")
+		}
 	}
 }
 


### PR DESCRIPTION


**Summary**
when we attempt to bridge eth from l1 -> l2, prior we were only retying checking if the balance increased.  now retry the tx itself if the balance does not increase.

fixes #1011

**Changes**
see summary
