### PR TITLE
e2e: reorg bitcoin in localnet

### DIFF
--- a/e2e/block-does-not-exist.sh
+++ b/e2e/block-does-not-exist.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reads invalidated block hashes written by bitcoind-reorg and verifies none
+# exist on the target node. Exits 0 if all blocks are absent, 1 if any exist.
+set -euo pipefail
+
+: "${BITCOIND_RPC_URL:?BITCOIND_RPC_URL environment variable is required}"
+: "${BITCOIND_RPC_USER:?BITCOIND_RPC_USER environment variable is required}"
+: "${BITCOIND_RPC_PASS:?BITCOIND_RPC_PASS environment variable is required}"
+: "${INVALIDATED_HASHES_FILE:=/shared-dir/invalidated_hashes}"
+
+command -v jq   >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 2; }
+command -v curl >/dev/null 2>&1 || { echo "error: curl is required" >&2; exit 2; }
+
+[[ -f "$INVALIDATED_HASHES_FILE" ]] \
+    || { echo "error: hashes file not found: ${INVALIDATED_HASHES_FILE}" >&2; exit 2; }
+
+block_exists() {
+    local hash="$1"
+    local response error_code
+    response=$(curl -s -X POST "$BITCOIND_RPC_URL" \
+        -u "${BITCOIND_RPC_USER}:${BITCOIND_RPC_PASS}" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"1.0\",\"id\":\"blockcheck\",\"method\":\"getblockheader\",\"params\":[\"${hash}\",false]}") \
+        || { echo "error: RPC request failed" >&2; exit 2; }
+    error_code=$(printf '%s' "$response" | jq -r '.error.code // empty')
+    case "$error_code" in
+        "")  return 0 ;;  # no error → block found
+        -5)  return 1 ;;  # block not found
+        *)
+            echo "error: unexpected RPC error (code ${error_code}): $(printf '%s' "$response" | jq -r '.error.message // "unknown"')" >&2
+            exit 2
+            ;;
+    esac
+}
+
+while IFS= read -r hash || [[ -n "$hash" ]]; do
+    [[ -z "$hash" ]] && continue
+    if block_exists "$hash"; then
+        echo "block ${hash} still exists on ${BITCOIND_RPC_URL}" >&2
+        exit 1
+    fi
+    echo "block ${hash} confirmed absent"
+done < "$INVALIDATED_HASHES_FILE"

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -28,6 +28,71 @@ services:
     networks:
       e2e:
 
+  bitcoind-setban-1:
+    # yamllint disable-line rule:line-length
+    image: "kylemanna/bitcoind@sha256:46904e5c985f0148ca07a7702d17299fb5fa0678cb4a091c080c11ac78e92617"
+    depends_on:
+      bitcoind:
+        condition: "service_started"
+    restart: "on-failure"
+    command:
+      - bitcoin-cli
+      - "-regtest=1"
+      - "-rpcuser=user"
+      - "-rpcpassword=password"
+      - "-rpcport=18443"
+      - "-rpcconnect=bitcoind"
+      - setban
+      - "192.169.199.10"
+      - "add"
+    networks:
+      e2e:
+
+  bitcoind-setban-2:
+    # yamllint disable-line rule:line-length
+    image: "kylemanna/bitcoind@sha256:46904e5c985f0148ca07a7702d17299fb5fa0678cb4a091c080c11ac78e92617"
+    depends_on:
+      bitcoind:
+        condition: "service_started"
+    restart: "on-failure"
+    command:
+      - bitcoin-cli
+      - "-regtest=1"
+      - "-rpcuser=user"
+      - "-rpcpassword=password"
+      - "-rpcport=18443"
+      - "-rpcconnect=bitcoind"
+      - setban
+      - "192.169.199.11"
+      - "add"
+    networks:
+      e2e:
+
+  bitcoind-other:
+    # yamllint disable-line rule:line-length
+    image: "kylemanna/bitcoind@sha256:46904e5c985f0148ca07a7702d17299fb5fa0678cb4a091c080c11ac78e92617"
+    depends_on:
+      bitcoind-reorg:
+        condition: "service_completed_successfully"
+    command:
+      - "bitcoind"
+      - "-regtest=1"
+      - "-rpcuser=user"
+      - "-rpcpassword=password"
+      - "-rpcallowip=0.0.0.0/0"
+      - "-rpcbind=0.0.0.0:18443"
+      - "-txindex=1"
+      - "-rpcworkqueue=400"
+      - "-printtoconsole"
+      - "-addnode=bitcoind:18444"
+    ports:
+      - "28443:18443"
+      - "28444:18444"
+    volumes:
+      - {type: "tmpfs", target: "/bitcoin/.bitcoin"}
+    networks:
+      e2e:
+
   bitcoind-initialblocks:
     # yamllint disable-line rule:line-length
     image: "kylemanna/bitcoind@sha256:46904e5c985f0148ca07a7702d17299fb5fa0678cb4a091c080c11ac78e92617"
@@ -455,10 +520,57 @@ services:
     networks:
       e2e:
 
+  bitcoind-reorg:
+    depends_on:
+      wait-for-finalized:
+        condition: "service_completed_successfully"
+    image: optimism-stack:latest
+    volumes:
+      - ./invalidate_blocks.sh:/tmp/invalidate_blocks.sh
+      - shared-dir:/shared-dir
+    command:
+      - bash
+      - /tmp/invalidate_blocks.sh
+    environment:
+      ETH_RPC_URL: "http://op-geth-l2-non-sequencing:8546"
+      BITCOIND_RPC_URL: http://bitcoind:18443
+      BITCOIND_RPC_USER: user
+      BITCOIND_RPC_PASS: password
+    networks:
+      e2e:
+
+  bitcoind-block-removed:
+    depends_on:
+      bitcoind-other:
+        condition: "service_started"
+      bitcoind-reorg:
+        condition: "service_completed_successfully"
+      op-geth-l2-non-sequencing-snap-sync:
+        condition: "service_healthy"
+      op-geth-l2-non-sequencing-full-sync:
+        condition: "service_healthy"
+    image: optimism-stack:latest
+    volumes:
+      - ./block-does-not-exist.sh:/tmp/block-does-not-exist.sh
+      - shared-dir:/shared-dir
+    command:
+      - bash
+      - /tmp/block-does-not-exist.sh
+    environment:
+      BITCOIND_RPC_URL: http://bitcoind-other:18443
+      BITCOIND_RPC_USER: user
+      BITCOIND_RPC_PASS: password
+    networks:
+      e2e:
+
   op-geth-l2-non-sequencing-snap-sync:
     image: optimism-stack:latest
     depends_on:
-      wait-for-finalized:
+      bitcoind-other:
+        condition: "service_started"
+      bitcoind-setban-1:
+        condition: "service_completed_successfully"
+      bitcoind-setban-2:
         condition: "service_completed_successfully"
     healthcheck:
       test: ["CMD-SHELL", "ls /tmp/datadir/geth.ipc"]
@@ -470,6 +582,7 @@ services:
       OP_GETH_L1_RPC: "http://geth-l1:8545"
       HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
       GETH_SYNCMODE: "snap"
+      TBC_SEEDS: "bitcoind-other:18444"
     working_dir: "/tmp"
     command:
       - "sh"
@@ -487,13 +600,18 @@ services:
       - {type: "tmpfs", target: "/tmp"}
     networks:
       e2e:
+        ipv4_address: 192.169.199.10
     ports:
       - "28546:8546"
 
   op-geth-l2-non-sequencing-full-sync:
     image: optimism-stack:latest
     depends_on:
-      wait-for-finalized:
+      bitcoind-other:
+        condition: "service_started"
+      bitcoind-setban-1:
+        condition: "service_completed_successfully"
+      bitcoind-setban-2:
         condition: "service_completed_successfully"
     healthcheck:
       test: ["CMD-SHELL", "ls /tmp/datadir/geth.ipc"]
@@ -505,6 +623,7 @@ services:
       OP_GETH_L1_RPC: "http://geth-l1:8545"
       HVM_PHASE0_TIMESTAMP: ${HVM_PHASE0_TIMESTAMP}
       GETH_SYNCMODE: "full"
+      TBC_SEEDS: "bitcoind-other:18444"
     working_dir: "/tmp"
     command:
       - "sh"
@@ -522,6 +641,7 @@ services:
       - {type: "tmpfs", target: "/tmp"}
     networks:
       e2e:
+        ipv4_address: 192.169.199.11
     ports:
       - "38546:8546"
 
@@ -631,6 +751,7 @@ services:
       - ./proposer-entrypoint.sh:/proposer-entrypoint.sh
     networks:
       e2e:
+
 volumes:
   shared-dir:
 networks:

--- a/e2e/entrypointl2.sh
+++ b/e2e/entrypointl2.sh
@@ -94,7 +94,7 @@ echo "setting hvm genesis to $BLOCKHEADER:$BLOCKHEIGHT"
  --authrpc.jwtsecret=/tmp/jwt.hex \
  --tbc.network=localnet \
  --tbc.prometheusaddress='0.0.0.0:5555' \
- --tbc.seeds='bitcoind:18444' \
+ --tbc.seeds="${TBC_SEEDS:-bitcoind:18444}" \
  --override.ecotone=1725868497 \
  --override.canyon=1725868497 \
  --hvm.headerdatadir=/tbc/headers \

--- a/e2e/invalidate_blocks.sh
+++ b/e2e/invalidate_blocks.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ETH_RPC_URL:?ETH_RPC_URL environment variable is required}"
+: "${BITCOIND_RPC_URL:?BITCOIND_RPC_URL environment variable is required}"
+: "${BITCOIND_RPC_USER:?BITCOIND_RPC_USER environment variable is required}"
+: "${BITCOIND_RPC_PASS:?BITCOIND_RPC_PASS environment variable is required}"
+: "${INVALIDATED_HASHES_FILE:=/shared-dir/invalidated_hashes}"
+command -v jq        >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
+command -v xxd       >/dev/null 2>&1 || { echo "error: xxd is required" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "error: sha256sum is required" >&2; exit 1; }
+
+ZERO_HASH="0x0000000000000000000000000000000000000000000000000000000000000000"
+
+rpc() {
+    curl -sf -X POST "$ETH_RPC_URL" \
+        -H "Content-Type: application/json" \
+        -d "$1"
+}
+
+invalidate_block() {
+    local btc_hash="$1"
+    if grep -qF "$btc_hash" "$INVALIDATED_HASHES_FILE" 2>/dev/null; then
+        echo "    skipping duplicate: $btc_hash"
+        return
+    fi
+    echo "    invalidating block: $btc_hash"
+    local response
+    response=$(curl -sf -X POST "$BITCOIND_RPC_URL" \
+        -u "${BITCOIND_RPC_USER}:${BITCOIND_RPC_PASS}" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"1.0\",\"id\":\"scan\",\"method\":\"invalidateblock\",\"params\":[\"$btc_hash\"]}")
+    local err
+    err=$(printf '%s' "$response" | jq -r '.error')
+    if [[ "$err" != "null" ]]; then
+        echo "error: invalidateblock failed for $btc_hash: $err" >&2
+        exit 1
+    fi
+    printf '%s\n' "$btc_hash" >> "$INVALIDATED_HASHES_FILE"
+}
+
+tx_type_name() {
+    case "$1" in
+        0x0|"null") echo "legacy" ;;
+        0x1)        echo "eip-2930" ;;
+        0x2)        echo "eip-1559" ;;
+        0x3)        echo "eip-4844 blob" ;;
+        0x7c)       echo "bitcoin attributes deposited" ;;
+        *)          echo "unknown ($1)" ;;
+    esac
+}
+
+# Reverse a hex string byte-by-byte (for Bitcoin display order).
+reverse_hex() {
+    printf '%s' "$1" | awk '{
+        for (i = length($0) - 1; i >= 1; i -= 2)
+            printf "%s", substr($0, i, 2)
+    }'
+}
+
+# Double SHA-256 of raw bytes encoded as hex; result in Bitcoin display order.
+btc_hash() {
+    local hex="$1"
+    local pass1 pass2
+    pass1=$(printf '%s' "$hex" | xxd -r -p | sha256sum -b | cut -d' ' -f1)
+    pass2=$(printf '%s' "$pass1" | xxd -r -p | sha256sum -b | cut -d' ' -f1)
+    reverse_hex "$pass2"
+}
+
+# Parse a 0x7c bitcoin attributes deposited transaction input field.
+#
+# ABI layout (all multi-byte integers are big-endian 32-byte words):
+#   [0:4]        4 B  function selector
+#   [4:36]      32 B  canonicalTip (Bitcoin block hash)
+#   [36:68]     32 B  initialOffset (uint64, right-aligned)
+#   [68:100]    32 B  numHeaders   (uint64, right-aligned)
+#   [100:100+32N] 32B × N  per-header ABI offsets
+#   then for each header i:
+#     [+0:+32]  32 B  header byte-length word
+#     [+32:+112] 80 B  raw Bitcoin header
+#     [+112:+128] 16 B  ABI padding (80 rounds up to 3×32 = 96 bytes)
+parse_btc_deposit_tx() {
+    local input="${1#0x}"  # strip leading 0x
+
+    # canonicalTip: bytes 4-35 → nibbles 8-71
+    local canonical_tip
+    canonical_tip=$(reverse_hex "${input:8:64}")
+    echo "    canonical tip: $canonical_tip"
+    invalidate_block "$canonical_tip"
+
+    # numHeaders: bytes 68-99 (32-byte ABI word), uint64 in last 16 nibbles
+    local num_headers
+    num_headers=$(printf "%d" "0x${input:184:16}")
+
+    # first header block starts at byte 100 + 32*N, then +32 for the length word
+    local headers_base_nibble=$(( (132 + 32 * num_headers) * 2 ))
+
+    local i=0
+    while [[ $i -lt $num_headers ]]; do
+        # each header block is 128 bytes = 256 nibbles; data begins after the 32-byte length word (64 nibbles)
+        local header_hex="${input:$(( headers_base_nibble + i * 256 )):160}"
+        local hdr_hash
+        hdr_hash=$(btc_hash "$header_hex")
+        echo "    header $i hash: $hdr_hash"
+        invalidate_block "$hdr_hash"
+        i=$(( i + 1 ))
+    done
+}
+
+result=$(rpc '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest",true],"id":1}')
+hash=$(printf '%s' "$result" | jq -r '.result.hash')
+
+if [[ -z "$hash" || "$hash" == "null" ]]; then
+    echo "error: failed to fetch latest block" >&2
+    exit 1
+fi
+
+while true; do
+    result=$(rpc "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByHash\",\"params\":[\"$hash\",true],\"id\":1}")
+    block=$(printf '%s' "$result" | jq '.result')
+    number=$(printf '%s' "$block" | jq -r '.number')
+    parent=$(printf '%s' "$block" | jq -r '.parentHash')
+
+    echo "block $number ($hash)"
+
+    while read -r tx; do
+        tx_hash=$(printf '%s' "$tx" | jq -r '.hash')
+        tx_type=$(printf '%s' "$tx" | jq -r '.type // "null"')
+        echo "  tx $tx_hash  type=$(tx_type_name "$tx_type")"
+        if [[ "$tx_type" == "0x7c" ]]; then
+            echo "found bitcoin attributes deposited transaction: $tx_hash"
+            parse_btc_deposit_tx "$(printf '%s' "$tx" | jq -r '.input')"
+            exit 0
+        fi
+    done < <(printf '%s' "$block" | jq -c '.transactions[]')
+
+    [[ "$parent" == "$ZERO_HASH" ]] && break
+    hash="$parent"
+done
+
+echo "error: no bitcoin attributes deposited transaction found" >&2
+exit 1

--- a/e2e/monitor/main.go
+++ b/e2e/monitor/main.go
@@ -201,14 +201,25 @@ func monitorPopTxs(ctx context.Context, s *state, mtx *sync.Mutex) {
 			panic(fmt.Sprintf("could not get chain tips: %v", err))
 		}
 
-		if len(tips) != 1 {
-			// should not happen in localnet
-			continue
+		// we have introduced bitcoin forking into localnet tests, so we must
+		// ensure that we use the active tip (there will be multiple tips)
+		var activeTipHash string
+
+		for _, potentialActiveTip := range tips {
+			if potentialActiveTip.Status == "active" {
+				activeTipHash = potentialActiveTip.Hash
+				break
+			}
 		}
 
-		hash, err := chainhash.NewHashFromStr(tips[0].Hash)
+		// should not happen in localnet
+		if activeTipHash == "" {
+			panic("could not find active tip")
+		}
+
+		hash, err := chainhash.NewHashFromStr(activeTipHash)
 		if err != nil {
-			panic(fmt.Sprintf("could not get hash from string %s: %v", tips[0].Hash, err))
+			panic(fmt.Sprintf("could not get hash from string %s: %v", activeTipHash, err))
 		}
 
 		if ctx.Err() != nil {
@@ -217,7 +228,7 @@ func monitorPopTxs(ctx context.Context, s *state, mtx *sync.Mutex) {
 
 		block, err := c.GetBlock(hash)
 		if err != nil {
-			panic(fmt.Sprintf("could not get block from hash %v: %v", tips[0].Hash, err))
+			panic(fmt.Sprintf("could not get block from hash %v: %v", activeTipHash, err))
 		}
 
 		for block != nil {

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -57,7 +57,7 @@ ARG OPTIMISM_COMMIT
 COPY --from=build_1 /git/op-geth/build/bin/geth /bin/geth
 
 RUN apt-get update
-RUN apt-get install -y jq yq
+RUN apt-get install -y jq yq xxd
 
 WORKDIR /git
 COPY --from=build_1 /git/op-geth /git/op-geth


### PR DESCRIPTION


**Summary**
* upon a finalized block, invalidate a bitcoin block via "invalidateblock" rpc call
* start up another bitcoind node, bitcoind-other, and connect it to the first bitcoind via p2p
* start up nodes that need to snap sync and full sync, with their tbcs connected to bitcoind-other
* assert that the block cannot be retrived in bitcoind-other
* use the "active" tip in tests since we now have a fork in our bitcoin network
* add "setban" call to ensure that *-full-sync and *-snap-sync nodes cannot connect to bitcoind containing the invalidated block, i.e. they have to find it another way

fixes https://github.com/hemilabs/heminetwork/issues/989

**Changes**
see summary
