### PR TITLE
all: enable revive linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,8 +31,7 @@ linters:
     - "prealloc" # Finds slice declarations that could potentially be pre-allocated.
     - "predeclared" # Find code that shadows one of Go's predeclared identifiers.
     - "promlinter" # Check Prometheus metrics naming via promlint.
-    # TODO: enable revive - when bored, run 'golangci-lint run -Erevive' and fix issues
-    # - "revive" # Miscellaneous linter
+    - "revive" # Miscellaneous linter
     - "staticcheck" # Runs staticcheck.
     - "sqlclosecheck" # Checks that sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed.
     - "rowserrcheck" # Checks whether Rows.Err of rows is checked successfully.

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -62,11 +62,11 @@ const (
 	CmdUTXOsByAddressRequest  = "tbcapi-utxos-by-address-request"
 	CmdUTXOsByAddressResponse = "tbcapi-utxos-by-address-response"
 
-	CmdTxByIdRawRequest  = "tbcapi-tx-by-id-raw-request"
-	CmdTxByIdRawResponse = "tbcapi-tx-by-id-raw-response"
+	CmdTxByIDRawRequest  = "tbcapi-tx-by-id-raw-request"
+	CmdTxByIDRawResponse = "tbcapi-tx-by-id-raw-response"
 
-	CmdTxByIdRequest  = "tbcapi-tx-by-id-request"
-	CmdTxByIdResponse = "tbcapi-tx-by-id-response"
+	CmdTxByIDRequest  = "tbcapi-tx-by-id-request"
+	CmdTxByIDResponse = "tbcapi-tx-by-id-response"
 
 	CmdTxBroadcastRequest  = "tbcapi-tx-broadcast-request"
 	CmdTxBroadcastResponse = "tbcapi-tx-broadcast-response"
@@ -173,7 +173,7 @@ type Tx struct {
 
 // UTXO represents a Bitcoin unspent transaction output.
 type UTXO struct {
-	TxId     chainhash.Hash `json:"tx_id"`
+	TxID     chainhash.Hash `json:"tx_id"`
 	Value    btcutil.Amount `json:"value"`
 	OutIndex uint32         `json:"out_index"`
 }
@@ -296,20 +296,20 @@ type UTXOsByAddressResponse struct {
 	Error *protocol.Error `json:"error,omitempty"`
 }
 
-type TxByIdRawRequest struct {
+type TxByIDRawRequest struct {
 	TxID chainhash.Hash `json:"tx_id"`
 }
 
-type TxByIdRawResponse struct {
+type TxByIDRawResponse struct {
 	Tx    api.ByteSlice   `json:"tx"`
 	Error *protocol.Error `json:"error,omitempty"`
 }
 
-type TxByIdRequest struct {
+type TxByIDRequest struct {
 	TxID chainhash.Hash `json:"tx_id"`
 }
 
-type TxByIdResponse struct {
+type TxByIDResponse struct {
 	Tx    *Tx             `json:"tx"`
 	Error *protocol.Error `json:"error,omitempty"`
 }
@@ -444,8 +444,8 @@ type MempoolUtxosRequest struct {
 
 // MempoolUTXO is an output from an unconfirmed mempool transaction.
 type MempoolUTXO struct {
-	// TxId is the transaction hash containing this output.
-	TxId chainhash.Hash `json:"tx_id"`
+	// TxID is the transaction hash containing this output.
+	TxID chainhash.Hash `json:"tx_id"`
 
 	// Value is the output amount in satoshis.
 	Value btcutil.Amount `json:"value"`
@@ -608,10 +608,10 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdUTXOsByAddressRawResponse:                reflect.TypeFor[UTXOsByAddressRawResponse](),
 	CmdUTXOsByAddressRequest:                    reflect.TypeFor[UTXOsByAddressRequest](),
 	CmdUTXOsByAddressResponse:                   reflect.TypeFor[UTXOsByAddressResponse](),
-	CmdTxByIdRawRequest:                         reflect.TypeFor[TxByIdRawRequest](),
-	CmdTxByIdRawResponse:                        reflect.TypeFor[TxByIdRawResponse](),
-	CmdTxByIdRequest:                            reflect.TypeFor[TxByIdRequest](),
-	CmdTxByIdResponse:                           reflect.TypeFor[TxByIdResponse](),
+	CmdTxByIDRawRequest:                         reflect.TypeFor[TxByIDRawRequest](),
+	CmdTxByIDRawResponse:                        reflect.TypeFor[TxByIDRawResponse](),
+	CmdTxByIDRequest:                            reflect.TypeFor[TxByIDRequest](),
+	CmdTxByIDResponse:                           reflect.TypeFor[TxByIDResponse](),
 	CmdTxBroadcastRequest:                       reflect.TypeFor[TxBroadcastRequest](),
 	CmdTxBroadcastResponse:                      reflect.TypeFor[TxBroadcastResponse](),
 	CmdTxBroadcastRawRequest:                    reflect.TypeFor[TxBroadcastRawRequest](),

--- a/bitcoin/wallet/gozer/blockstream/blockstream.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream.go
@@ -156,7 +156,7 @@ func (bs *blockstreamGozer) BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*c
 	return txidHash, nil
 }
 
-func (bs *blockstreamGozer) UtxosByAddress(ctx context.Context, filterMempool bool, addr btcutil.Address, start, count uint) ([]*tbcapi.UTXO, error) {
+func (bs *blockstreamGozer) UtxosByAddress(ctx context.Context, _ bool, addr btcutil.Address, _, _ uint) ([]*tbcapi.UTXO, error) {
 	u := fmt.Sprintf("%v/address/%v/utxo", bs.url, addr)
 	utxos, err := httpclient.Request(ctx, "GET", u, nil)
 	if err != nil {
@@ -171,7 +171,7 @@ func (bs *blockstreamGozer) UtxosByAddress(ctx context.Context, filterMempool bo
 		BlockTime   int64          `json:"block_time"`
 	}
 	type utxosJSON struct {
-		TxId   chainhash.Hash `json:"txid"`
+		TxID   chainhash.Hash `json:"txid"`
 		Vout   uint32         `json:"vout"`
 		Value  btcutil.Amount `json:"value"`
 		Status statusJSON     `json:"status"`
@@ -188,7 +188,7 @@ func (bs *blockstreamGozer) UtxosByAddress(ctx context.Context, filterMempool bo
 			continue
 		}
 		urv = append(urv, &tbcapi.UTXO{
-			TxId:     v.TxId,
+			TxID:     v.TxID,
 			OutIndex: v.Vout,
 			Value:    v.Value,
 		})
@@ -201,13 +201,13 @@ func (bs *blockstreamGozer) MempoolUtxos(_ context.Context, _ []api.ByteSlice) (
 	return nil, errors.New("mempool utxos not supported by blockstream")
 }
 
-func (bs *blockstreamGozer) BlocksByL2AbrevHashes(ctx context.Context, hashes []chainhash.Hash) *gozer.BlocksByL2AbrevHashesResponse {
+func (bs *blockstreamGozer) BlocksByL2AbrevHashes(_ context.Context, _ []chainhash.Hash) *gozer.BlocksByL2AbrevHashesResponse {
 	return &gozer.BlocksByL2AbrevHashesResponse{
 		Error: protocol.Errorf("not supported yet"),
 	}
 }
 
-func (bs *blockstreamGozer) KeystonesByHeight(ctx context.Context, height uint32, depth int) (*gozer.KeystonesByHeightResponse, error) {
+func (bs *blockstreamGozer) KeystonesByHeight(_ context.Context, _ uint32, _ int) (*gozer.KeystonesByHeightResponse, error) {
 	err := errors.New("not supported yet")
 	return &gozer.KeystonesByHeightResponse{
 		Error: protocol.Errorf("%v", err),
@@ -218,7 +218,7 @@ func (bs *blockstreamGozer) KeystonesByHeight(ctx context.Context, height uint32
 // TxByID is a stub — blockstream support for transaction lookup is
 // not yet implemented.  The only consumer today is ectoplasm which
 // uses tbcGozer.
-func (bs *blockstreamGozer) TxByID(ctx context.Context, txid *chainhash.Hash) (*tbcapi.Tx, error) {
+func (bs *blockstreamGozer) TxByID(_ context.Context, _ *chainhash.Hash) (*tbcapi.Tx, error) {
 	// Blockstream exposes GET /tx/{txid}/hex and GET /tx/{txid},
 	// either of which could be mapped onto *tbcapi.Tx.  Left as
 	// a stub here because the only consumer today is ectoplasm

--- a/bitcoin/wallet/gozer/blockstream/blockstream_test.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer"
 )
 
-func mockHttpServer() *httptest.Server {
+func mockHTTPServer() *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fakeHash := "00000000c5cbf1fcdc75539ac75fe8a98417976e548197355b3e5f6c4e884a17"
 		switch {
@@ -98,7 +98,7 @@ func TestBlockstreamGozer(t *testing.T) {
 	defer cancel()
 
 	// use mock http server rather than blockstream api
-	ts := mockHttpServer()
+	ts := mockHTTPServer()
 	defer ts.Close()
 
 	// can't use Run() for custom urls

--- a/bitcoin/wallet/gozer/filter_test.go
+++ b/bitcoin/wallet/gozer/filter_test.go
@@ -18,10 +18,10 @@ func TestFilterSpent(t *testing.T) {
 	h3 := chainhash.HashH([]byte("tx3"))
 
 	utxos := []*tbcapi.MempoolUTXO{
-		{TxId: h1, OutIndex: 0, Value: 1000},
-		{TxId: h1, OutIndex: 1, Value: 2000},
-		{TxId: h2, OutIndex: 0, Value: 3000},
-		{TxId: h3, OutIndex: 0, Value: 4000},
+		{TxID: h1, OutIndex: 0, Value: 1000},
+		{TxID: h1, OutIndex: 1, Value: 2000},
+		{TxID: h2, OutIndex: 0, Value: 3000},
+		{TxID: h3, OutIndex: 0, Value: 4000},
 	}
 
 	t.Run("no spent", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestFilterSpent(t *testing.T) {
 			t.Fatalf("got %d, want 3", len(result))
 		}
 		for _, u := range result {
-			if u.TxId == h1 && u.OutIndex == 0 {
+			if u.TxID == h1 && u.OutIndex == 0 {
 				t.Fatal("spent utxo should be excluded")
 			}
 		}

--- a/bitcoin/wallet/gozer/gozer.go
+++ b/bitcoin/wallet/gozer/gozer.go
@@ -146,7 +146,7 @@ type KeystonesByHeightResponse struct {
 	Error            *protocol.Error         `json:"error,omitempty"`
 }
 
-// FilterSpent removes mempool UTXOs whose outpoint (TxId:OutIndex)
+// FilterSpent removes mempool UTXOs whose outpoint (TxID:OutIndex)
 // appears in the spent set.  Use this to exclude outputs that have
 // been spent by another mempool transaction (CPFP chains).
 func FilterSpent(utxos []*tbcapi.MempoolUTXO, spent []tbcapi.OutPoint) []*tbcapi.MempoolUTXO {
@@ -163,7 +163,7 @@ func FilterSpent(utxos []*tbcapi.MempoolUTXO, spent []tbcapi.OutPoint) []*tbcapi
 	}
 	var out []*tbcapi.MempoolUTXO
 	for _, u := range utxos {
-		if _, ok := set[op{Hash: u.TxId, Index: u.OutIndex}]; ok {
+		if _, ok := set[op{Hash: u.TxID, Index: u.OutIndex}]; ok {
 			continue
 		}
 		out = append(out, u)

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -64,9 +64,9 @@ type tbcGozer struct {
 
 var _ gozer.Gozer = (*tbcGozer)(nil)
 
-func New(tbcUrl string) gozer.Gozer {
+func New(tbcURL string) gozer.Gozer {
 	return &tbcGozer{
-		url:   tbcUrl,
+		url:   tbcURL,
 		cmdCh: make(chan tbcCmd, DefaultCommandQueueDepth),
 	}
 }
@@ -162,16 +162,16 @@ func (t *tbcGozer) TxByID(ctx context.Context, txid *chainhash.Hash) (*tbcapi.Tx
 	if txid == nil {
 		return nil, errors.New("txid is nil")
 	}
-	req := &tbcapi.TxByIdRequest{TxID: *txid}
+	req := &tbcapi.TxByIDRequest{TxID: *txid}
 
 	res, err := t.callTBC(ctx, DefaultRequestTimeout, req)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, ok := res.(*tbcapi.TxByIdResponse)
+	resp, ok := res.(*tbcapi.TxByIDResponse)
 	if !ok {
-		return nil, fmt.Errorf("not a TxByIdResponse: %T", res)
+		return nil, fmt.Errorf("not a TxByIDResponse: %T", res)
 	}
 
 	if resp.Error != nil {

--- a/bitcoin/wallet/wallet.go
+++ b/bitcoin/wallet/wallet.go
@@ -100,7 +100,7 @@ func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerByte float
 	tx.LockTime = locktime
 	prevOuts := make(PrevOuts, len(utxoList))
 	for _, utxo := range utxoList {
-		outpoint := wire.NewOutPoint(&utxo.TxId, utxo.OutIndex)
+		outpoint := wire.NewOutPoint(&utxo.TxID, utxo.OutIndex)
 		tx.AddTxIn(wire.NewTxIn(outpoint, script, nil))
 		prevOuts[outpoint.String()] = wire.NewTxOut(int64(utxo.Value), script)
 	}
@@ -143,7 +143,7 @@ func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerB
 	// Assemble transaction
 	tx := wire.NewMsgTx(2) // Latest supported version
 	tx.LockTime = locktime
-	outpoint := wire.NewOutPoint(&utxo.TxId, utxo.OutIndex)
+	outpoint := wire.NewOutPoint(&utxo.TxID, utxo.OutIndex)
 	tx.AddTxIn(wire.NewTxIn(outpoint, script, nil))
 
 	// Return previous outs to caller so that they can be signed.

--- a/bitcoin/wallet/wallet_pop_test.go
+++ b/bitcoin/wallet/wallet_pop_test.go
@@ -65,7 +65,7 @@ func newPoPFixture(t *testing.T) *popFixture {
 
 	fundHash := chainhash.DoubleHashH([]byte("pop-regression-funding-txid-000"))
 	utxo := &tbcapi.UTXO{
-		TxId:     fundHash,
+		TxID:     fundHash,
 		OutIndex: 0,
 		Value:    btcutil.Amount(500000),
 	}

--- a/cmd/btctool/btctool.go
+++ b/cmd/btctool/btctool.go
@@ -67,7 +67,7 @@ func parseBlockFromHex(blk string) (*btcutil.Block, error) {
 	return b, nil
 }
 
-func parseBlock(ctx context.Context, filename string) (*btcutil.Block, error) {
+func parseBlock(_ context.Context, filename string) (*btcutil.Block, error) {
 	heb, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (p *peer) read() (wire.Message, error) {
 	return msg, err
 }
 
-func (p *peer) handshake(ctx context.Context) error {
+func (p *peer) handshake(_ context.Context) error {
 	// 1. send our version
 	// 2. receive version
 	// 3. send sendaddrv2
@@ -257,7 +257,7 @@ func handleInv(p *peer, msg *wire.MsgInv) {
 	}
 }
 
-func handleBlock(p *peer, msg *wire.MsgBlock) {
+func handleBlock(_ *peer, msg *wire.MsgBlock) {
 	fmt.Printf("handle block: %v txs %v\n", msg.Header.BlockHash(),
 		len(msg.Transactions))
 }

--- a/cmd/hemictl/hemictl.go
+++ b/cmd/hemictl/hemictl.go
@@ -619,7 +619,7 @@ func tbcdb(pctx context.Context, flags []string) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		bh, err := s.BlockHashByTxId(ctx, *chtxid)
+		bh, err := s.BlockHashByTxID(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("block by txid: %w", err)
 		}
@@ -635,7 +635,7 @@ func tbcdb(pctx context.Context, flags []string) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		tx, err := s.TxById(ctx, *chtxid)
+		tx, err := s.TxByID(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("block by txid: %w", err)
 		}
@@ -651,7 +651,7 @@ func tbcdb(pctx context.Context, flags []string) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		si, err := s.SpentOutputsByTxId(ctx, *chtxid)
+		si, err := s.SpentOutputsByTxID(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("spend outputs by txid: %w", err)
 		}
@@ -670,7 +670,7 @@ func tbcdb(pctx context.Context, flags []string) error {
 			return fmt.Errorf("chainhash: %w", err)
 		}
 
-		si, err := s.SpentOutputsByTxId(ctx, *chtxid)
+		si, err := s.SpentOutputsByTxID(ctx, *chtxid)
 		if err != nil {
 			return fmt.Errorf("spend outputs by txid: %w", err)
 		}
@@ -687,8 +687,8 @@ func tbcdb(pctx context.Context, flags []string) error {
 		if err != nil {
 			return err
 		}
-		txIdBytes := [32]byte(chtxid.CloneBytes())
-		op := tbcd.NewOutpoint(txIdBytes, uint32(idx))
+		txIDBytes := [32]byte(chtxid.CloneBytes())
+		op := tbcd.NewOutpoint(txIDBytes, uint32(idx))
 		// copy(h[:], chtxid[:])
 		// op := tbcd.NewOutpoint(h, uint32(idx))
 		sh, err := s.ScriptHashByOutpoint(ctx, op)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,8 +16,8 @@ type MyConfig struct {
 }
 
 var (
-	cfg        = MyConfig{}
-	cm  CfgMap = CfgMap{
+	cfg = MyConfig{}
+	cm  = CfgMap{
 		"STRING": Config{
 			Value:        &cfg.IamString,
 			DefaultValue: "default",

--- a/database/level/level.go
+++ b/database/level/level.go
@@ -172,7 +172,7 @@ func (l *Database) openRawDB(name string, blockSize int64) error {
 	return nil
 }
 
-func New(ctx context.Context, cfg *Config) (*Database, error) {
+func New(_ context.Context, cfg *Config) (*Database, error) {
 	log.Tracef("New")
 	defer log.Tracef("New exit")
 

--- a/database/tbcd/database.go
+++ b/database/tbcd/database.go
@@ -120,8 +120,8 @@ type Database interface {
 	BlockHeaderByTxIndex(ctx context.Context) (*BlockHeader, error)
 	BlockUtxoUpdate(ctx context.Context, direction int, utxos map[Outpoint]CacheOutput, utxoIndexHash chainhash.Hash) error
 	BlockTxUpdate(ctx context.Context, direction int, txs map[TxKey]*TxValue, txIndexHash chainhash.Hash) error
-	BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainhash.Hash, error)
-	SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]SpentInfo, error)
+	BlockHashByTxID(ctx context.Context, txID chainhash.Hash) (*chainhash.Hash, error)
+	SpentOutputsByTxID(ctx context.Context, txID chainhash.Hash) ([]SpentInfo, error)
 	// ScriptHash returns the sha256 of PkScript for the provided outpoint.
 	BalanceByScriptHash(ctx context.Context, sh ScriptHash) (uint64, error)
 	BlockInTxIndex(ctx context.Context, hash chainhash.Hash) (bool, error)
@@ -213,7 +213,7 @@ type BlockIdentifier struct {
 
 type SpentInfo struct {
 	BlockHash  *chainhash.Hash
-	TxId       *chainhash.Hash
+	TxID       *chainhash.Hash
 	InputIndex uint32
 }
 
@@ -234,11 +234,11 @@ func (o Outpoint) String() string {
 	return fmt.Sprintf("%s:%d", hash, binary.BigEndian.Uint32(o[33:]))
 }
 
-func (o Outpoint) TxId() []byte {
+func (o Outpoint) TxID() []byte {
 	return o[1:33]
 }
 
-func (o Outpoint) TxIdHash() *chainhash.Hash {
+func (o Outpoint) TxIDHash() *chainhash.Hash {
 	h, _ := chainhash.NewHash(o[1:33])
 	return h
 }
@@ -456,7 +456,7 @@ type (
 
 // NewTxSpent returns a TxKey and TxValue that maps a spent transaction to a
 // location in a block.
-func NewTxSpent(blockHash, txId, inPrevHash *chainhash.Hash, inPrevIndex, txInIndex uint32) (txKey TxKey, txValue TxValue) {
+func NewTxSpent(blockHash, txID, inPrevHash *chainhash.Hash, inPrevIndex, txInIndex uint32) (txKey TxKey, txValue TxValue) {
 	// Construct key
 	txKey[0] = 's'
 	copy(txKey[1:33], inPrevHash[:])
@@ -464,27 +464,27 @@ func NewTxSpent(blockHash, txId, inPrevHash *chainhash.Hash, inPrevIndex, txInIn
 	copy(txKey[37:], blockHash[:])
 
 	// Construct value
-	copy(txValue[0:], txId[:])
+	copy(txValue[0:], txID[:])
 	binary.BigEndian.PutUint32(txValue[32:36], txInIndex)
 
 	return txKey, txValue
 }
 
 // NewTxMapping returns a TxKey and TxValue that maps a tx id to a block hash.
-func NewTxMapping(txId, blockHash *chainhash.Hash) (txKey TxKey) {
+func NewTxMapping(txID, blockHash *chainhash.Hash) (txKey TxKey) {
 	// Construct key
 	txKey[0] = 't'
-	copy(txKey[1:33], txId[:])
+	copy(txKey[1:33], txID[:])
 	copy(txKey[33:], blockHash[:])
 
 	return txKey
 }
 
-func TxIdBlockHashFromTxKey(txKey TxKey) (*chainhash.Hash, *chainhash.Hash, error) {
+func TxIDBlockHashFromTxKey(txKey TxKey) (*chainhash.Hash, *chainhash.Hash, error) {
 	if txKey[0] != 't' {
 		return nil, nil, fmt.Errorf("invalid magic 0x%02x", txKey[0])
 	}
-	txId, err := chainhash.NewHash(txKey[1:33])
+	txID, err := chainhash.NewHash(txKey[1:33])
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid tx id: %w", err)
 	}
@@ -492,7 +492,7 @@ func TxIdBlockHashFromTxKey(txKey TxKey) (*chainhash.Hash, *chainhash.Hash, erro
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid block hash: %w", err)
 	}
-	return txId, blockHash, nil
+	return txID, blockHash, nil
 }
 
 // Cache
@@ -515,8 +515,8 @@ type ZKSpendingOutpoint struct {
 	SpendingOutpoint *ZKSpendingOutpointValue
 }
 
-func NewSpendingOutpointKey(txId chainhash.Hash, height uint32, blockHash chainhash.Hash, voutIdx uint32) (sok SpendingOutpointKey) {
-	copy(sok[:], txId[:])
+func NewSpendingOutpointKey(txID chainhash.Hash, height uint32, blockHash chainhash.Hash, voutIdx uint32) (sok SpendingOutpointKey) {
+	copy(sok[:], txID[:])
 	binary.BigEndian.PutUint32(sok[32:], height)
 	copy(sok[32+4:], blockHash[:])
 	binary.BigEndian.PutUint32(sok[32+4+32:], voutIdx)
@@ -547,7 +547,7 @@ func NewSpendingOutpointValueSlice(h chainhash.Hash, idx uint32) []byte {
 	return p[:]
 }
 
-// SpentOutput sha256(PreviousOutPoint->pkscript):blockheight:blockhash:txId:PreviousOutPoint.Hash:PreviousOutPoint.Index:txInIdx
+// SpentOutput sha256(PreviousOutPoint->pkscript):blockheight:blockhash:txID:PreviousOutPoint.Hash:PreviousOutPoint.Index:txInIdx
 type SpentOutput [32 + 4 + 32 + 32 + 32 + 4 + 4]byte
 
 type ZKSpentOutput struct {
@@ -571,7 +571,7 @@ func NewSpentOutput(prevScripthash chainhash.Hash, height uint32, blockhash, txi
 	return o
 }
 
-// SpendableOutput = sha256(PkScript):blockheight:blockhash:txId:txOutIdx
+// SpendableOutput = sha256(PkScript):blockheight:blockhash:txID:txOutIdx
 type SpendableOutput [32 + 4 + 32 + 32 + 4]byte
 
 type ZKSpendableOutput struct {

--- a/database/tbcd/database_test.go
+++ b/database/tbcd/database_test.go
@@ -36,7 +36,7 @@ func TestNewOutpoint(t *testing.T) {
 			},
 		},
 		{
-			txid:  decodeTxId("369346b9912c5a7ce6986cc7761941eceb7c8c9e7756e4bae045677daa6c0862"),
+			txid:  decodeTxID("369346b9912c5a7ce6986cc7761941eceb7c8c9e7756e4bae045677daa6c0862"),
 			index: 1,
 			want: []byte{
 				// Prefix - 1 byte
@@ -51,7 +51,7 @@ func TestNewOutpoint(t *testing.T) {
 			},
 		},
 		{
-			txid:  decodeTxId("1fce5b19d295e03289dcfa18b0e554d25a7396dbe8e7d83533463d957525bf6d"),
+			txid:  decodeTxID("1fce5b19d295e03289dcfa18b0e554d25a7396dbe8e7d83533463d957525bf6d"),
 			index: 43111,
 			want: []byte{
 				// Prefix - 1 byte
@@ -76,7 +76,7 @@ func TestNewOutpoint(t *testing.T) {
 	}
 }
 
-func decodeTxId(s string) [32]byte {
+func decodeTxID(s string) [32]byte {
 	b := testutil.DecodeHex(s)
 	if len(b) != 32 {
 		panic(fmt.Errorf("invalid txid: %s", s))

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -251,7 +251,25 @@ func open(ctx context.Context, cfg *Config) (*ldb, error) {
 	return l, nil
 }
 
-func New(ctx context.Context, cfg *Config) (*ldb, error) {
+func New(ctx context.Context, cfg *Config) (tbcd.Database, error) {
+	return newLDB(ctx, cfg)
+}
+
+// Pool returns the underlying leveldb pool for the given Database. It panics
+// if db was not created by this package's New constructor. It is intended for
+// internal tooling and tests that need direct access to the key/value store.
+func Pool(db tbcd.Database) level.Pool {
+	return db.(*ldb).DB()
+}
+
+// RawPool returns the underlying rawdb pool for the given Database. It panics
+// if db was not created by this package's New constructor. It is intended for
+// internal tooling and tests that need direct access to the raw store.
+func RawPool(db tbcd.Database) level.RawPool {
+	return db.(*ldb).RawDB()
+}
+
+func newLDB(ctx context.Context, cfg *Config) (*ldb, error) {
 	log.Tracef("New")
 	defer log.Tracef("New exit")
 
@@ -356,7 +374,7 @@ func (l *ldb) startTransaction(db string) (*leveldb.Transaction, commitFunc, dis
 	return tx, cf, df, nil
 }
 
-func (l *ldb) transactionBatchGet(ctx context.Context, t *leveldb.Transaction, allOrNone bool, keys [][]byte) ([]tbcd.Row, error) {
+func (l *ldb) transactionBatchGet(_ context.Context, t *leveldb.Transaction, allOrNone bool, keys [][]byte) ([]tbcd.Row, error) {
 	log.Tracef("transactionBatchGet")
 	defer log.Tracef("transactionBatchGet exit")
 
@@ -379,7 +397,7 @@ func (l *ldb) transactionBatchGet(ctx context.Context, t *leveldb.Transaction, a
 	return rows, nil
 }
 
-func (l *ldb) Version(ctx context.Context) (int, error) {
+func (l *ldb) Version(_ context.Context) (int, error) {
 	mdDB := l.pool[level.MetadataDB]
 	value, err := mdDB.Get(versionKey, nil)
 	if err != nil {
@@ -390,7 +408,7 @@ func (l *ldb) Version(ctx context.Context) (int, error) {
 	return int(dbVersion), nil
 }
 
-func (l *ldb) MetadataDel(ctx context.Context, key []byte) error {
+func (l *ldb) MetadataDel(_ context.Context, key []byte) error {
 	log.Tracef("MetadataDel")
 	defer log.Tracef("MetadataDel exit")
 
@@ -459,7 +477,7 @@ func (l *ldb) MetadataBatchGet(ctx context.Context, allOrNone bool, keys [][]byt
 	return l.transactionBatchGet(ctx, mdDB, allOrNone, keys)
 }
 
-func (l *ldb) BlockKeystoneByL2KeystoneAbrevHash(ctx context.Context, abrevhash chainhash.Hash) (*tbcd.Keystone, error) {
+func (l *ldb) BlockKeystoneByL2KeystoneAbrevHash(_ context.Context, abrevhash chainhash.Hash) (*tbcd.Keystone, error) {
 	log.Tracef("BlockKeystoneByL2KeystoneAbrevHash")
 	defer log.Tracef("BlockKeystoneByL2KeystoneAbrevHash exit")
 
@@ -481,7 +499,7 @@ func (l *ldb) BlockKeystoneByL2KeystoneAbrevHash(ctx context.Context, abrevhash 
 }
 
 // BatchAppend appends rows to batch b.
-func BatchAppend(ctx context.Context, b *leveldb.Batch, rows []tbcd.Row) {
+func BatchAppend(_ context.Context, b *leveldb.Batch, rows []tbcd.Row) {
 	log.Tracef("BatchAppend")
 	defer log.Tracef("BatchAppend exit")
 
@@ -543,7 +561,7 @@ func (l *ldb) MetadataPut(ctx context.Context, key, value []byte) error {
 	return nil
 }
 
-func (l *ldb) BlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*tbcd.BlockHeader, error) {
+func (l *ldb) BlockHeaderByHash(_ context.Context, hash chainhash.Hash) (*tbcd.BlockHeader, error) {
 	log.Tracef("BlockHeaderByHash")
 	defer log.Tracef("BlockHeaderByHash exit")
 
@@ -607,7 +625,7 @@ func (l *ldb) BlockHeadersByHeight(ctx context.Context, height uint64) ([]tbcd.B
 	return bhs, nil
 }
 
-func (l *ldb) BlockHeaderBest(ctx context.Context) (*tbcd.BlockHeader, error) {
+func (l *ldb) BlockHeaderBest(_ context.Context) (*tbcd.BlockHeader, error) {
 	log.Tracef("BlockHeaderBest")
 	defer log.Tracef("BlockHeaderBest exit")
 
@@ -672,7 +690,7 @@ func decodeBlockHeader(ebh []byte) *tbcd.BlockHeader {
 	return bh
 }
 
-func (l *ldb) BlockHeaderGenesisInsert(ctx context.Context, wbh wire.BlockHeader, height uint64, diff *big.Int) error {
+func (l *ldb) BlockHeaderGenesisInsert(_ context.Context, wbh wire.BlockHeader, height uint64, diff *big.Int) error {
 	log.Tracef("BlockHeaderGenesisInsert")
 	defer log.Tracef("BlockHeaderGenesisInsert exit")
 
@@ -1087,7 +1105,7 @@ func (l *ldb) BlockHeadersRemove(ctx context.Context, bhs *wire.MsgHeaders, tipA
 	tipEbh := encodeBlockHeader(tipAfterRemovalFromDb.Height, tipAfterRemovalEncoded, &tipAfterRemovalFromDb.Difficulty)
 	bhsBatch.Put([]byte(bhsCanonicalTipKey), tipEbh[:])
 
-	// XXX move upstreamStateId from here to right before Commit
+	// XXX move upstreamStateID from here to right before Commit
 
 	// Get parent block from database
 	// XXX verify l. here instead of using the bh transaction to get the hash
@@ -1450,7 +1468,7 @@ func (l *ldb) BlockHeadersInsert(ctx context.Context, bhs *wire.MsgHeaders, batc
 }
 
 // XXX return hash and height only
-func (l *ldb) BlocksMissing(ctx context.Context, count int) ([]tbcd.BlockIdentifier, error) {
+func (l *ldb) BlocksMissing(_ context.Context, count int) ([]tbcd.BlockIdentifier, error) {
 	log.Tracef("BlocksMissing")
 	defer log.Tracef("BlocksMissing exit")
 
@@ -1521,7 +1539,7 @@ func (l *ldb) BlockInsert(ctx context.Context, b *btcutil.Block) (int64, error) 
 	return int64(bh.Height), nil
 }
 
-func (l *ldb) BlockMissingDelete(ctx context.Context, height int64, hash chainhash.Hash) error {
+func (l *ldb) BlockMissingDelete(_ context.Context, height int64, hash chainhash.Hash) error {
 	log.Tracef("BlockMissingDelete")
 	defer log.Tracef("BlockMissingDelete exit")
 
@@ -1536,7 +1554,7 @@ func (l *ldb) BlockMissingDelete(ctx context.Context, height int64, hash chainha
 	return nil
 }
 
-func (l *ldb) BlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error) {
+func (l *ldb) BlockByHash(_ context.Context, hash chainhash.Hash) (*btcutil.Block, error) {
 	log.Tracef("BlockByHash")
 	defer log.Tracef("BlockByHash exit")
 
@@ -1573,7 +1591,7 @@ func (l *ldb) BlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Bl
 	return b, nil
 }
 
-func (l *ldb) BlockExistsByHash(ctx context.Context, hash chainhash.Hash) (bool, error) {
+func (l *ldb) BlockExistsByHash(_ context.Context, hash chainhash.Hash) (bool, error) {
 	log.Tracef("BlockExistsByHash")
 	defer log.Tracef("BlockExistsByHash exit")
 
@@ -1595,15 +1613,15 @@ func (l *ldb) BlockExistsByHash(ctx context.Context, hash chainhash.Hash) (bool,
 	return ok, nil
 }
 
-func (l *ldb) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainhash.Hash, error) {
-	log.Tracef("BlockHashByTxId")
-	defer log.Tracef("BlockHashByTxId exit")
+func (l *ldb) BlockHashByTxID(_ context.Context, txID chainhash.Hash) (*chainhash.Hash, error) {
+	log.Tracef("BlockHashByTxID")
+	defer log.Tracef("BlockHashByTxID exit")
 
 	blocks := make([]*chainhash.Hash, 0, 2)
 	txDB := l.pool[level.TransactionsDB]
 	var txid [33]byte
 	txid[0] = 't'
-	copy(txid[1:], txId[:])
+	copy(txid[1:], txID[:])
 	it := txDB.NewIterator(util.BytesPrefix(txid[:]), nil)
 	defer it.Release()
 	for it.Next() {
@@ -1618,7 +1636,7 @@ func (l *ldb) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainh
 	}
 	switch len(blocks) {
 	case 0:
-		return nil, database.NotFoundError(fmt.Sprintf("tx not found: %v", txId))
+		return nil, database.NotFoundError(fmt.Sprintf("tx not found: %v", txID))
 	case 1:
 		return blocks[0], nil
 	default:
@@ -1627,7 +1645,7 @@ func (l *ldb) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainh
 	}
 }
 
-func (l *ldb) SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]tbcd.SpentInfo, error) {
+func (l *ldb) SpentOutputsByTxID(_ context.Context, txID chainhash.Hash) ([]tbcd.SpentInfo, error) {
 	log.Tracef("SpentOutputByOutpoint")
 	defer log.Tracef("SpentOutputByOutpoint exit")
 
@@ -1635,7 +1653,7 @@ func (l *ldb) SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]tb
 	txDB := l.pool[level.TransactionsDB]
 	var key [1 + 32]byte
 	key[0] = 's'
-	copy(key[1:], txId[:])
+	copy(key[1:], txID[:])
 	it := txDB.NewIterator(&util.Range{Start: key[:]}, nil)
 	defer it.Release()
 	for it.Next() {
@@ -1646,7 +1664,7 @@ func (l *ldb) SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]tb
 			s   tbcd.SpentInfo
 			err error
 		)
-		s.TxId, err = chainhash.NewHash(it.Value()[0:32])
+		s.TxID, err = chainhash.NewHash(it.Value()[0:32])
 		if err != nil {
 			return nil, fmt.Errorf("new tx id: %w", err)
 		}
@@ -1661,13 +1679,13 @@ func (l *ldb) SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]tb
 		return nil, fmt.Errorf("blocks by id iterator: %w", err)
 	}
 	if len(si) == 0 {
-		return nil, database.NotFoundError(fmt.Sprintf("not found %v", txId))
+		return nil, database.NotFoundError(fmt.Sprintf("not found %v", txID))
 	}
 
 	return si, nil
 }
 
-func (l *ldb) BlockInTxIndex(ctx context.Context, hash chainhash.Hash) (bool, error) {
+func (l *ldb) BlockInTxIndex(_ context.Context, hash chainhash.Hash) (bool, error) {
 	log.Tracef("BlockInTxIndex")
 	defer log.Tracef("BlockInTxIndex exit")
 
@@ -1699,7 +1717,7 @@ func (l *ldb) BlockInTxIndex(ctx context.Context, hash chainhash.Hash) (bool, er
 	}
 }
 
-func (l *ldb) ScriptHashesByOutpoint(ctx context.Context, ops []*tbcd.Outpoint, result func(tbcd.Outpoint, tbcd.ScriptHash) error) error {
+func (l *ldb) ScriptHashesByOutpoint(_ context.Context, ops []*tbcd.Outpoint, result func(tbcd.Outpoint, tbcd.ScriptHash) error) error {
 	log.Tracef("ScriptHashesByOutpoint")
 	defer log.Tracef("ScriptHashesByOutpoint exit")
 
@@ -1723,7 +1741,7 @@ func (l *ldb) ScriptHashesByOutpoint(ctx context.Context, ops []*tbcd.Outpoint, 
 	return nil
 }
 
-func (l *ldb) ScriptHashByOutpoint(ctx context.Context, op tbcd.Outpoint) (*tbcd.ScriptHash, error) {
+func (l *ldb) ScriptHashByOutpoint(_ context.Context, op tbcd.Outpoint) (*tbcd.ScriptHash, error) {
 	log.Tracef("ScriptHashByOutpoint")
 	defer log.Tracef("ScriptHashByOutpoint exit")
 
@@ -1737,7 +1755,7 @@ func (l *ldb) ScriptHashByOutpoint(ctx context.Context, op tbcd.Outpoint) (*tbcd
 	return &sh, err
 }
 
-func (l *ldb) BalanceByScriptHash(ctx context.Context, sh tbcd.ScriptHash) (uint64, error) {
+func (l *ldb) BalanceByScriptHash(_ context.Context, sh tbcd.ScriptHash) (uint64, error) {
 	log.Tracef("BalanceByScriptHash")
 	defer log.Tracef("BalanceByScriptHash exit")
 
@@ -1760,7 +1778,7 @@ func (l *ldb) BalanceByScriptHash(ctx context.Context, sh tbcd.ScriptHash) (uint
 	return balance, nil
 }
 
-func (l *ldb) UtxosByScriptHash(ctx context.Context, sh tbcd.ScriptHash, start uint64, count uint64) ([]tbcd.Utxo, error) {
+func (l *ldb) UtxosByScriptHash(_ context.Context, sh tbcd.ScriptHash, start uint64, count uint64) ([]tbcd.Utxo, error) {
 	log.Tracef("UtxosByScriptHash")
 	defer log.Tracef("UtxosByScriptHash exit")
 
@@ -1779,9 +1797,9 @@ func (l *ldb) UtxosByScriptHash(ctx context.Context, sh tbcd.ScriptHash, start u
 		}
 		index := binary.BigEndian.Uint32(it.Key()[65:])
 		value := binary.BigEndian.Uint64(it.Value())
-		var txId chainhash.Hash
-		copy(txId[:], it.Key()[33:65])
-		utxos = append(utxos, tbcd.NewUtxo(txId, value, index))
+		var txID chainhash.Hash
+		copy(txID[:], it.Key()[33:65])
+		utxos = append(utxos, tbcd.NewUtxo(txID, value, index))
 
 		if uint64(len(utxos)) >= count {
 			break
@@ -1794,7 +1812,7 @@ func (l *ldb) UtxosByScriptHash(ctx context.Context, sh tbcd.ScriptHash, start u
 	return utxos, nil
 }
 
-func (l *ldb) UtxosByScriptHashCount(ctx context.Context, sh tbcd.ScriptHash) (uint64, error) {
+func (l *ldb) UtxosByScriptHashCount(_ context.Context, sh tbcd.ScriptHash) (uint64, error) {
 	log.Tracef("UtxosByScriptHashCount")
 	defer log.Tracef("UtxosByScriptHashCount exit")
 
@@ -1815,7 +1833,7 @@ func (l *ldb) UtxosByScriptHashCount(ctx context.Context, sh tbcd.ScriptHash) (u
 	return x, nil
 }
 
-func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd.Outpoint]tbcd.CacheOutput, utxoIndexHash chainhash.Hash) error {
+func (l *ldb) BlockUtxoUpdate(_ context.Context, direction int, utxos map[tbcd.Outpoint]tbcd.CacheOutput, utxoIndexHash chainhash.Hash) error {
 	log.Tracef("BlockUtxoUpdate")
 	defer log.Tracef("BlockUtxoUpdate exit")
 
@@ -1837,7 +1855,7 @@ func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd
 		var hop [69]byte // 'h' script_hash tx_id tx_output_idx
 		hop[0] = 'h'
 		copy(hop[1:33], utxo.ScriptHashSlice())
-		copy(hop[33:65], op.TxId())
+		copy(hop[33:65], op.TxID())
 		copy(hop[65:], utxo.OutputIndexBytes())
 
 		// The cache is updated in a way that makes the direction
@@ -1872,7 +1890,7 @@ func (l *ldb) BlockUtxoUpdate(ctx context.Context, direction int, utxos map[tbcd
 	return nil
 }
 
-func (l *ldb) BlockTxUpdate(ctx context.Context, direction int, txs map[tbcd.TxKey]*tbcd.TxValue, txIndexHash chainhash.Hash) error {
+func (l *ldb) BlockTxUpdate(_ context.Context, direction int, txs map[tbcd.TxKey]*tbcd.TxValue, txIndexHash chainhash.Hash) error {
 	log.Tracef("BlockTxUpdate")
 	defer log.Tracef("BlockTxUpdate exit")
 
@@ -2027,7 +2045,7 @@ func keystoneHeightRange(height int64, depth int64) *util.Range {
 
 // Searches for the first occurrence of keystones within the given
 // height + range, excluding the height itself.
-func (l *ldb) KeystonesByHeight(ctx context.Context, height uint32, depth int) ([]tbcd.Keystone, error) {
+func (l *ldb) KeystonesByHeight(_ context.Context, height uint32, depth int) ([]tbcd.Keystone, error) {
 	log.Tracef("KeystonesByHeight")
 	defer log.Tracef("KeystonesByHeight exit")
 
@@ -2038,7 +2056,7 @@ func (l *ldb) KeystonesByHeight(ctx context.Context, height uint32, depth int) (
 	start := int64(height)
 	end := start + d
 	if depth > 0 {
-		end += 1
+		end++
 	}
 	if end > math.MaxUint32 {
 		return nil, errors.New("the overflow that matters")
@@ -2075,7 +2093,7 @@ func (l *ldb) KeystonesByHeight(ctx context.Context, height uint32, depth int) (
 	return kssList, nil
 }
 
-func (l *ldb) BlockKeystoneUpdate(ctx context.Context, direction int, keystones map[chainhash.Hash]tbcd.Keystone, keystoneIndexHash chainhash.Hash) error {
+func (l *ldb) BlockKeystoneUpdate(_ context.Context, direction int, keystones map[chainhash.Hash]tbcd.Keystone, keystoneIndexHash chainhash.Hash) error {
 	log.Tracef("BlockKeystoneUpdate")
 	defer log.Tracef("BlockKeystoneUpdate exit")
 
@@ -2223,7 +2241,7 @@ func (l *ldb) BlockHeaderByZKIndex(ctx context.Context) (*tbcd.BlockHeader, erro
 	return l.BlockHeaderByHash(ctx, *ch)
 }
 
-func (l *ldb) ZKValueAndScriptByOutpoint(ctx context.Context, op tbcd.Outpoint) (uint64, []byte, error) {
+func (l *ldb) ZKValueAndScriptByOutpoint(_ context.Context, op tbcd.Outpoint) (uint64, []byte, error) {
 	log.Tracef("ZKValueAndScriptByOutpoint")
 	defer log.Tracef("ZKValueAndScriptByOutpoint exit")
 
@@ -2238,7 +2256,7 @@ func (l *ldb) ZKValueAndScriptByOutpoint(ctx context.Context, op tbcd.Outpoint) 
 	return binary.BigEndian.Uint64(v[0:]), v[8:], nil
 }
 
-func (l *ldb) ZKBalanceByScriptHash(ctx context.Context, sh tbcd.ScriptHash) (uint64, error) {
+func (l *ldb) ZKBalanceByScriptHash(_ context.Context, sh tbcd.ScriptHash) (uint64, error) {
 	log.Tracef("ZKBalanceByScriptHash")
 	defer log.Tracef("ZKBalanceByScriptHash exit")
 
@@ -2267,7 +2285,7 @@ func bytes2hash(b []byte) chainhash.Hash {
 	return *h
 }
 
-func (l *ldb) ZKSpentOutputs(ctx context.Context, sh tbcd.ScriptHash) ([]tbcd.ZKSpentOutput, error) {
+func (l *ldb) ZKSpentOutputs(_ context.Context, sh tbcd.ScriptHash) ([]tbcd.ZKSpentOutput, error) {
 	log.Tracef("ZKSpentOutputs")
 	defer log.Tracef("ZKSpentOutputs exit")
 
@@ -2301,7 +2319,7 @@ var (
 	lzsokv = len(tbcd.SpendingOutpointValue{})
 )
 
-func (l *ldb) ZKSpendingOutpoints(ctx context.Context, txid chainhash.Hash) ([]tbcd.ZKSpendingOutpoint, error) {
+func (l *ldb) ZKSpendingOutpoints(_ context.Context, txid chainhash.Hash) ([]tbcd.ZKSpendingOutpoint, error) {
 	log.Tracef("ZKSpendingOutpoints")
 	defer log.Tracef("ZKSpendingOutpoints exit")
 
@@ -2335,7 +2353,7 @@ func (l *ldb) ZKSpendingOutpoints(ctx context.Context, txid chainhash.Hash) ([]t
 
 var lzsops = len(tbcd.SpendableOutput{})
 
-func (l *ldb) ZKSpendableOutputs(ctx context.Context, sh tbcd.ScriptHash) ([]tbcd.ZKSpendableOutput, error) {
+func (l *ldb) ZKSpendableOutputs(_ context.Context, sh tbcd.ScriptHash) ([]tbcd.ZKSpendableOutput, error) {
 	log.Tracef("ZKSpendableOutputs")
 	defer log.Tracef("ZKSpendableOutputs exit")
 
@@ -2362,7 +2380,7 @@ func (l *ldb) ZKSpendableOutputs(ctx context.Context, sh tbcd.ScriptHash) ([]tbc
 
 var scriptHashLen = len(tbcd.ScriptHash{})
 
-func (l *ldb) BlockZKUpdate(ctx context.Context, direction int, utxos map[tbcd.ZKIndexKey][]byte, zkIndexHash chainhash.Hash) error {
+func (l *ldb) BlockZKUpdate(_ context.Context, direction int, utxos map[tbcd.ZKIndexKey][]byte, zkIndexHash chainhash.Hash) error {
 	log.Tracef("BlockZKUpdate")
 	defer log.Tracef("BlockZKUpdate exit")
 

--- a/database/tbcd/level/level_test.go
+++ b/database/tbcd/level/level_test.go
@@ -41,7 +41,7 @@ func TestMD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db, err := New(ctx, cfg)
+	db, err := newLDB(ctx, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestHeightHashIndexing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db, err := New(ctx, cfg)
+	db, err := newLDB(ctx, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,7 +470,7 @@ func TestKeystoneUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			db, err := New(ctx, cfg)
+			db, err := newLDB(ctx, cfg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -568,7 +568,7 @@ func TestKeystoneDBWindUnwind(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db, err := New(ctx, cfg)
+	db, err := newLDB(ctx, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -636,7 +636,7 @@ func TestKeystoneDBCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db, err := New(ctx, cfg)
+	db, err := newLDB(ctx, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,7 +802,7 @@ func TestDbUpgradeV4Errors(t *testing.T) {
 			}
 
 			cfg.SetUpgradeOpen(true)
-			dbTemp, err := New(ctx, cfg)
+			dbTemp, err := newLDB(ctx, cfg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -824,7 +824,7 @@ func TestDbUpgradeV4Errors(t *testing.T) {
 
 			cfg.SetUpgradeOpen(false)
 			// upgrade
-			_, err = New(ctx, cfg)
+			_, err = newLDB(ctx, cfg)
 			if !tti.pass && err == nil {
 				t.Fatal("expected error")
 			}
@@ -879,7 +879,7 @@ func TestDbUpgradeV5(t *testing.T) {
 	// rows in the tables v5 must not touch, then stamp the
 	// version down so reopen runs v5.
 	cfg.SetUpgradeOpen(true)
-	db, err := New(ctx, cfg)
+	db, err := newLDB(ctx, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -956,7 +956,7 @@ func TestDbUpgradeV5(t *testing.T) {
 	// Phase 2: reopen with the upgrade ladder enabled.  The
 	// stamped v4 triggers v5 end-to-end.
 	cfg.SetUpgradeOpen(false)
-	db2, err := New(ctx, cfg)
+	db2, err := newLDB(ctx, cfg)
 	if err != nil {
 		t.Fatalf("reopen (runs v5): %v", err)
 	}
@@ -1142,13 +1142,13 @@ func insertBlockHeader(ctx context.Context, db *ldb, prevHash *chainhash.Hash, h
 	return *bh, it, nil
 }
 
-func createNewDB(t *testing.T, ctx context.Context) (*ldb, func()) {
+func createNewDB(ctx context.Context, t *testing.T) (*ldb, func()) {
 	home := t.TempDir()
 	cfg, err := NewConfig("testnet3", home, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	db, err := New(ctx, cfg)
+	db, err := newLDB(ctx, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1166,7 +1166,7 @@ func TestBlockInsert(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	db, discard := createNewDB(t, ctx)
+	db, discard := createNewDB(ctx, t)
 	defer discard()
 
 	prevHash := &chainhash.Hash{}
@@ -1218,7 +1218,7 @@ func TestBlockNegative(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	db, discard := createNewDB(t, ctx)
+	db, discard := createNewDB(ctx, t)
 	defer discard()
 
 	fakeHash := chainhash.Hash{0xFF}
@@ -1255,7 +1255,7 @@ func TestBlocksMissing(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	db, discard := createNewDB(t, ctx)
+	db, discard := createNewDB(ctx, t)
 	defer discard()
 
 	var (
@@ -1328,7 +1328,7 @@ func TestBlockHeadersFork(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	db, discard := createNewDB(t, ctx)
+	db, discard := createNewDB(ctx, t)
 	defer discard()
 
 	hashes := []*chainhash.Hash{{}}
@@ -1388,7 +1388,7 @@ func TestBlockHeadersByHeight(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	db, discard := createNewDB(t, ctx)
+	db, discard := createNewDB(ctx, t)
 	defer discard()
 
 	gen, _, err := insertBlockHeader(ctx, db, &chainhash.Hash{}, 0, 0)
@@ -1500,7 +1500,7 @@ func TestBlockHeadersRemove(t *testing.T) {
 
 	for _, tti := range tests {
 		t.Run(tti.name, func(t *testing.T) {
-			db, discard := createNewDB(t, ctx)
+			db, discard := createNewDB(ctx, t)
 			defer discard()
 
 			gen, _, err := insertBlockHeader(ctx, db, &chainhash.Hash{}, 0, 0)
@@ -1608,7 +1608,7 @@ func TestDbUpgradeV5Errors(t *testing.T) {
 				t.Fatal(err)
 			}
 			cfg.SetUpgradeOpen(true)
-			db, err := New(ctx, cfg)
+			db, err := newLDB(ctx, cfg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/database/tbcd/level/upgrade.go
+++ b/database/tbcd/level/upgrade.go
@@ -405,7 +405,7 @@ func (l *ldb) v3(ctx context.Context) error {
 		return fmt.Errorf("destination expand: %w", err)
 	}
 	log.Infof("open upgrade db: %v", dcfg.Home)
-	dst, err := New(ctx, &dcfg)
+	dst, err := newLDB(ctx, &dcfg)
 	if err != nil {
 		return fmt.Errorf("open destination database: %w", err)
 	}
@@ -660,7 +660,7 @@ func (l *ldb) v4(ctx context.Context) error {
 //     makes returns the full set for download.
 //
 // First start after the upgrade triggers a full re-download of the
-// chain's block bodies. BlockByHash and TxById return NotFound for
+// chain's block bodies. BlockByHash and TxByID return NotFound for
 // any block that has not yet been re-fetched during that window.
 func (l *ldb) v5(ctx context.Context) error {
 	log.Tracef("v5")

--- a/e2e/e2e_ext_test.go
+++ b/e2e/e2e_ext_test.go
@@ -38,15 +38,15 @@ import (
 	"github.com/hemilabs/heminetwork/v2/service/tbc"
 )
 
-func createBfgServer(ctx context.Context, t *testing.T, levelDbHome string, opgethWsUrl string) (*bfg.Server, string) {
-	_, tbcPublicUrl := createTbcServer(ctx, t, levelDbHome)
+func createBfgServer(ctx context.Context, t *testing.T, levelDbHome string, opgethWsURL string) (*bfg.Server, string) {
+	_, tbcPublicURL := createTbcServer(ctx, t, levelDbHome)
 
 	cfg := &bfg.Config{
 		ListenAddress: "127.0.0.1:0",
-		BitcoinURL:    tbcPublicUrl,
+		BitcoinURL:    tbcPublicURL,
 		BitcoinSource: "tbc",
 		Network:       "localnet",
-		OpgethURL:     opgethWsUrl,
+		OpgethURL:     opgethWsURL,
 	}
 
 	bfgServer, err := bfg.NewServer(cfg)
@@ -62,7 +62,7 @@ func createBfgServer(ctx context.Context, t *testing.T, levelDbHome string, opge
 	}()
 
 	// Wait for HTTP server to start
-	var bfgPublicUrl string
+	var bfgPublicURL string
 	for {
 		select {
 		case <-ctx.Done():
@@ -70,16 +70,16 @@ func createBfgServer(ctx context.Context, t *testing.T, levelDbHome string, opge
 		case <-time.After(10 * time.Millisecond):
 		}
 		if addr := bfgServer.HTTPAddress(); addr != nil {
-			bfgPublicUrl = addr.String()
+			bfgPublicURL = addr.String()
 			break
 		}
 	}
 
-	if err := EnsureCanConnectHTTP(t, fmt.Sprintf("http://%s/somethinginvalid", bfgPublicUrl)); err != nil {
+	if err := EnsureCanConnectHTTP(t, fmt.Sprintf("http://%s/somethinginvalid", bfgPublicURL)); err != nil {
 		t.Fatalf("could not make http request to bfg in timeout: %s", err)
 	}
 
-	return bfgServer, bfgPublicUrl
+	return bfgServer, bfgPublicURL
 }
 
 func EnsureCanConnectHTTP(t *testing.T, url string) error {
@@ -132,7 +132,7 @@ func createTbcServer(ctx context.Context, t *testing.T, levelDbHome string) (*tb
 	}()
 
 	// Wait for HTTP server to start
-	var tbcPublicUrl string
+	var tbcPublicURL string
 	for {
 		select {
 		case <-ctx.Done():
@@ -140,13 +140,13 @@ func createTbcServer(ctx context.Context, t *testing.T, levelDbHome string) (*tb
 		case <-time.After(10 * time.Millisecond):
 		}
 		if addr := tbcServer.HTTPAddress(); addr != nil {
-			tbcPublicUrl = fmt.Sprintf("http://%s/v1/ws", addr.String())
+			tbcPublicURL = fmt.Sprintf("http://%s/v1/ws", addr.String())
 			break
 		}
 	}
 
 	// Connect with gozer to ensure connectedness
-	g := tbcgozer.New(tbcPublicUrl)
+	g := tbcgozer.New(tbcPublicURL)
 	err = g.Run(ctx, nil)
 	if err != nil {
 		panic(err)
@@ -163,7 +163,7 @@ func createTbcServer(ctx context.Context, t *testing.T, levelDbHome string) (*tb
 	}
 	t.Logf("gozer connected")
 
-	return tbcServer, tbcPublicUrl
+	return tbcServer, tbcPublicURL
 }
 
 func defaultTestContext(t *testing.T) (context.Context, context.CancelFunc) {
@@ -295,7 +295,7 @@ func TestGetFinalitiesByL2KeystoneBFGInheritingfinality(t *testing.T) {
 
 	opgethWsurl := "ws" + strings.TrimPrefix(opgeth.URL(), "http")
 
-	_, bfgUrl := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
+	_, bfgURL := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
 
 	expectedConfirmations := []int{
 		11,
@@ -306,11 +306,11 @@ func TestGetFinalitiesByL2KeystoneBFGInheritingfinality(t *testing.T) {
 		*keystoneOne,
 		*keystoneTwo,
 	} {
-		bfgUrlTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgUrl, hemi.L2KeystoneAbbreviate(k).Hash())
-		t.Logf("%v", bfgUrlTmp)
+		bfgURLTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgURL, hemi.L2KeystoneAbbreviate(k).Hash())
+		t.Logf("%v", bfgURLTmp)
 
 		client := &http.Client{}
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgUrlTmp, http.NoBody)
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgURLTmp, http.NoBody)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -408,7 +408,7 @@ func TestGetFinalitiesByL2KeystoneBFGInOrder(t *testing.T) {
 
 	opgethWsurl := "ws" + strings.TrimPrefix(opgeth.URL(), "http")
 
-	_, bfgUrl := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
+	_, bfgURL := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
 
 	expectedConfirmations := []int{
 		11,
@@ -421,12 +421,12 @@ func TestGetFinalitiesByL2KeystoneBFGInOrder(t *testing.T) {
 		*keystoneTwo,
 		*keystoneThree,
 	} {
-		bfgUrlTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgUrl, hemi.L2KeystoneAbbreviate(k).Hash())
+		bfgURLTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgURL, hemi.L2KeystoneAbbreviate(k).Hash())
 
-		t.Logf("will query for %s", bfgUrlTmp)
+		t.Logf("will query for %s", bfgURLTmp)
 
 		client := http.Client{}
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgUrlTmp, http.NoBody)
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgURLTmp, http.NoBody)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -508,12 +508,12 @@ func TestGetFinalitiesByL2KeystoneBFGNotFoundOnChain(t *testing.T) {
 
 	opgethWsurl := "ws" + strings.TrimPrefix(opgeth.URL(), "http")
 
-	_, bfgUrl := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
+	_, bfgURL := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
 
-	bfgUrlTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgUrl, hemi.L2KeystoneAbbreviate(*keystoneOne).Hash())
+	bfgURLTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgURL, hemi.L2KeystoneAbbreviate(*keystoneOne).Hash())
 
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgUrlTmp, http.NoBody)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgURLTmp, http.NoBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -543,10 +543,10 @@ func TestGetFinalitiesByL2KeystoneBFGNotFoundOnChain(t *testing.T) {
 	for i, k := range []hemi.L2Keystone{
 		*keystoneOne,
 	} {
-		bfgUrlTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgUrl, hemi.L2KeystoneAbbreviate(k).Hash())
+		bfgURLTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgURL, hemi.L2KeystoneAbbreviate(k).Hash())
 
 		client := http.Client{}
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgUrlTmp, http.NoBody)
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgURLTmp, http.NoBody)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -630,12 +630,12 @@ func TestGetFinalitiesByL2KeystoneBFGNotFoundOpGeth(t *testing.T) {
 
 	opgethWsurl := "ws" + strings.TrimPrefix(opgeth.URL(), "http")
 
-	_, bfgUrl := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
+	_, bfgURL := createBfgServer(ctx, t, levelDbHome, opgethWsurl)
 
-	bfgUrlTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgUrl, hemi.L2KeystoneAbbreviate(*keystoneOne).Hash())
+	bfgURLTmp := fmt.Sprintf("http://%s/v2/keystonefinality/%s", bfgURL, hemi.L2KeystoneAbbreviate(*keystoneOne).Hash())
 
 	client := http.Client{}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgUrlTmp, http.NoBody)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, bfgURLTmp, http.NoBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -664,11 +664,11 @@ func TestTxWatchUnwatchE2E(t *testing.T) {
 	defer cancel()
 
 	levelDbHome := t.TempDir()
-	tbcServer, tbcUrl := createTbcServer(ctx, t, levelDbHome)
+	tbcServer, tbcURL := createTbcServer(ctx, t, levelDbHome)
 	_ = tbcServer
 
 	// Connect a websocket client to tbcd.
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutil/mock/geth.go
+++ b/internal/testutil/mock/geth.go
@@ -55,19 +55,19 @@ type jsonrpcMessage struct {
 	ID      int             `json:"id,omitempty"`
 	Method  string          `json:"method,omitempty"`
 	Params  json.RawMessage `json:"params,omitempty"`
-	Error   *jsonError      `json:"error,omitempty"`
+	Error   *JSONError      `json:"error,omitempty"`
 	Result  any             `json:"result,omitempty"`
 }
 
-type jsonError struct {
+type JSONError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 	Data    any    `json:"data,omitempty"`
 }
 
 // NewJSONError creates a new JSON error.
-func NewJSONError(code int, message string, data any) *jsonError {
-	return &jsonError{Code: code, Message: message, Data: data}
+func NewJSONError(code int, message string, data any) *JSONError {
+	return &JSONError{Code: code, Message: message, Data: data}
 }
 
 // Retrieve the URL from the test server
@@ -107,7 +107,7 @@ func NewMockOpGeth(pctx context.Context, errCh chan error, msgCh chan string, ke
 	return &th
 }
 
-func (f *OpGethMockHandler) handle(c *websocket.Conn, w http.ResponseWriter, r *http.Request, kc *keystoneCounter) (string, error) {
+func (f *OpGethMockHandler) handle(c *websocket.Conn, _ http.ResponseWriter, _ *http.Request, kc *keystoneCounter) (string, error) {
 	var msg jsonrpcMessage
 
 	_, rd, err := c.Reader(f.pctx)

--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -68,7 +68,7 @@ func NewMockTBC(pctx context.Context, errCh chan error, msgCh chan string, keyst
 	return &th
 }
 
-func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.Mempool, w http.ResponseWriter, r *http.Request) (string, error) {
+func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.Mempool, _ http.ResponseWriter, _ *http.Request) (string, error) {
 	cmd, id, payload, err := tbcapi.Read(f.pctx, c)
 	if err != nil {
 		var ce websocket.CloseError
@@ -114,7 +114,7 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 				panic(fmt.Errorf("amount from utxo value: %w", err))
 			}
 			respUtxos = append(respUtxos, &tbcapi.UTXO{
-				TxId:     *txHash,
+				TxID:     *txHash,
 				Value:    value,
 				OutIndex: utxo.OutputIndex(),
 			})
@@ -208,18 +208,18 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 				{Blocks: 10, SatsPerByte: 1},
 			},
 		}
-	case tbcapi.CmdTxByIdRequest:
-		pl, ok := payload.(*tbcapi.TxByIdRequest)
+	case tbcapi.CmdTxByIDRequest:
+		pl, ok := payload.(*tbcapi.TxByIDRequest)
 		if !ok {
 			panic(fmt.Errorf("unexpected payload format: %v", payload))
 		}
 		// Zero hash signals "not found" for testing error paths.
 		if pl.TxID == (chainhash.Hash{}) {
-			resp = &tbcapi.TxByIdResponse{
+			resp = &tbcapi.TxByIDResponse{
 				Error: protocol.RequestErrorf("tx not found"),
 			}
 		} else {
-			resp = &tbcapi.TxByIdResponse{
+			resp = &tbcapi.TxByIDResponse{
 				Tx: &tbcapi.Tx{
 					Version:  2,
 					LockTime: 0,
@@ -292,7 +292,7 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 		for i, sh := range shs {
 			if _, ok := filter[sh]; ok {
 				mempoolUtxos = append(mempoolUtxos, &tbcapi.MempoolUTXO{
-					TxId:       *utxos[i].ChainHash(),
+					TxID:       *utxos[i].ChainHash(),
 					Value:      btcutil.Amount(utxos[i].Value()),
 					OutIndex:   utxos[i].OutputIndex(),
 					ScriptHash: chainhash.Hash(sh),

--- a/rawdb/rawdb.go
+++ b/rawdb/rawdb.go
@@ -185,9 +185,11 @@ func (r *RawDB) Insert(key, value []byte) error {
 				log.Errorf("close %v: %v", lastFilename, err)
 			}
 		}()
-		if fi, err := fh.Stat(); err != nil {
+		fi, err := fh.Stat()
+		if err != nil {
 			return err
-		} else if fi.Size()+int64(len(value)) > r.cfg.MaxSize {
+		}
+		if fi.Size()+int64(len(value)) > r.cfg.MaxSize {
 			last++
 			lastData := make([]byte, 8)
 			binary.BigEndian.PutUint32(lastData, last)
@@ -197,30 +199,29 @@ func (r *RawDB) Insert(key, value []byte) error {
 			}
 			tries++
 			continue
-		} else {
-			// Encoded coordinates.
-			c := make([]byte, 4+4+4)
-			binary.BigEndian.PutUint32(c[0:4], last)
-			binary.BigEndian.PutUint32(c[4:8], uint32(fi.Size()))
-			binary.BigEndian.PutUint32(c[8:12], uint32(len(value)))
-
-			// Append value to latest file.
-			n, err := fh.Write(value)
-			if err != nil {
-				return err
-			}
-			if n != len(value) {
-				return fmt.Errorf("partial write, data corruption: %v != %v", n, len(value))
-			}
-
-			// Write coordinates
-			err = r.index.Put(key, c, nil)
-			if err != nil {
-				return err
-			}
-
-			return nil
 		}
+		// Encoded coordinates.
+		c := make([]byte, 4+4+4)
+		binary.BigEndian.PutUint32(c[0:4], last)
+		binary.BigEndian.PutUint32(c[4:8], uint32(fi.Size()))
+		binary.BigEndian.PutUint32(c[8:12], uint32(len(value)))
+
+		// Append value to latest file.
+		n, err := fh.Write(value)
+		if err != nil {
+			return err
+		}
+		if n != len(value) {
+			return fmt.Errorf("partial write, data corruption: %v != %v", n, len(value))
+		}
+
+		// Write coordinates
+		err = r.index.Put(key, c, nil)
+		if err != nil {
+			return err
+		}
+
+		return nil
 	}
 }
 

--- a/service/bfg/bfg_test.go
+++ b/service/bfg/bfg_test.go
@@ -74,7 +74,7 @@ func TestBFG(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	sendFinalityRequests(t, ctx, kssList, s.HTTPAddress().String(), 9, 10000)
+	sendFinalityRequests(ctx, t, kssList, s.HTTPAddress().String(), 9, 10000)
 }
 
 func TestKeystoneFinalityInheritance(t *testing.T) {
@@ -135,7 +135,7 @@ func TestKeystoneFinalityInheritance(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	sendFinalityRequests(t, ctx, kssList, s.HTTPAddress().String(), 9, 10000)
+	sendFinalityRequests(ctx, t, kssList, s.HTTPAddress().String(), 9, 10000)
 }
 
 func TestFullMockIntegration(t *testing.T) {
@@ -192,7 +192,7 @@ func TestFullMockIntegration(t *testing.T) {
 		defer func() {
 			msgCh <- "finalityRequestDone"
 		}()
-		sendFinalityRequests(t, ctx, kssList, bfgAddr, 0, 0)
+		sendFinalityRequests(ctx, t, kssList, bfgAddr, 0, 0)
 	}()
 
 	// wait until all keystones are mined and broadcast
@@ -244,7 +244,7 @@ func TestFullMockIntegration(t *testing.T) {
 		defer func() {
 			msgCh <- "finalityRequestDone"
 		}()
-		sendFinalityRequests(t, ctx, kssList, bfgAddr, 9, 10000)
+		sendFinalityRequests(ctx, t, kssList, bfgAddr, 9, 10000)
 	}()
 
 	// wait until all keystones are mined and broadcast
@@ -259,7 +259,7 @@ func TestFullMockIntegration(t *testing.T) {
 	}
 }
 
-func sendFinalityRequests(t *testing.T, ctx context.Context, kssList []hemi.L2Keystone, url string, minConfirms, maxConfirms uint) {
+func sendFinalityRequests(ctx context.Context, t *testing.T, kssList []hemi.L2Keystone, url string, minConfirms, maxConfirms uint) {
 	client := &http.Client{}
 	for i := range wantedKeystones {
 		// this will retry until the test times out, as we don't expect errors

--- a/service/continuum/continuum_test.go
+++ b/service/continuum/continuum_test.go
@@ -115,7 +115,7 @@ func (h *dnsHandler) insertDNS(n *node, forward, reverse []dns.RR) {
 	h.nodes[n.DNSName] = n
 }
 
-func (h *dnsHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) {
+func (h *dnsHandler) ServeDNS(_ context.Context, w dns.ResponseWriter, r *dns.Msg) {
 	m := new(dns.Msg)
 	dnsutil.SetReply(m, r)
 
@@ -131,7 +131,7 @@ func (h *dnsHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 func newResolver(resolverAddress string) *net.Resolver {
 	return &net.Resolver{
 		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			d := &net.Dialer{
 				Timeout: 10000 * time.Millisecond,
 			}

--- a/service/continuum/protocol.go
+++ b/service/continuum/protocol.go
@@ -472,8 +472,8 @@ var (
 	ErrMessageTooLarge        = errors.New("message too large")
 
 	// placeholders until we decide on timeout handling
-	readTimeout  time.Duration = 4 * time.Second
-	writeTimeout time.Duration = 4 * time.Second
+	readTimeout  = 4 * time.Second
+	writeTimeout = 4 * time.Second
 )
 
 // Transport is an opaque type that provides encrypted transport for
@@ -613,7 +613,7 @@ func KeyExchange(us *ecdh.PrivateKey, them *ecdh.PublicKey) (*[32]byte, error) {
 // KeyExchange performs a series of reads and writes to establish a transport
 // encryption key between the server and the client. Note that the server
 // dictates the curve.
-func (t *Transport) KeyExchange(ctx context.Context, conn net.Conn) error {
+func (t *Transport) KeyExchange(_ context.Context, conn net.Conn) error {
 	var (
 		them         *ecdh.PublicKey
 		tr           TransportRequest
@@ -753,7 +753,7 @@ func (t *Transport) decrypt(ciphertext []byte) ([]byte, error) {
 // Handshake advertises to the other side what version and options this
 // transport wishes to use. It is also used to verify that the derived Identity
 // did indeed sign the challenge.
-func (t *Transport) Handshake(ctx context.Context, secret *Secret) (*Identity, error) {
+func (t *Transport) Handshake(_ context.Context, secret *Secret) (*Identity, error) {
 	var ourChallenge [32]byte
 	_, err := rand.Read(ourChallenge[:])
 	if err != nil {

--- a/service/continuum/protocol_test.go
+++ b/service/continuum/protocol_test.go
@@ -397,7 +397,7 @@ func TestKeyExchangeErrors(t *testing.T) {
 			curve:         ecdh.P256(),
 			isServer:      true,
 			expectedError: ErrUnsupportedVersion,
-			keyExchange: func(ctx context.Context, c net.Conn) error {
+			keyExchange: func(_ context.Context, c net.Conn) error {
 				pk, err := ecdh.P256().GenerateKey(rand.Reader)
 				if err != nil {
 					return err
@@ -412,7 +412,7 @@ func TestKeyExchangeErrors(t *testing.T) {
 			name:          "unsupported version - client",
 			isServer:      false,
 			expectedError: ErrUnsupportedVersion,
-			keyExchange: func(ctx context.Context, c net.Conn) error {
+			keyExchange: func(_ context.Context, c net.Conn) error {
 				pk, err := ecdh.P256().GenerateKey(rand.Reader)
 				if err != nil {
 					return err
@@ -428,7 +428,7 @@ func TestKeyExchangeErrors(t *testing.T) {
 			curve:         ecdh.P256(),
 			isServer:      true,
 			expectedError: ErrInvalidPublicKey,
-			keyExchange: func(ctx context.Context, c net.Conn) error {
+			keyExchange: func(_ context.Context, c net.Conn) error {
 				return json.NewEncoder(c).Encode(TransportRequest{
 					Version: TransportVersion,
 				})
@@ -439,7 +439,7 @@ func TestKeyExchangeErrors(t *testing.T) {
 			curve:         ecdh.P256(),
 			isServer:      true,
 			expectedError: ErrNoType,
-			keyExchange: func(ctx context.Context, c net.Conn) error {
+			keyExchange: func(_ context.Context, c net.Conn) error {
 				pk, err := ecdh.P521().GenerateKey(rand.Reader)
 				if err != nil {
 					return err
@@ -454,7 +454,7 @@ func TestKeyExchangeErrors(t *testing.T) {
 			name:          "invalid curve",
 			isServer:      false,
 			expectedError: ErrNoType,
-			keyExchange: func(ctx context.Context, c net.Conn) error {
+			keyExchange: func(_ context.Context, c net.Conn) error {
 				return json.NewEncoder(c).Encode(TransportRequest{
 					Version:   TransportVersion,
 					PublicKey: []byte("invalid"),
@@ -544,7 +544,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "unsupported version",
 			curve:         ecdh.P256(),
 			expectedError: ErrUnsupportedVersion,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				var ourChallenge [32]byte
 				_, err := rand.Read(ourChallenge[:])
 				if err != nil {
@@ -564,7 +564,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "invalid challenge",
 			curve:         ecdh.P256(),
 			expectedError: ErrInvalidChallenge,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				return tr.Write(s.Identity, HelloRequest{
 					Version: ProtocolVersion,
 					Options: map[string]string{
@@ -578,7 +578,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "zero challenge",
 			curve:         ecdh.P256(),
 			expectedError: ErrInvalidChallenge,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				return tr.Write(s.Identity, HelloRequest{
 					Version:   ProtocolVersion,
 					Challenge: ZeroChallenge[:],
@@ -593,7 +593,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "malformed signature",
 			curve:         ecdh.P256(),
 			expectedError: ErrNoType,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				var ourChallenge [32]byte
 				_, err := rand.Read(ourChallenge[:])
 				if err != nil {
@@ -618,7 +618,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "uncompact signature",
 			curve:         ecdh.P256(),
 			expectedError: ErrNotCompact,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				var ourChallenge [32]byte
 				_, err := rand.Read(ourChallenge[:])
 				if err != nil {
@@ -644,7 +644,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "invalid encryption",
 			curve:         ecdh.P256(),
 			expectedError: ErrInvalidSecretboxLength,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, _ *Secret) error {
 				nonce := tr.nonce.Next()
 				msg := []byte("test")
 				var size [4]byte
@@ -658,7 +658,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "unexpected cmd",
 			curve:         ecdh.P256(),
 			expectedError: ErrNoType,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				return tr.Write(s.Identity, HelloResponse{
 					Signature: []byte("invalid"),
 				})
@@ -668,7 +668,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "fake signature",
 			curve:         ecdh.P256(),
 			expectedError: ErrIdentityMismatch,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				var ourChallenge [32]byte
 				_, err := rand.Read(ourChallenge[:])
 				if err != nil {
@@ -695,7 +695,7 @@ func TestHandshakeErrors(t *testing.T) {
 			name:          "fake identity",
 			curve:         ecdh.P256(),
 			expectedError: ErrIdentityMismatch,
-			handshake: func(ctx context.Context, tr *Transport, s *Secret) error {
+			handshake: func(_ context.Context, tr *Transport, s *Secret) error {
 				var ourChallenge [32]byte
 				_, err := rand.Read(ourChallenge[:])
 				if err != nil {

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -609,7 +609,7 @@ func (s *Server) handleProxyRequest(w http.ResponseWriter, r *http.Request) {
 		s.mtx.Lock()
 		s.hvmHandlers[id].setupDuration += int64(setupDuration)
 		s.hvmHandlers[id].proxyDuration += int64(proxyDuration)
-		s.hvmHandlers[id].proxyCalls += 1
+		s.hvmHandlers[id].proxyCalls++
 		s.mtx.Unlock()
 	}
 }
@@ -1077,24 +1077,24 @@ func (s *Server) Run(pctx context.Context) error {
 	}()
 
 	// Control HTTP server
-	ctrlHttpErrCh := make(chan error)
+	ctrlHTTPErrCh := make(chan error)
 	if s.cfg.ControlAddress != "" {
 		cmux := http.NewServeMux()
 		handle("Control", cmux, RouteControlAdd, s.handleControlAddRequest)
 		handle("Control", cmux, RouteControlRemove, s.handleControlRemoveRequest)
 		handle("Control", cmux, RouteControlList, s.handleControlListRequest)
 
-		ctrlHttpServer := &http.Server{
+		ctrlHTTPServer := &http.Server{
 			Addr:        s.cfg.ControlAddress,
 			Handler:     cmux,
 			BaseContext: func(_ net.Listener) context.Context { return ctx },
 		}
 		go func() {
 			log.Infof("Control listening: %s", s.cfg.ControlAddress)
-			ctrlHttpErrCh <- ctrlHttpServer.ListenAndServe()
+			ctrlHTTPErrCh <- ctrlHTTPServer.ListenAndServe()
 		}()
 		defer func() {
-			if err := ctrlHttpServer.Shutdown(ctx); err != nil {
+			if err := ctrlHTTPServer.Shutdown(ctx); err != nil {
 				log.Errorf("control http server exit: %v", err)
 				return
 			}
@@ -1152,7 +1152,7 @@ func (s *Server) Run(pctx context.Context) error {
 	case <-ctx.Done():
 		err = ctx.Err()
 	case err = <-httpErrCh:
-	case err = <-ctrlHttpErrCh:
+	case err = <-ctrlHTTPErrCh:
 	}
 	cancel()
 

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -273,7 +273,7 @@ func TestClientReap(t *testing.T) {
 func TestRequestTimeout(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	s := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		wg.Wait() // Stupid test server is stupid
 
 		// exit so that we can complete the test. If we don't exit the

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -493,7 +493,7 @@ func TestOpgethReconnect(t *testing.T) {
 			t.Fatal("reconnect too long")
 		case err := <-errCh:
 			if errors.Is(err, mock.ErrConnectionClosed) {
-				reconAttempts += 1
+				reconAttempts++
 			}
 		}
 

--- a/service/pprof/pprof.go
+++ b/service/pprof/pprof.go
@@ -47,7 +47,7 @@ func (s *Server) Run(ctx context.Context) error {
 	pprofMux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
 	pprofMux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 
-	pprofHttpServer := &http.Server{
+	pprofHTTPServer := &http.Server{
 		Addr:        s.cfg.ListenAddress,
 		Handler:     pprofMux,
 		BaseContext: func(net.Listener) context.Context { return ctx },
@@ -56,10 +56,10 @@ func (s *Server) Run(ctx context.Context) error {
 	httpErrCh := make(chan error)
 	go func() {
 		log.Infof("pprof listening: %s", s.cfg.ListenAddress)
-		httpErrCh <- pprofHttpServer.ListenAndServe()
+		httpErrCh <- pprofHTTPServer.ListenAndServe()
 	}()
 	defer func() {
-		if err := pprofHttpServer.Shutdown(ctx); err != nil {
+		if err := pprofHTTPServer.Shutdown(ctx); err != nil {
 			log.Errorf("pprof http server exit: %v", err)
 		}
 	}()

--- a/service/tbc/admin_hub.go
+++ b/service/tbc/admin_hub.go
@@ -115,7 +115,7 @@ func (h *AdminHub) NewJob(jt jobType, jr JobRunFunc) (string, error) {
 
 	for {
 		// Create random hexadecimal string to use as an ID
-		id, err := randHexId(16)
+		id, err := randHexID(16)
 		if err != nil {
 			cancel()
 			return "", fmt.Errorf("generate job id: %w", err)
@@ -218,7 +218,7 @@ func (h *AdminHub) NewSession(ctx context.Context, blocking bool) (string, *List
 
 	for {
 		// Create random hexadecimal string to use as an ID
-		id, err := randHexId(16)
+		id, err := randHexID(16)
 		if err != nil {
 			client.listener.Unsubscribe()
 			return "", nil, fmt.Errorf("generate admin session id: %w", err)

--- a/service/tbc/admin_rpc.go
+++ b/service/tbc/admin_rpc.go
@@ -29,7 +29,7 @@ type tbcAdminWs struct {
 }
 
 func (s *Server) validateJWT(strToken string) error {
-	keyFunc := func(token *jwt.Token) (any, error) {
+	keyFunc := func(_ *jwt.Token) (any, error) {
 		return s.adminJWTSecret, nil
 	}
 

--- a/service/tbc/admin_rpc_test.go
+++ b/service/tbc/admin_rpc_test.go
@@ -464,7 +464,7 @@ func TestAdminRPCCommands(t *testing.T) {
 		{
 			name:    "JobCancelRequest",
 			request: tbcadminapi.JobCancelRequest{JobID: jid},
-			postCheck: func(c *protocol.WSConn, msg protocol.Message) error {
+			postCheck: func(_ *protocol.WSConn, msg protocol.Message) error {
 				if msg.Header.Command != tbcadminapi.CmdJobCancelResponse {
 					return fmt.Errorf("expected %s, got %s",
 						tbcadminapi.CmdJobCancelResponse, msg.Header.Command)
@@ -489,7 +489,7 @@ func TestAdminRPCCommands(t *testing.T) {
 		{
 			name:    "BlockHeaderBestRawRequest",
 			request: tbcapi.BlockHeaderBestRawRequest{},
-			postCheck: func(c *protocol.WSConn, msg protocol.Message) error {
+			postCheck: func(_ *protocol.WSConn, msg protocol.Message) error {
 				if msg.Header.Command != tbcapi.CmdBlockHeaderBestRawResponse {
 					return fmt.Errorf("expected %s, got %s",
 						tbcapi.CmdBlockHeaderBestRawResponse, msg.Header.Command)
@@ -510,7 +510,7 @@ func TestAdminRPCCommands(t *testing.T) {
 		{
 			name:    "BlockHeaderBestRequest",
 			request: tbcapi.BlockHeaderBestRequest{},
-			postCheck: func(c *protocol.WSConn, msg protocol.Message) error {
+			postCheck: func(_ *protocol.WSConn, msg protocol.Message) error {
 				if msg.Header.Command != tbcapi.CmdBlockHeaderBestResponse {
 					return fmt.Errorf("expected %s, got %s",
 						tbcapi.CmdBlockHeaderBestResponse, msg.Header.Command)

--- a/service/tbc/cpfp_test.go
+++ b/service/tbc/cpfp_test.go
@@ -25,15 +25,15 @@ type stubDB struct{}
 
 func (stubDB) Close() error { return nil }
 
-// BlockHashByTxId is the first thing txOutFromOutPoint calls.
+// BlockHashByTxID is the first thing txOutFromOutPoint calls.
 // Returning an error simulates "parent not in block db", which
 // is the trigger for the CPFP mempool fallback.
-func (stubDB) BlockHashByTxId(context.Context, chainhash.Hash) (*chainhash.Hash, error) {
+func (stubDB) BlockHashByTxID(context.Context, chainhash.Hash) (*chainhash.Hash, error) {
 	return nil, errors.New("not found")
 }
 
 // The remaining methods satisfy the tbcd.Database interface but
-// should never be reached by parseTx when BlockHashByTxId fails.
+// should never be reached by parseTx when BlockHashByTxID fails.
 func (stubDB) Version(context.Context) (int, error)                { panic("stub") }
 func (stubDB) MetadataDel(context.Context, []byte) error           { panic("stub") }
 func (stubDB) MetadataGet(context.Context, []byte) ([]byte, error) { panic("stub") }
@@ -102,7 +102,7 @@ func (stubDB) BlockTxUpdate(context.Context, int, map[tbcd.TxKey]*tbcd.TxValue, 
 	panic("stub")
 }
 
-func (stubDB) SpentOutputsByTxId(context.Context, chainhash.Hash) ([]tbcd.SpentInfo, error) {
+func (stubDB) SpentOutputsByTxID(context.Context, chainhash.Hash) ([]tbcd.SpentInfo, error) {
 	panic("stub")
 }
 

--- a/service/tbc/mempool.go
+++ b/service/tbc/mempool.go
@@ -90,7 +90,7 @@ func (m *Mempool) txOutByOutpoint(txid chainhash.Hash, index uint32) *wire.TxOut
 	return mptx.tx.TxOut[index]
 }
 
-func (m *Mempool) FilterUtxos(ctx context.Context, utxos []tbcd.Utxo) ([]tbcd.Utxo, error) {
+func (m *Mempool) FilterUtxos(_ context.Context, utxos []tbcd.Utxo) ([]tbcd.Utxo, error) {
 	log.Tracef("filterUtxos")
 	defer log.Tracef("filterUtxos exit")
 
@@ -121,7 +121,7 @@ func (m *Mempool) FilterUtxos(ctx context.Context, utxos []tbcd.Utxo) ([]tbcd.Ut
 // UnconfirmedUtxos returns all outputs from mempool transactions
 // with their script hashes, plus all outpoints being spent by
 // mempool transactions.
-func (m *Mempool) UnconfirmedUtxos(ctx context.Context) ([]tbcd.Utxo, []tbcd.ScriptHash, []wire.OutPoint, error) {
+func (m *Mempool) UnconfirmedUtxos(_ context.Context) ([]tbcd.Utxo, []tbcd.ScriptHash, []wire.OutPoint, error) {
 	log.Tracef("UnconfirmedUtxos")
 	defer log.Tracef("UnconfirmedUtxos exit")
 
@@ -148,7 +148,7 @@ func (m *Mempool) UnconfirmedUtxos(ctx context.Context) ([]tbcd.Utxo, []tbcd.Scr
 	return utxos, shs, spent, nil
 }
 
-func (m *Mempool) getDataConstruct(ctx context.Context) (*wire.MsgGetData, error) {
+func (m *Mempool) getDataConstruct(_ context.Context) (*wire.MsgGetData, error) {
 	log.Tracef("getDataConstruct")
 	defer log.Tracef("getDataConstruct exit")
 
@@ -182,7 +182,7 @@ func (m *Mempool) txProcessed(txid chainhash.Hash) bool {
 	return m.txs[txid] != nil // return true when tx is not nil
 }
 
-func (m *Mempool) TxInsert(ctx context.Context, mptx *MempoolTx) error {
+func (m *Mempool) TxInsert(_ context.Context, mptx *MempoolTx) error {
 	log.Tracef("txInsert")
 	defer log.Tracef("txInsert exit")
 
@@ -197,7 +197,7 @@ func (m *Mempool) TxInsert(ctx context.Context, mptx *MempoolTx) error {
 	return nil
 }
 
-func (m *Mempool) invTxsInsert(ctx context.Context, inv *wire.MsgInv) error {
+func (m *Mempool) invTxsInsert(_ context.Context, inv *wire.MsgInv) error {
 	log.Tracef("invTxsInsert")
 	defer log.Tracef("invTxsInsert exit")
 
@@ -225,7 +225,7 @@ func (m *Mempool) invTxsInsert(ctx context.Context, inv *wire.MsgInv) error {
 	return nil
 }
 
-func (m *Mempool) txsRemove(ctx context.Context, txs []chainhash.Hash) {
+func (m *Mempool) txsRemove(_ context.Context, txs []chainhash.Hash) {
 	log.Tracef("txsRemove")
 	defer log.Tracef("txsRemove exit")
 
@@ -281,7 +281,7 @@ func (m *Mempool) reap() {
 	m.reaping = false
 }
 
-func (m *Mempool) stats(ctx context.Context) (int, int) {
+func (m *Mempool) stats(_ context.Context) (int, int) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -289,7 +289,7 @@ func (m *Mempool) stats(ctx context.Context) (int, int) {
 	return len(m.txs), int(m.size) + (len(m.txs) * chainhash.HashSize)
 }
 
-func (m *Mempool) Dump(ctx context.Context) string {
+func (m *Mempool) Dump(_ context.Context) string {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/service/tbc/mempool_test.go
+++ b/service/tbc/mempool_test.go
@@ -320,9 +320,9 @@ func BenchmarkMempoolFilter(b *testing.B) {
 			utxos := make([]tbcd.Utxo, 0, txInNum*mempoolTxNum)
 			// Create new MempoolTx
 			for k := range mempoolTxNum {
-				txIdBytes := make([]byte, 32)
-				binary.BigEndian.PutUint32(txIdBytes[0:32], uint32(k))
-				txId := testutil.Bytes2Hash(txIdBytes)
+				txIDBytes := make([]byte, 32)
+				binary.BigEndian.PutUint32(txIDBytes[0:32], uint32(k))
+				txID := testutil.Bytes2Hash(txIDBytes)
 				msgTx := wire.NewMsgTx(2)
 				// Create utxo and add it to the MempoolTx
 				for i := range txInNum {
@@ -337,7 +337,7 @@ func BenchmarkMempoolFilter(b *testing.B) {
 					msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: *opp})
 				}
 				mptx := NewMempoolTx(msgTx)
-				mptx.id = *txId
+				mptx.id = *txID
 				mptx.expires = time.Now().Add(10 * time.Hour)
 				if err = mp.TxInsert(b.Context(), &mptx); err != nil {
 					b.Fatal(err)

--- a/service/tbc/mempoolfees.go
+++ b/service/tbc/mempoolfees.go
@@ -43,14 +43,14 @@ func medianFee(fees []float64) float64 {
 	l := len(fees)
 	if l == 0 {
 		return 0
-	} else if l%2 == 0 {
-		return (fees[l/2-1] + fees[l/2]) / 2
-	} else {
-		return fees[l/2]
 	}
+	if l%2 == 0 {
+		return (fees[l/2-1] + fees[l/2]) / 2
+	}
+	return fees[l/2]
 }
 
-func (m *Mempool) generateMempoolBlocks(ctx context.Context) (blks []mempoolBlock, err error) {
+func (m *Mempool) generateMempoolBlocks(_ context.Context) (blks []mempoolBlock, err error) {
 	if len(m.txs) == 0 {
 		return blks, nil
 	}

--- a/service/tbc/peer/peer_test.go
+++ b/service/tbc/peer/peer_test.go
@@ -132,7 +132,7 @@ func TestPeer(t *testing.T) {
 		}(uint64(i))
 	}
 	wg.Wait()
-	pongs.Range(func(k, v any) bool {
+	pongs.Range(func(k, _ any) bool {
 		t.Fatalf("expected empty map: %v", k)
 		return false
 	})

--- a/service/tbc/peer/peer_witness_test.go
+++ b/service/tbc/peer/peer_witness_test.go
@@ -23,7 +23,7 @@ import (
 // of a net.Pipe.  The server end is returned so the caller can
 // read/write wire messages directly.  readLoop is started; callers
 // must cancel ctx to tear down.
-func newLoopbackPeer(t *testing.T, ctx context.Context) (*Peer, *rawpeer.RawPeer) {
+func newLoopbackPeer(ctx context.Context, t *testing.T) (*Peer, *rawpeer.RawPeer) {
 	t.Helper()
 	clientConn, serverConn := net.Pipe()
 	t.Cleanup(func() {
@@ -78,7 +78,7 @@ func TestGetDataWitnessBlock(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(ctx, t)
 
 		// Build block first, derive its hash, then request that hash.
 		prev := chainhash.DoubleHashH([]byte("prev"))
@@ -133,7 +133,7 @@ func TestGetDataWitnessTx(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(ctx, t)
 
 		// Build tx first, derive its hash, then request that hash.
 		tx := wire.NewMsgTx(2)
@@ -188,7 +188,7 @@ func TestGetDataBaseBlockStillWorks(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(ctx, t)
 
 		prev := chainhash.DoubleHashH([]byte("base-prev"))
 		bh := wire.NewBlockHeader(0, &prev, &chainhash.Hash{}, 0, 0)
@@ -231,7 +231,7 @@ func TestGetDataNotFound(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(ctx, t)
 
 		hash := chainhash.DoubleHashH([]byte("missing-block"))
 
@@ -274,7 +274,7 @@ func TestGetBlockWitness(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(ctx, t)
 		// Also register the headers handler.
 		p.setHandler(wire.CmdHeaders, p.onHeadersHandler)
 
@@ -351,7 +351,7 @@ func TestGetTxWitness(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
-		p, srv := newLoopbackPeer(t, ctx)
+		p, srv := newLoopbackPeer(ctx, t)
 
 		tx := wire.NewMsgTx(2)
 		prevHash := chainhash.DoubleHashH([]byte("gettx-prev"))

--- a/service/tbc/peer/rawpeer/rawpeer.go
+++ b/service/tbc/peer/rawpeer/rawpeer.go
@@ -90,7 +90,7 @@ func New(network wire.BitcoinNet, id int, address string) (*RawPeer, error) {
 	}, nil
 }
 
-func NewFromConn(conn net.Conn, network wire.BitcoinNet, protocolVersion uint32, id int) (*RawPeer, error) {
+func NewFromConn(conn net.Conn, network wire.BitcoinNet, protocolVersion uint32, _ int) (*RawPeer, error) {
 	return &RawPeer{
 		conn:            conn,
 		connected:       time.Now(),
@@ -104,7 +104,7 @@ func (r *RawPeer) String() string {
 	return r.address
 }
 
-func (r *RawPeer) Id() int {
+func (r *RawPeer) ID() int {
 	return r.id
 }
 
@@ -160,7 +160,7 @@ func (r *RawPeer) Read(timeout time.Duration) (wire.Message, []byte, error) {
 	return msg, buf, err
 }
 
-func (r *RawPeer) handshake(ctx context.Context, conn net.Conn) error {
+func (r *RawPeer) handshake(_ context.Context, conn net.Conn) error {
 	log.Tracef("handshake %v -> %v", conn.LocalAddr(), conn.RemoteAddr())
 	defer log.Tracef("handshake exit %v -> %v", conn.LocalAddr(), conn.RemoteAddr())
 

--- a/service/tbc/peermanager.go
+++ b/service/tbc/peermanager.go
@@ -237,7 +237,7 @@ func (pm *PeerManager) Bad(ctx context.Context, address string) error {
 				// Run outside of mutex
 				select {
 				case <-ctx.Done():
-				case pm.slotsC <- p.Id():
+				case pm.slotsC <- p.ID():
 				}
 			}()
 		}
@@ -324,7 +324,7 @@ func (pm *PeerManager) RandomConnect(ctx context.Context) (*rawpeer.RawPeer, err
 	}
 }
 
-func (pm *PeerManager) randomPeer(ctx context.Context, slot int) (*rawpeer.RawPeer, error) {
+func (pm *PeerManager) randomPeer(_ context.Context, slot int) (*rawpeer.RawPeer, error) {
 	pm.mtx.Lock()
 	defer pm.mtx.Unlock()
 
@@ -361,8 +361,8 @@ func (pm *PeerManager) randomPeer(ctx context.Context, slot int) (*rawpeer.RawPe
 }
 
 func (pm *PeerManager) connect(ctx context.Context, p *rawpeer.RawPeer) error {
-	log.Tracef("connect: %v %v", p.Id(), p)
-	defer log.Tracef("connect exit: %v %v", p.Id(), p)
+	log.Tracef("connect: %v %v", p.ID(), p)
+	defer log.Tracef("connect exit: %v %v", p.ID(), p)
 
 	if err := p.Connect(ctx); err != nil {
 		return fmt.Errorf("new peer: %w", err)
@@ -387,7 +387,7 @@ func (pm *PeerManager) connect(ctx context.Context, p *rawpeer.RawPeer) error {
 func (pm *PeerManager) connectSlot(ctx context.Context, p *rawpeer.RawPeer) {
 	if err := pm.connect(ctx, p); err != nil {
 		// log.Errorf("%v", err)
-		pm.slotsC <- p.Id() // give slot back
+		pm.slotsC <- p.ID() // give slot back
 		return
 	}
 }

--- a/service/tbc/peermanager_test.go
+++ b/service/tbc/peermanager_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hemilabs/heminetwork/v2/service/tbc/peer/rawpeer"
 )
 
-func ping(ctx context.Context, t *testing.T, p *rawpeer.RawPeer) error {
+func ping(_ context.Context, _ *testing.T, p *rawpeer.RawPeer) error {
 	err := p.Write(time.Second, wire.NewMsgPing(uint64(time.Now().Unix())))
 	if err != nil {
 		return err

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -94,13 +94,13 @@ func (s *Server) getTBCAPICommandHandler(cmd protocol.Command, payload any) func
 		return func(ctx context.Context) (any, error) {
 			return s.handleUtxosByAddressRequest(ctx, payload.(*tbcapi.UTXOsByAddressRequest))
 		}
-	case tbcapi.CmdTxByIdRequest:
+	case tbcapi.CmdTxByIDRequest:
 		return func(ctx context.Context) (any, error) {
-			return s.handleTxByIdRequest(ctx, payload.(*tbcapi.TxByIdRequest))
+			return s.handleTxByIDRequest(ctx, payload.(*tbcapi.TxByIDRequest))
 		}
-	case tbcapi.CmdTxByIdRawRequest:
+	case tbcapi.CmdTxByIDRawRequest:
 		return func(ctx context.Context) (any, error) {
-			return s.handleTxByIdRawRequest(ctx, payload.(*tbcapi.TxByIdRawRequest))
+			return s.handleTxByIDRawRequest(ctx, payload.(*tbcapi.TxByIDRawRequest))
 		}
 	case tbcapi.CmdTxBroadcastRequest:
 		return func(ctx context.Context) (any, error) {
@@ -253,7 +253,7 @@ func (s *Server) handleRequest(ctx context.Context, ws *tbcWs, id string, cmd pr
 	s.cmdsProcessed.Inc()
 }
 
-func (s *Server) handlePingRequest(ctx context.Context, req *tbcapi.PingRequest) (any, error) {
+func (s *Server) handlePingRequest(_ context.Context, req *tbcapi.PingRequest) (any, error) {
 	log.Tracef("handlePingRequest")
 	defer log.Tracef("handlePingRequest exit")
 
@@ -466,7 +466,7 @@ func (s *Server) handleUtxosByAddressRequest(ctx context.Context, req *tbcapi.UT
 
 	responseUtxos := make([]*tbcapi.UTXO, 0, len(utxos))
 	for _, utxo := range utxos {
-		txId, err := chainhash.NewHash(utxo.ScriptHashSlice())
+		txID, err := chainhash.NewHash(utxo.ScriptHashSlice())
 		if err != nil {
 			e := protocol.NewInternalError(err)
 			return &tbcapi.UTXOsByAddressResponse{
@@ -475,7 +475,7 @@ func (s *Server) handleUtxosByAddressRequest(ctx context.Context, req *tbcapi.UT
 		}
 
 		responseUtxos = append(responseUtxos, &tbcapi.UTXO{
-			TxId:     *txId,
+			TxID:     *txID,
 			Value:    btcutil.Amount(utxo.Value()),
 			OutIndex: utxo.OutputIndex(),
 		})
@@ -486,21 +486,21 @@ func (s *Server) handleUtxosByAddressRequest(ctx context.Context, req *tbcapi.UT
 	}, nil
 }
 
-func (s *Server) handleTxByIdRawRequest(ctx context.Context, req *tbcapi.TxByIdRawRequest) (any, error) {
-	log.Tracef("handleTxByIdRawRequest")
-	defer log.Tracef("handleTxByIdRawRequest exit")
+func (s *Server) handleTxByIDRawRequest(ctx context.Context, req *tbcapi.TxByIDRawRequest) (any, error) {
+	log.Tracef("handleTxByIDRawRequest")
+	defer log.Tracef("handleTxByIDRawRequest exit")
 
-	tx, err := s.TxById(ctx, req.TxID)
+	tx, err := s.TxByID(ctx, req.TxID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			responseErr := protocol.NotFoundError("tx", req.TxID)
-			return &tbcapi.TxByIdRawResponse{
+			return &tbcapi.TxByIDRawResponse{
 				Error: responseErr,
 			}, nil
 		}
 
 		responseErr := protocol.NewInternalError(err)
-		return &tbcapi.TxByIdRawResponse{
+		return &tbcapi.TxByIDRawResponse{
 			Error: responseErr.ProtocolError(),
 		}, responseErr
 	}
@@ -508,36 +508,36 @@ func (s *Server) handleTxByIdRawRequest(ctx context.Context, req *tbcapi.TxByIdR
 	b, err := tx2Bytes(tx)
 	if err != nil {
 		e := protocol.NewInternalError(err)
-		return &tbcapi.TxByIdRawResponse{
+		return &tbcapi.TxByIDRawResponse{
 			Error: e.ProtocolError(),
 		}, e
 	}
 
-	return &tbcapi.TxByIdRawResponse{
+	return &tbcapi.TxByIDRawResponse{
 		Tx: b,
 	}, nil
 }
 
-func (s *Server) handleTxByIdRequest(ctx context.Context, req *tbcapi.TxByIdRequest) (any, error) {
-	log.Tracef("handleTxByIdRequest")
-	defer log.Tracef("handleTxByIdRequest exit")
+func (s *Server) handleTxByIDRequest(ctx context.Context, req *tbcapi.TxByIDRequest) (any, error) {
+	log.Tracef("handleTxByIDRequest")
+	defer log.Tracef("handleTxByIDRequest exit")
 
-	tx, err := s.TxById(ctx, req.TxID)
+	tx, err := s.TxByID(ctx, req.TxID)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			responseErr := protocol.NotFoundError("tx", req.TxID)
-			return &tbcapi.TxByIdResponse{
+			return &tbcapi.TxByIDResponse{
 				Error: responseErr,
 			}, nil
 		}
 
 		responseErr := protocol.NewInternalError(err)
-		return &tbcapi.TxByIdResponse{
+		return &tbcapi.TxByIDResponse{
 			Error: responseErr.ProtocolError(),
 		}, responseErr
 	}
 
-	return &tbcapi.TxByIdResponse{
+	return &tbcapi.TxByIDResponse{
 		Tx: wireTxToTBC(tx),
 	}, nil
 }
@@ -746,7 +746,7 @@ func (s *Server) handleMempoolUtxosRequest(ctx context.Context, req *tbcapi.Memp
 	out := make([]*tbcapi.MempoolUTXO, len(filtered))
 	for i, u := range filtered {
 		out[i] = &tbcapi.MempoolUTXO{
-			TxId:       *u.ChainHash(),
+			TxID:       *u.ChainHash(),
 			Value:      btcutil.Amount(u.Value()),
 			OutIndex:   u.OutputIndex(),
 			ScriptHash: chainhash.Hash(filteredShs[i]),
@@ -1206,7 +1206,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, r *http.Request) {
 func (s *Server) newSession(ws *tbcWs) (string, error) {
 	for {
 		// Create random hexadecimal string to use as an ID
-		id, err := randHexId(16)
+		id, err := randHexID(16)
 		if err != nil {
 			return "", fmt.Errorf("generate session id: %w", err)
 		}
@@ -1235,7 +1235,7 @@ func (s *Server) deleteSession(id string) {
 	}
 }
 
-func randHexId(length int) (string, error) {
+func randHexID(length int) (string, error) {
 	b := make([]byte, length)
 	if _, err := rand.Read(b); err != nil {
 		return "", fmt.Errorf("read random bytes: %w", err)
@@ -1417,7 +1417,7 @@ func (s *Server) handleTxWatchRequest(ctx context.Context, ws *tbcWs, req *tbcap
 	return &tbcapi.TxWatchResponse{}, nil
 }
 
-func (s *Server) handleTxUnwatchRequest(ctx context.Context, ws *tbcWs, req *tbcapi.TxUnwatchRequest) (any, error) {
+func (s *Server) handleTxUnwatchRequest(_ context.Context, ws *tbcWs, req *tbcapi.TxUnwatchRequest) (any, error) {
 	log.Tracef("handleTxUnwatchRequest: %v", ws.addr)
 	defer log.Tracef("handleTxUnwatchRequest exit: %v", ws.addr)
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -88,9 +88,9 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 			panic(err)
 		}
 	}()
-	_, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	_, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,9 +160,9 @@ func TestBlockHeadersByHeight(t *testing.T) {
 		}
 	}()
 
-	_, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	_, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,9 +225,9 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 		}
 	}()
 
-	_, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	_, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,9 +284,9 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 		}
 	}()
 
-	_, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	_, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,9 +352,9 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 		}
 	}()
 
-	_, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	_, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,9 +520,9 @@ func TestBalanceByAddress(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+			tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-			c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+			c, _, err := websocket.Dial(ctx, tbcURL, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -565,7 +565,7 @@ func TestBalanceByAddress(t *testing.T) {
 
 				var pricePerBlock uint64 = 50 * 100000000
 				var blocks uint64 = 4
-				var expectedBalance uint64 = 0
+				var expectedBalance uint64
 				if !tti.doNotGenerate {
 					expectedBalance = pricePerBlock * blocks
 				}
@@ -583,9 +583,8 @@ func TestBalanceByAddress(t *testing.T) {
 					// there is a chance we just haven't finished indexing
 					// the blocks and txs, retry until timeout
 					continue
-				} else {
-					break
 				}
+				break
 			}
 		})
 	}
@@ -744,9 +743,9 @@ func TestUtxosByAddressRaw(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+			tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-			c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+			c, _, err := websocket.Dial(ctx, tbcURL, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -954,9 +953,9 @@ func TestUtxosByAddress(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+			tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-			c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+			c, _, err := websocket.Dial(ctx, tbcURL, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1031,9 +1030,9 @@ func TestTxByIdRaw(t *testing.T) {
 		}
 	}()
 
-	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1045,7 +1044,7 @@ func TestTxByIdRaw(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var response tbcapi.TxByIdRawResponse
+	var response tbcapi.TxByIDRawResponse
 	select {
 	case <-time.Tick(1 * time.Second):
 	case <-ctx.Done():
@@ -1053,10 +1052,10 @@ func TestTxByIdRaw(t *testing.T) {
 	}
 	indexAll(ctx, t, tbcServer)
 
-	txId := getRandomTxId(ctx, t, bitcoindContainer)
+	txID := getRandomTxID(ctx, t, bitcoindContainer)
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxID: *txId,
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIDRawRequest{
+		TxID: *txID,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1067,7 +1066,7 @@ func TestTxByIdRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if v.Header.Command != tbcapi.CmdTxByIdRawResponse {
+	if v.Header.Command != tbcapi.CmdTxByIDRawResponse {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
@@ -1090,8 +1089,8 @@ func TestTxByIdRaw(t *testing.T) {
 
 	// is the hash equal to what we queried for?
 	txHash := tx.TxHash()
-	if !txId.IsEqual(&txHash) {
-		t.Fatalf("id mismatch: %s != %s", txHash, txId)
+	if !txID.IsEqual(&txHash) {
+		t.Fatalf("id mismatch: %s != %s", txHash, txID)
 	}
 }
 
@@ -1114,9 +1113,9 @@ func TestTxByIdRawInvalid(t *testing.T) {
 		}
 	}()
 
-	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1128,7 +1127,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var response tbcapi.TxByIdRawResponse
+	var response tbcapi.TxByIDRawResponse
 	select {
 	case <-time.Tick(1 * time.Second):
 	case <-ctx.Done():
@@ -1136,11 +1135,11 @@ func TestTxByIdRawInvalid(t *testing.T) {
 	}
 	indexAll(ctx, t, tbcServer)
 
-	txId := getRandomTxId(ctx, t, bitcoindContainer)
-	txId[0]++
+	txID := getRandomTxID(ctx, t, bitcoindContainer)
+	txID[0]++
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxID: *txId,
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIDRawRequest{
+		TxID: *txID,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1151,7 +1150,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if v.Header.Command != tbcapi.CmdTxByIdRawResponse {
+	if v.Header.Command != tbcapi.CmdTxByIDRawResponse {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
@@ -1204,9 +1203,9 @@ func TestTxByIdRawNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1218,7 +1217,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var response tbcapi.TxByIdRawResponse
+	var response tbcapi.TxByIDRawResponse
 	select {
 	case <-time.Tick(1 * time.Second):
 	case <-ctx.Done():
@@ -1226,11 +1225,11 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	}
 	indexAll(ctx, t, tbcServer)
 
-	txId := getRandomTxId(ctx, t, bitcoindContainer)
-	txId[len(txId)-1] = 8
+	txID := getRandomTxID(ctx, t, bitcoindContainer)
+	txID[len(txID)-1] = 8
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRawRequest{
-		TxID: *txId,
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIDRawRequest{
+		TxID: *txID,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1241,7 +1240,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if v.Header.Command != tbcapi.CmdTxByIdRawResponse {
+	if v.Header.Command != tbcapi.CmdTxByIDRawResponse {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
@@ -1280,9 +1279,9 @@ func TestTxById(t *testing.T) {
 		}
 	}()
 
-	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1300,13 +1299,13 @@ func TestTxById(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	var response tbcapi.TxByIdResponse
+	var response tbcapi.TxByIDResponse
 
 	indexAll(ctx, t, tbcServer)
 
-	txId := getRandomTxId(ctx, t, bitcoindContainer)
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxID: *txId,
+	txID := getRandomTxID(ctx, t, bitcoindContainer)
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIDRequest{
+		TxID: *txID,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1317,7 +1316,7 @@ func TestTxById(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if v.Header.Command != tbcapi.CmdTxByIdResponse {
+	if v.Header.Command != tbcapi.CmdTxByIDResponse {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
@@ -1329,7 +1328,7 @@ func TestTxById(t *testing.T) {
 		t.Fatal(response.Error.Message)
 	}
 
-	tx, err := tbcServer.TxById(ctx, *txId)
+	tx, err := tbcServer.TxByID(ctx, *txID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1360,9 +1359,9 @@ func TestTxByIdInvalid(t *testing.T) {
 		}
 	}()
 
-	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1374,7 +1373,7 @@ func TestTxByIdInvalid(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var response tbcapi.TxByIdResponse
+	var response tbcapi.TxByIDResponse
 	select {
 	case <-time.Tick(1 * time.Second):
 	case <-ctx.Done():
@@ -1382,11 +1381,11 @@ func TestTxByIdInvalid(t *testing.T) {
 	}
 	indexAll(ctx, t, tbcServer)
 
-	txId := getRandomTxId(ctx, t, bitcoindContainer)
-	txId[0]++
+	txID := getRandomTxID(ctx, t, bitcoindContainer)
+	txID[0]++
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxID: *txId,
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIDRequest{
+		TxID: *txID,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1397,7 +1396,7 @@ func TestTxByIdInvalid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if v.Header.Command != tbcapi.CmdTxByIdResponse {
+	if v.Header.Command != tbcapi.CmdTxByIDResponse {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
@@ -1522,9 +1521,9 @@ func TestRpcZK(t *testing.T) {
 		}
 	}
 
-	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+	tbcURL := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1549,12 +1548,12 @@ func TestRpcZK(t *testing.T) {
 			name: "ValueAndScriptByOutpoint",
 			req: tbcapi.ZKValueAndScriptByOutpointRequest{
 				Outpoint: tbcapi.OutPoint{
-					Hash:  *out.TxIdHash(),
+					Hash:  *out.TxIDHash(),
 					Index: out.TxIndex(),
 				},
 			},
 			respHeader: tbcapi.CmdZKValueAndScriptByOutpointResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKValueAndScriptByOutpointResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1574,7 +1573,7 @@ func TestRpcZK(t *testing.T) {
 			name:       "ValueAndScriptByOutpoint Not Found",
 			req:        tbcapi.ZKValueAndScriptByOutpointRequest{},
 			respHeader: tbcapi.CmdZKValueAndScriptByOutpointResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKValueAndScriptByOutpointResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1589,7 +1588,7 @@ func TestRpcZK(t *testing.T) {
 				ScriptHash: sh[:],
 			},
 			respHeader: tbcapi.CmdZKBalanceByScriptHashResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKBalanceByScriptHashResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1607,7 +1606,7 @@ func TestRpcZK(t *testing.T) {
 				ScriptHash: testutil.SHA256(nil),
 			},
 			respHeader: tbcapi.CmdZKBalanceByScriptHashResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKBalanceByScriptHashResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1622,7 +1621,7 @@ func TestRpcZK(t *testing.T) {
 			name:       "BalanceByScriptHash Invalid",
 			req:        tbcapi.ZKBalanceByScriptHashRequest{},
 			respHeader: tbcapi.CmdZKBalanceByScriptHashResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKBalanceByScriptHashResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1637,7 +1636,7 @@ func TestRpcZK(t *testing.T) {
 				ScriptHash: sh[:],
 			},
 			respHeader: tbcapi.CmdZKSpentOutputsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpentOutputsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1658,7 +1657,7 @@ func TestRpcZK(t *testing.T) {
 				ScriptHash: testutil.SHA256(nil),
 			},
 			respHeader: tbcapi.CmdZKSpentOutputsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpentOutputsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1674,7 +1673,7 @@ func TestRpcZK(t *testing.T) {
 			name:       "SpentOutputs Invalid",
 			req:        tbcapi.ZKSpentOutputsRequest{},
 			respHeader: tbcapi.CmdZKSpentOutputsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpentOutputsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1689,7 +1688,7 @@ func TestRpcZK(t *testing.T) {
 				TxID: chainhash.Hash(spending[:32]),
 			},
 			respHeader: tbcapi.CmdZKSpendingOutpointsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpendingOutpointsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1710,7 +1709,7 @@ func TestRpcZK(t *testing.T) {
 				TxID: chainhash.Hash{},
 			},
 			respHeader: tbcapi.CmdZKSpendingOutpointsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpendingOutpointsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1728,7 +1727,7 @@ func TestRpcZK(t *testing.T) {
 				ScriptHash: sh[:],
 			},
 			respHeader: tbcapi.CmdZKSpendableOutputsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpendableOutputsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1749,7 +1748,7 @@ func TestRpcZK(t *testing.T) {
 				ScriptHash: testutil.SHA256(nil),
 			},
 			respHeader: tbcapi.CmdZKSpendableOutputsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpendableOutputsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1765,7 +1764,7 @@ func TestRpcZK(t *testing.T) {
 			name:       "SpendableOutputs Invalid",
 			req:        tbcapi.ZKSpendableOutputsRequest{},
 			respHeader: tbcapi.CmdZKSpendableOutputsResponse,
-			handler: func(ctx context.Context, v protocol.Message) *protocol.Error {
+			handler: func(_ context.Context, v protocol.Message) *protocol.Error {
 				var r tbcapi.ZKSpendableOutputsResponse
 				if err := json.Unmarshal(v.Payload, &r); err != nil {
 					panic(err)
@@ -1839,9 +1838,9 @@ func TestTxByIdNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
+	tbcServer, tbcURL := createTbcServer(ctx, t, mappedPeerPort)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1853,7 +1852,7 @@ func TestTxByIdNotFound(t *testing.T) {
 		conn: protocol.NewWSConn(c),
 	}
 
-	var response tbcapi.TxByIdResponse
+	var response tbcapi.TxByIDResponse
 	select {
 	case <-time.Tick(1 * time.Second):
 	case <-ctx.Done():
@@ -1862,11 +1861,11 @@ func TestTxByIdNotFound(t *testing.T) {
 
 	indexAll(ctx, t, tbcServer)
 
-	txId := getRandomTxId(ctx, t, bitcoindContainer)
-	txId[len(txId)-1] = 8
+	txID := getRandomTxID(ctx, t, bitcoindContainer)
+	txID[len(txID)-1] = 8
 
-	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIdRequest{
-		TxID: *txId,
+	err = tbcapi.Write(ctx, tws.conn, "someid", tbcapi.TxByIDRequest{
+		TxID: *txID,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1877,7 +1876,7 @@ func TestTxByIdNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if v.Header.Command != tbcapi.CmdTxByIdResponse {
+	if v.Header.Command != tbcapi.CmdTxByIDResponse {
 		t.Fatalf("received unexpected command: %s", v.Header.Command)
 	}
 
@@ -1954,9 +1953,9 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			s, tbcUrl := createTbcServer(ctx, t, port)
+			s, tbcURL := createTbcServer(ctx, t, port)
 
-			c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+			c, _, err := websocket.Dial(ctx, tbcURL, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2240,13 +2239,13 @@ func TestNotFoundError(t *testing.T) {
 			expectedError: *protocol.NotFoundError("block headers", 1),
 		},
 		{
-			name: "TxById",
+			name: "TxByID",
 			handler: func(ctx context.Context) (*protocol.Error, error) {
-				req := tbcapi.TxByIdRequest{
+				req := tbcapi.TxByIDRequest{
 					TxID: emptyHash,
 				}
-				res, err := s.handleTxByIdRequest(ctx, &req)
-				val, ok := res.(*tbcapi.TxByIdResponse)
+				res, err := s.handleTxByIDRequest(ctx, &req)
+				val, ok := res.(*tbcapi.TxByIDResponse)
 				if !ok {
 					return nil, fmt.Errorf("unexpected type: %T", res)
 				}
@@ -2257,11 +2256,11 @@ func TestNotFoundError(t *testing.T) {
 		{
 			name: "TxByIdRaw",
 			handler: func(ctx context.Context) (*protocol.Error, error) {
-				req := tbcapi.TxByIdRawRequest{
+				req := tbcapi.TxByIDRawRequest{
 					TxID: emptyHash,
 				}
-				res, err := s.handleTxByIdRawRequest(ctx, &req)
-				val, ok := res.(*tbcapi.TxByIdRawResponse)
+				res, err := s.handleTxByIDRawRequest(ctx, &req)
+				val, ok := res.(*tbcapi.TxByIDRawResponse)
 				if !ok {
 					return nil, fmt.Errorf("unexpected type: %T", res)
 				}
@@ -2384,10 +2383,10 @@ func TestTxWatchNotification(t *testing.T) {
 		}
 	}
 
-	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+	tbcURL := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
 
 	// Connect websocket client.
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2516,9 +2515,9 @@ func TestTxWatchFilterDrop(t *testing.T) {
 		}
 	}
 
-	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+	tbcURL := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
 
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2638,8 +2637,8 @@ func txWatchTestServer(t *testing.T) (*Server, *websocket.Conn, *tbcWs) {
 		}
 	}
 
-	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
-	c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+	tbcURL := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+	c, _, err := websocket.Dial(ctx, tbcURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -80,9 +80,9 @@ var (
 	ErrTxBroadcastNoPeers = errors.New("can't broadcast tx, no peers")
 	ErrNotInDebugMode     = errors.New("debug flag not set")
 
-	// upstreamStateIdKey is used for storing upstream state IDs
+	// upstreamStateIDKey is used for storing upstream state IDs
 	// representing a unique state of an upstream system driving TBC state/
-	upstreamStateIdKey = []byte("upstreamstateid")
+	upstreamStateIDKey = []byte("upstreamstateid")
 
 	mainnetHemiGenesis = &HashHeight{
 		Hash:   *s2h("000000000000000000001d8132106b63876117569713ef4fe89d5a2f1173c66e"),
@@ -420,7 +420,7 @@ func (s *Server) invInsert(h chainhash.Hash) bool {
 	return s.invInsertUnlocked(h)
 }
 
-func (s *Server) getHeadersByHashes(ctx context.Context, p *rawpeer.RawPeer, hashes ...*chainhash.Hash) error {
+func (s *Server) getHeadersByHashes(_ context.Context, p *rawpeer.RawPeer, hashes ...*chainhash.Hash) error {
 	log.Tracef("getHeadersByHashes %v %v", p, hashes)
 	defer log.Tracef("getHeadersByHashes exit %v %v", p, hashes)
 
@@ -468,7 +468,7 @@ func (s *Server) getHeadersByHeights(ctx context.Context, p *rawpeer.RawPeer, he
 	return nil
 }
 
-func (s *Server) pingExpired(ctx context.Context, key any, value any) {
+func (s *Server) pingExpired(_ context.Context, key any, value any) {
 	log.Tracef("pingExpired")
 	defer log.Tracef("pingExpired exit")
 
@@ -506,7 +506,7 @@ func (s *Server) pingPeer(ctx context.Context, p *rawpeer.RawPeer) {
 	s.pings.Put(ctx, defaultPingTimeout, peer, p, s.pingExpired, nil)
 }
 
-func (s *Server) mempoolPeer(ctx context.Context, p *rawpeer.RawPeer) {
+func (s *Server) mempoolPeer(_ context.Context, p *rawpeer.RawPeer) {
 	log.Tracef("mempoolPeer %v", p)
 	defer log.Tracef("mempoolPeer %v exit", p)
 
@@ -641,14 +641,13 @@ func (s *Server) handlePeer(ctx context.Context, p *rawpeer.RawPeer) error {
 		// Disconnect for now. We only want more or less synced peers.
 		readError = err
 		return errors.New("remote peer height below ours")
-	} else {
-		err := s.getHeadersByHeights(ctx, p,
-			bhb.Height, bhb.Height-1000, bhb.Height-1999,
-			previousCheckpointHeight(bhb.Height, s.g.chain.Checkpoints))
-		if err != nil {
-			readError = err
-			return fmt.Errorf("handle peer heights: %w", err)
-		}
+	}
+	err = s.getHeadersByHeights(ctx, p,
+		bhb.Height, bhb.Height-1000, bhb.Height-1999,
+		previousCheckpointHeight(bhb.Height, s.g.chain.Checkpoints))
+	if err != nil {
+		readError = err
+		return fmt.Errorf("handle peer heights: %w", err)
 	}
 
 	// Get p2p information.
@@ -998,7 +997,7 @@ func (s *Server) handleAddrV2(_ context.Context, p *rawpeer.RawPeer, msg *wire.M
 	return nil
 }
 
-func (s *Server) handlePing(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgPing) error {
+func (s *Server) handlePing(_ context.Context, p *rawpeer.RawPeer, msg *wire.MsgPing) error {
 	log.Tracef("handlePing %v", p)
 	defer log.Tracef("handlePing exit %v", p)
 
@@ -1012,7 +1011,7 @@ func (s *Server) handlePing(ctx context.Context, p *rawpeer.RawPeer, msg *wire.M
 	return nil
 }
 
-func (s *Server) handlePong(ctx context.Context, p *rawpeer.RawPeer, pong *wire.MsgPong) error {
+func (s *Server) handlePong(_ context.Context, p *rawpeer.RawPeer, pong *wire.MsgPong) error {
 	log.Tracef("handlePong %v", p)
 	defer log.Tracef("handlePong exit %v", p)
 
@@ -1024,7 +1023,7 @@ func (s *Server) handlePong(ctx context.Context, p *rawpeer.RawPeer, pong *wire.
 	return nil
 }
 
-func (s *Server) downloadBlock(ctx context.Context, p *rawpeer.RawPeer, ch chainhash.Hash) error {
+func (s *Server) downloadBlock(_ context.Context, p *rawpeer.RawPeer, ch chainhash.Hash) error {
 	log.Tracef("downloadBlock")
 	defer log.Tracef("downloadBlock exit")
 
@@ -1184,7 +1183,7 @@ func (s *Server) downloadMissingTx(ctx context.Context, p *rawpeer.RawPeer) erro
 	return err
 }
 
-func (s *Server) handleTx(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgTx, raw []byte) error {
+func (s *Server) handleTx(ctx context.Context, _ *rawpeer.RawPeer, msg *wire.MsgTx, _ []byte) error {
 	log.Tracef("handleTx")
 	defer log.Tracef("handleTx exit")
 
@@ -1420,7 +1419,7 @@ func (s *Server) syncBlocks(ctx context.Context) {
 // corresponding TBC database state transition. Otherwise, an unexpected termination
 // between updating TBC state and recording the updated upstreamCursor could cause
 // state corruption.
-func (s *Server) RemoveExternalHeaders(ctx context.Context, headers *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, upstreamStateId []byte) (tbcd.RemoveType, *tbcd.BlockHeader, error) {
+func (s *Server) RemoveExternalHeaders(ctx context.Context, headers *wire.MsgHeaders, tipAfterRemoval *wire.BlockHeader, upstreamStateID []byte) (tbcd.RemoveType, *tbcd.BlockHeader, error) {
 	if !s.cfg.ExternalHeaderMode {
 		return tbcd.RTInvalid, nil,
 			errors.New("RemoveExternalHeaders called on TBC instance that is not in external header mode")
@@ -1431,7 +1430,7 @@ func (s *Server) RemoveExternalHeaders(ctx context.Context, headers *wire.MsgHea
 			errors.New("RemoveExternalHeaders called with no headers")
 	}
 
-	if upstreamStateId == nil {
+	if upstreamStateID == nil {
 		return tbcd.RTInvalid, nil,
 			errors.New("upstream state invalid")
 	}
@@ -1462,7 +1461,7 @@ func (s *Server) RemoveExternalHeaders(ctx context.Context, headers *wire.MsgHea
 				dbnames.MetadataDB)
 		}
 		level.BatchAppend(ctx, b.Batch, []tbcd.Row{
-			{Key: upstreamStateIdKey, Value: upstreamStateId},
+			{Key: upstreamStateIDKey, Value: upstreamStateID},
 		})
 		return nil
 	}
@@ -1478,9 +1477,9 @@ func (s *Server) RemoveExternalHeaders(ctx context.Context, headers *wire.MsgHea
 	return it, por, err
 }
 
-// AddExternalHeaders XXX if we are passing in upstreamStateId then why does
+// AddExternalHeaders XXX if we are passing in upstreamStateID then why does
 // the default live in tbcd?
-func (s *Server) AddExternalHeaders(ctx context.Context, headers *wire.MsgHeaders, upstreamStateId []byte) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
+func (s *Server) AddExternalHeaders(ctx context.Context, headers *wire.MsgHeaders, upstreamStateID []byte) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
 	if !s.cfg.ExternalHeaderMode {
 		return tbcd.ITInvalid, nil, nil, 0,
 			errors.New("AddExternalHeaders called on TBC instance that is not in external header mode")
@@ -1491,7 +1490,7 @@ func (s *Server) AddExternalHeaders(ctx context.Context, headers *wire.MsgHeader
 			errors.New("AddExternalHeaders called with no headers")
 	}
 
-	if upstreamStateId == nil {
+	if upstreamStateID == nil {
 		return tbcd.ITInvalid, nil, nil, 0,
 			errors.New("upstream state invalid")
 	}
@@ -1517,7 +1516,7 @@ func (s *Server) AddExternalHeaders(ctx context.Context, headers *wire.MsgHeader
 				dbnames.MetadataDB)
 		}
 		level.BatchAppend(ctx, b.Batch, []tbcd.Row{
-			{Key: upstreamStateIdKey, Value: upstreamStateId},
+			{Key: upstreamStateIDKey, Value: upstreamStateID},
 		})
 		return nil
 	}
@@ -1763,10 +1762,9 @@ func (s *Server) handleBlock(ctx context.Context, p *rawpeer.RawPeer, msg *wire.
 	height, err := s.insertBlock(ctx, block) // XXX see if we can use raw here
 	if err != nil {
 		return fmt.Errorf("database block insert %v: %w", bhs, err)
-	} else {
-		log.Infof("Insert block %v at %v txs %v %v", bhs, height,
-			len(msg.Transactions), msg.Header.Timestamp)
 	}
+	log.Infof("Insert block %v at %v txs %v %v", bhs, height,
+		len(msg.Transactions), msg.Header.Timestamp)
 
 	// Reap broadcast messages.
 	txHashes, _ := block.MsgBlock().TxHashes()
@@ -1843,7 +1841,7 @@ func (s *Server) handleBlock(ctx context.Context, p *rawpeer.RawPeer, msg *wire.
 	return nil
 }
 
-func (s *Server) handleInv(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgInv, raw []byte) error {
+func (s *Server) handleInv(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgInv, _ []byte) error {
 	switch msg.InvList[0].Type {
 	case wire.InvTypeTx:
 	case wire.InvTypeBlock:
@@ -1896,7 +1894,7 @@ func (s *Server) handleInv(ctx context.Context, p *rawpeer.RawPeer, msg *wire.Ms
 	return nil
 }
 
-func (s *Server) handleNotFound(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgNotFound, raw []byte) error {
+func (s *Server) handleNotFound(_ context.Context, _ *rawpeer.RawPeer, _ *wire.MsgNotFound, _ []byte) error {
 	// log.Infof("handleNotFound %v", spew.Sdump(msg))
 	// defer log.Infof("handleNotFound exit")
 
@@ -1906,7 +1904,7 @@ func (s *Server) handleNotFound(ctx context.Context, p *rawpeer.RawPeer, msg *wi
 	return nil
 }
 
-func (s *Server) handleGetData(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgGetData, raw []byte) error {
+func (s *Server) handleGetData(_ context.Context, p *rawpeer.RawPeer, msg *wire.MsgGetData, _ []byte) error {
 	log.Tracef("handleGetData %v", p)
 	defer log.Tracef("handleGetData %v exit", p)
 
@@ -2211,7 +2209,7 @@ func (s *Server) BlockKeystoneByL2KeystoneAbrevHash(ctx context.Context, abrevha
 	return s.g.db.BlockKeystoneByL2KeystoneAbrevHash(ctx, abrevhash)
 }
 
-func (s *Server) KeystoneTxsByL2KeystoneAbrevHash(ctx context.Context, abrevhash chainhash.Hash, depth uint) ([]tbcapi.KeystoneTx, error) {
+func (s *Server) KeystoneTxsByL2KeystoneAbrevHash(ctx context.Context, abrevhash chainhash.Hash, _ uint) ([]tbcapi.KeystoneTx, error) {
 	log.Tracef("KeystoneTxsByL2KeystoneAbrevHash")
 	defer log.Tracef("KeystoneTxsByL2KeystoneAbrevHash exit")
 
@@ -2225,20 +2223,20 @@ func (s *Server) KeystoneTxsByL2KeystoneAbrevHash(ctx context.Context, abrevhash
 }
 
 // ScriptHashAvailableToSpend returns a boolean which indicates whether
-// a specific output (uniquely identified by TxId output index) is
+// a specific output (uniquely identified by TxID output index) is
 // available for spending in the UTXO table.
 // This function can return false for two reasons:
 //  1. The outpoint was already spent
 //  2. The outpoint never existed
-func (s *Server) ScriptHashAvailableToSpend(ctx context.Context, txId chainhash.Hash, index uint32) (bool, error) {
+func (s *Server) ScriptHashAvailableToSpend(ctx context.Context, txID chainhash.Hash, index uint32) (bool, error) {
 	log.Tracef("ScriptHashAvailableToSpend")
 	defer log.Tracef("ScriptHashAvailableToSpend exit")
 	if s.cfg.ExternalHeaderMode {
 		return false, NewExternalHeaderNotAllowedError("ScriptHashAvailableToSpend")
 	}
 
-	txIdBytes := [32]byte(txId.CloneBytes())
-	op := tbcd.NewOutpoint(txIdBytes, index)
+	txIDBytes := [32]byte(txID.CloneBytes())
+	op := tbcd.NewOutpoint(txIDBytes, index)
 	sh, err := s.g.db.ScriptHashByOutpoint(ctx, op)
 	if err != nil {
 		return false, err
@@ -2263,16 +2261,16 @@ func (s *Server) ScriptHashByOutpoint(ctx context.Context, op tbcd.Outpoint) (*t
 	return s.g.db.ScriptHashByOutpoint(ctx, op)
 }
 
-func (s *Server) SpentOutputsByTxId(ctx context.Context, txId chainhash.Hash) ([]tbcd.SpentInfo, error) {
-	log.Tracef("SpentOutputsByTxId")
-	defer log.Tracef("SpentOutputsByTxId exit")
+func (s *Server) SpentOutputsByTxID(ctx context.Context, txID chainhash.Hash) ([]tbcd.SpentInfo, error) {
+	log.Tracef("SpentOutputsByTxID")
+	defer log.Tracef("SpentOutputsByTxID exit")
 
 	if s.cfg.ExternalHeaderMode {
-		return nil, NewExternalHeaderNotAllowedError("SpentOutputsByTxId")
+		return nil, NewExternalHeaderNotAllowedError("SpentOutputsByTxID")
 	}
 
 	// As it is written now it returns all spent outputs per the tx index view.
-	si, err := s.g.db.SpentOutputsByTxId(ctx, txId)
+	si, err := s.g.db.SpentOutputsByTxID(ctx, txID)
 	if err != nil {
 		return nil, err
 	}
@@ -2292,26 +2290,26 @@ func (s *Server) BlockInTxIndex(ctx context.Context, blkid chainhash.Hash) (bool
 	return s.g.db.BlockInTxIndex(ctx, blkid)
 }
 
-func (s *Server) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainhash.Hash, error) {
-	log.Tracef("BlockHashByTxId")
-	defer log.Tracef("BlockHashByTxId exit")
+func (s *Server) BlockHashByTxID(ctx context.Context, txID chainhash.Hash) (*chainhash.Hash, error) {
+	log.Tracef("BlockHashByTxID")
+	defer log.Tracef("BlockHashByTxID exit")
 
 	if s.cfg.ExternalHeaderMode {
-		return nil, NewExternalHeaderNotAllowedError("BlockHashByTxId")
+		return nil, NewExternalHeaderNotAllowedError("BlockHashByTxID")
 	}
 
-	return s.g.db.BlockHashByTxId(ctx, txId)
+	return s.g.db.BlockHashByTxID(ctx, txID)
 }
 
-func (s *Server) TxById(ctx context.Context, txId chainhash.Hash) (*wire.MsgTx, error) {
-	log.Tracef("TxById")
-	defer log.Tracef("TxById exit")
+func (s *Server) TxByID(ctx context.Context, txID chainhash.Hash) (*wire.MsgTx, error) {
+	log.Tracef("TxByID")
+	defer log.Tracef("TxByID exit")
 
 	if s.cfg.ExternalHeaderMode {
-		return nil, NewExternalHeaderNotAllowedError("TxById")
+		return nil, NewExternalHeaderNotAllowedError("TxByID")
 	}
 
-	blockHash, err := s.g.db.BlockHashByTxId(ctx, txId)
+	blockHash, err := s.g.db.BlockHashByTxID(ctx, txID)
 	if err != nil {
 		return nil, err
 	}
@@ -2320,7 +2318,7 @@ func (s *Server) TxById(ctx context.Context, txId chainhash.Hash) (*wire.MsgTx, 
 		return nil, err
 	}
 	for _, tx := range block.Transactions() {
-		if tx.Hash().IsEqual(&txId) {
+		if tx.Hash().IsEqual(&txID) {
 			return tx.MsgTx(), nil
 		}
 	}
@@ -2328,7 +2326,7 @@ func (s *Server) TxById(ctx context.Context, txId chainhash.Hash) (*wire.MsgTx, 
 	return nil, database.ErrNotFound
 }
 
-func (s *Server) TxBroadcastAllToPeer(ctx context.Context, p *rawpeer.RawPeer) error {
+func (s *Server) TxBroadcastAllToPeer(_ context.Context, p *rawpeer.RawPeer) error {
 	log.Tracef("TxBroadcastAllToPeer %v", p)
 	defer log.Tracef("TxBroadcastAllToPeer %v exit", p)
 
@@ -2390,7 +2388,7 @@ func (s *Server) TxBroadcast(ctx context.Context, tx *wire.MsgTx, force bool) (*
 		return nil, fmt.Errorf("invalid vector: %w", err)
 	}
 	var success atomic.Uint64
-	inv := func(ctx context.Context, p *rawpeer.RawPeer) {
+	inv := func(_ context.Context, p *rawpeer.RawPeer) {
 		log.Tracef("inv %v", p)
 		defer log.Tracef("inv %v exit", p)
 
@@ -2705,19 +2703,19 @@ func (s *Server) FullBlockAvailable(ctx context.Context, hash chainhash.Hash) (b
 	return s.g.db.BlockExistsByHash(ctx, hash)
 }
 
-// UpstreamStateId fetches the last-stored upstream state ID.  If the last
+// UpstreamStateID fetches the last-stored upstream state ID.  If the last
 // header insertion/removal did not specify an upstream state ID, this will
 // return the default upstream state ID.
-func (s *Server) UpstreamStateId(ctx context.Context) (*[32]byte, error) {
-	log.Tracef("UpstreamStateId")
-	defer log.Tracef("UpstreamStateId exit")
+func (s *Server) UpstreamStateID(ctx context.Context) (*[32]byte, error) {
+	log.Tracef("UpstreamStateID")
+	defer log.Tracef("UpstreamStateID exit")
 
 	if !s.cfg.ExternalHeaderMode {
 		return nil, errors.New("upstream state id: " +
 			"not running in external header mode")
 	}
 
-	usi, err := s.g.db.MetadataGet(ctx, upstreamStateIdKey)
+	usi, err := s.g.db.MetadataGet(ctx, upstreamStateIDKey)
 	if err != nil {
 		return nil, err
 	}
@@ -2726,19 +2724,19 @@ func (s *Server) UpstreamStateId(ctx context.Context) (*[32]byte, error) {
 	return &x, nil
 }
 
-// SetUpstreamStateId sets a new upstream state ID without making any other
+// SetUpstreamStateID sets a new upstream state ID without making any other
 // state changes to TBC, used when the upstream state is updated without
 // requiring any TBC updates.
-func (s *Server) SetUpstreamStateId(ctx context.Context, upstreamStateId [32]byte) error {
-	log.Tracef("SetUpstreamStateId")
-	defer log.Tracef("SetUpstreamStateId exit")
+func (s *Server) SetUpstreamStateID(ctx context.Context, upstreamStateID [32]byte) error {
+	log.Tracef("SetUpstreamStateID")
+	defer log.Tracef("SetUpstreamStateID exit")
 
 	if !s.cfg.ExternalHeaderMode {
 		return errors.New("set upstream state id: " +
 			"not running in external header mode")
 	}
 
-	return s.g.db.MetadataPut(ctx, upstreamStateIdKey, upstreamStateId[:])
+	return s.g.db.MetadataPut(ctx, upstreamStateIDKey, upstreamStateID[:])
 }
 
 type SyncInfo struct {
@@ -3368,7 +3366,7 @@ func (s *Server) Run(pctx context.Context) error {
 	return err
 }
 
-func (s *Server) ExternalHeaderSetup(ctx context.Context, upstreamStateId []byte) error {
+func (s *Server) ExternalHeaderSetup(ctx context.Context, upstreamStateID []byte) error {
 	log.Tracef("ExternalHeaderSetup")
 	defer log.Tracef("ExternalHeaderSetup exit")
 
@@ -3399,8 +3397,8 @@ func (s *Server) ExternalHeaderSetup(ctx context.Context, upstreamStateId []byte
 			return fmt.Errorf("block headers best: %w", err)
 		}
 
-		// Insert default upstreamStateId
-		err := s.g.db.MetadataPut(ctx, upstreamStateIdKey, upstreamStateId)
+		// Insert default upstreamStateID
+		err := s.g.db.MetadataPut(ctx, upstreamStateIDKey, upstreamStateID)
 		if err != nil {
 			return fmt.Errorf("default upstream state id insert: %w",
 				err)

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -46,7 +46,7 @@ const (
 	levelDbHome = ".testleveldb"
 )
 
-var defaultUpstreamStateId = [32]byte{
+var defaultUpstreamStateID = [32]byte{
 	0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00,
 	0x44, 0x45, 0x46, 0x41, 0x55, 0x4C, 0x54, 0x55, 0x50, 0x53, // DEFAULTUPS
 	0x54, 0x52, 0x45, 0x41, 0x4D, 0x53, 0x54, 0x41, 0x54, 0x45, // TREAMSTATE
@@ -168,6 +168,7 @@ func TestDbUpgradeFull(t *testing.T) {
 
 	// check if db upgrade finished before checking for bh
 	for !s.Running() {
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	_, err = s.BlockHeadersByHeight(ctx, 9)
@@ -277,8 +278,9 @@ func TestDbUpgradeV3(t *testing.T) {
 	}
 
 	// Get all db keys
-	keys := make([]string, 0, len(dbTemp.DB()))
-	for k := range dbTemp.DB() {
+	dbTempPool := level.Pool(dbTemp)
+	keys := make([]string, 0, len(dbTempPool))
+	for k := range dbTempPool {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
@@ -340,10 +342,13 @@ func TestDbUpgradeV3(t *testing.T) {
 	t.Log("Comparing DBs")
 
 	// Compare all databases
+	dbv2Pool := level.Pool(dbv2)
+	dbMovePool := level.Pool(dbMove)
+	dbCopyPool := level.Pool(dbCopy)
 	for _, dbs := range keys {
-		a := dbv2.DB()[dbs]
-		b := dbMove.DB()[dbs]
-		c := dbCopy.DB()[dbs]
+		a := dbv2Pool[dbs]
+		b := dbMovePool[dbs]
+		c := dbCopyPool[dbs]
 
 		t.Logf("Comparing original records against dbmove (%v)", dbs)
 		records, err := cmpDB(a, b)
@@ -617,7 +622,7 @@ func TestForksWithGen(t *testing.T) {
 	testTable := []tbcForkTestTableItem{
 		{
 			name: "Split Tip, Single Block",
-			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, walletAddress string, tbcServer *Server) {
+			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, _ string, tbcServer *Server) {
 				// block 1A, send 7 btc to otherAddress
 				_, err := runBitcoinCommand(
 					ctx, t, bitcoindContainer,
@@ -713,7 +718,7 @@ func TestForksWithGen(t *testing.T) {
 		},
 		{
 			name: "Split Tip, Multiple Blocks",
-			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, walletAddress string, tbcServer *Server) {
+			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, _ string, _ *Server) {
 				lastA := ""
 				lastB := ""
 				earliestA := ""
@@ -831,7 +836,7 @@ func TestForksWithGen(t *testing.T) {
 
 		{
 			name: "Long reorg",
-			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, walletAddress string, tbcServer *Server) {
+			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, _ string, tbcServer *Server) {
 				_, err := runBitcoinCommand(
 					ctx,
 					t,
@@ -941,7 +946,7 @@ func TestForksWithGen(t *testing.T) {
 		},
 		{
 			name: "Ancient orphan",
-			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, walletAddress string, tbcServer *Server) {
+			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, _ string, tbcServer *Server) {
 				_, err := runBitcoinCommand(
 					ctx,
 					t,
@@ -1146,7 +1151,7 @@ func reconsiderBlock(ctx context.Context, t *testing.T, bitcoindContainer testco
 }
 
 func createBitcoind(ctx context.Context, t *testing.T) testcontainers.Container {
-	id, err := randHexId(6)
+	id, err := randHexID(6)
 	if err != nil {
 		t.Fatal("failed to generate random id:", err)
 	}
@@ -1201,7 +1206,7 @@ func runBitcoinCommand(ctx context.Context, t *testing.T, bitcoindContainer test
 	return buf.String()[8 : len(buf.String())-1], nil
 }
 
-func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container) *chainhash.Hash {
+func getRandomTxID(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container) *chainhash.Hash {
 	blockHash, err := runBitcoinCommand(
 		ctx,
 		t,
@@ -1216,7 +1221,7 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 		t.Fatal(err)
 	}
 
-	blockJson, err := runBitcoinCommand(
+	blockJSON, err := runBitcoinCommand(
 		ctx,
 		t,
 		bitcoindContainer,
@@ -1233,7 +1238,7 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 	var parsed struct {
 		Tx []string `json:"tx"`
 	}
-	if err := json.Unmarshal([]byte(blockJson), &parsed); err != nil {
+	if err := json.Unmarshal([]byte(blockJSON), &parsed); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1294,13 +1299,13 @@ func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port)
 		}
 	}
 
-	tbcUrl := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
-	err = EnsureCanConnect(t, tbcUrl, 5*time.Second)
+	tbcURL := fmt.Sprintf("http://%s%s", tbcAddr, tbcapi.RouteWebsocket)
+	err = EnsureCanConnect(t, tbcURL, 5*time.Second)
 	if err != nil {
-		t.Fatalf("could not connect to %s: %s", tbcUrl, err.Error())
+		t.Fatalf("could not connect to %s: %s", tbcURL, err.Error())
 	}
 
-	return tbcServer, tbcUrl
+	return tbcServer, tbcURL
 }
 
 func EnsureCanConnect(t *testing.T, url string, timeout time.Duration) error {
@@ -1429,7 +1434,7 @@ func bitcoindBestBlock(ctx context.Context, t *testing.T, bitcoindContainer test
 }
 
 func bitcoindBlockByHash(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container, blockHash string) *BtcCliBlockHeader {
-	blockHeaderJson, err := runBitcoinCommand(
+	blockHeaderJSON, err := runBitcoinCommand(
 		ctx, t, bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1442,7 +1447,7 @@ func bitcoindBlockByHash(ctx context.Context, t *testing.T, bitcoindContainer te
 	}
 
 	var btcCliBlockHeader BtcCliBlockHeader
-	if err = json.Unmarshal([]byte(blockHeaderJson), &btcCliBlockHeader); err != nil {
+	if err = json.Unmarshal([]byte(blockHeaderJSON), &btcCliBlockHeader); err != nil {
 		t.Fatal(fmt.Errorf("unmarshal json output: %w", err))
 	}
 
@@ -1508,7 +1513,7 @@ func createTbcServerExternalHeaderMode(ctx context.Context, t *testing.T) *Serve
 		t.Fatal(err)
 	}
 
-	err = tbcServer.ExternalHeaderSetup(ctx, defaultUpstreamStateId[:])
+	err = tbcServer.ExternalHeaderSetup(ctx, defaultUpstreamStateID[:])
 	if err != nil {
 		t.Fatalf("external header setup: %v", err)
 	}
@@ -1727,20 +1732,20 @@ func TestExternalHeaderModeSimpleSingleBlockChunks(t *testing.T) {
 			Headers: parsedHeaders,
 		}
 
-		stateId := [32]byte{byte(i)}
-		it, canon, last, _, err := tbc.AddExternalHeaders(ctx, msgHeaders, stateId[:])
+		stateID := [32]byte{byte(i)}
+		it, canon, last, _, err := tbc.AddExternalHeaders(ctx, msgHeaders, stateID[:])
 		if err != nil {
 			t.Error(err)
 		}
 
-		stateIdRet, err := tbc.UpstreamStateId(ctx)
+		stateIDRet, err := tbc.UpstreamStateID(ctx)
 		if err != nil {
 			t.Errorf("unable to get upstream state id, err: %v", err)
 		}
 
-		if !bytes.Equal(stateIdRet[:], stateId[:]) {
+		if !bytes.Equal(stateIDRet[:], stateID[:]) {
 			t.Errorf("after adding external headers, state id should have been %x but got %x instead",
-				stateId[:], stateIdRet[:])
+				stateID[:], stateIDRet[:])
 		}
 
 		if it != tbcd.ITChainExtend {
@@ -1827,20 +1832,20 @@ func TestExternalHeaderModeSimpleSingleBlockChunks(t *testing.T) {
 
 		prevHeaderHash := prevHeaderParsed.BlockHash()
 		// Different from the state IDs used earlier to ensure we differentiate
-		stateId := [32]byte{byte(i), 0xFF}
-		rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, prevHeaderParsed, stateId[:])
+		stateID := [32]byte{byte(i), 0xFF}
+		rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, prevHeaderParsed, stateID[:])
 		if err != nil {
 			t.Error(err)
 		}
 
-		stateIdRet, err := tbc.UpstreamStateId(ctx)
+		stateIDRet, err := tbc.UpstreamStateID(ctx)
 		if err != nil {
 			t.Errorf("unable to get upstream state id, err: %v", err)
 		}
 
-		if !bytes.Equal(stateIdRet[:], stateId[:]) {
+		if !bytes.Equal(stateIDRet[:], stateID[:]) {
 			t.Errorf("after removing external headers, state id should have been %x but got %x instead",
-				stateId[:], stateIdRet[:])
+				stateID[:], stateIDRet[:])
 		}
 
 		prtHash := postRemovalTip.BlockHash()
@@ -1923,7 +1928,7 @@ func TestExternalHeaderModeSimpleThreeBlockChunks(t *testing.T) {
 			Headers: parsedHeaders,
 		}
 
-		it, canon, last, _, err := tbc.AddExternalHeaders(ctx, msgHeaders, defaultUpstreamStateId[:])
+		it, canon, last, _, err := tbc.AddExternalHeaders(ctx, msgHeaders, defaultUpstreamStateID[:])
 		if err != nil {
 			t.Error(err)
 		}
@@ -2027,7 +2032,7 @@ func TestExternalHeaderModeSimpleThreeBlockChunks(t *testing.T) {
 			t.Logf("%d: %x", k, bh)
 		}
 
-		rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, prevHeaderParsed, defaultUpstreamStateId[:])
+		rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, prevHeaderParsed, defaultUpstreamStateID[:])
 		if err != nil {
 			t.Error(err)
 		}
@@ -2085,22 +2090,22 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 	}
 
 	// arbitrary values
-	origInsertStateId := [32]byte{0xFF, 0x33, 0x99, 0xE3}
-	it, canon, last, _, err := tbc.AddExternalHeaders(ctx, msgHeaders, origInsertStateId[:])
+	origInsertStateID := [32]byte{0xFF, 0x33, 0x99, 0xE3}
+	it, canon, last, _, err := tbc.AddExternalHeaders(ctx, msgHeaders, origInsertStateID[:])
 	if err != nil {
 		t.Error(err)
 	}
 
-	stateIdRet, err := tbc.UpstreamStateId(ctx)
+	stateIDRet, err := tbc.UpstreamStateID(ctx)
 	if err != nil {
 		t.Errorf("unable to get upstream state id, err: %v", err)
 	}
 
-	if !bytes.Equal(stateIdRet[:], origInsertStateId[:]) {
+	if !bytes.Equal(stateIDRet[:], origInsertStateID[:]) {
 		t.Errorf("after adding external headers, state id should have been %x but got %x instead",
-			origInsertStateId[:], stateIdRet[:])
+			origInsertStateID[:], stateIDRet[:])
 	} else {
-		t.Logf("after adding external headers, state id of %x is correct", stateIdRet[:])
+		t.Logf("after adding external headers, state id of %x is correct", stateIDRet[:])
 	}
 
 	if it != tbcd.ITChainExtend {
@@ -2183,8 +2188,8 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 			t.Errorf("unable to parse heacer %x", rawWouldBeCanonical[:])
 		}
 
-		removeStateId := [32]byte{0xAA, 0xBB, 0xCC, 0xDD}
-		rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, wouldBeCanonical, removeStateId[:])
+		removeStateID := [32]byte{0xAA, 0xBB, 0xCC, 0xDD}
+		rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, wouldBeCanonical, removeStateID[:])
 		if err == nil {
 			t.Errorf("removing headers from %d to %d when tip is %d should have failed but did not", start, end, canonicalHeightBefore)
 		}
@@ -2198,16 +2203,16 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 			t.Errorf("removing headers from %d to %d when tip is %d should not have returned a non-nil post removal tip", start, end, canonicalHeightBefore)
 		}
 
-		stateIdRet, err := tbc.UpstreamStateId(ctx)
+		stateIDRet, err := tbc.UpstreamStateID(ctx)
 		if err != nil {
 			t.Errorf("unable to get upstream state id, err: %v", err)
 		}
 
-		if !bytes.Equal(stateIdRet[:], origInsertStateId[:]) {
+		if !bytes.Equal(stateIDRet[:], origInsertStateID[:]) {
 			t.Errorf("after failing to remove external headers, state id should have been the original insert id %x but got %x instead",
-				origInsertStateId[:], stateIdRet[:])
+				origInsertStateID[:], stateIDRet[:])
 		} else {
-			t.Logf("after failing to remove external headers, state id of %x is correct", stateIdRet[:])
+			t.Logf("after failing to remove external headers, state id of %x is correct", stateIDRet[:])
 		}
 
 		canonicalHeightAfter, canonicalAfter, err := tbc.BlockHeaderBest(ctx)
@@ -2245,7 +2250,7 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 		t.Errorf("unable to parse heacer %x", rawShouldBeCanonical[:])
 	}
 
-	rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, shouldBeCanonical, defaultUpstreamStateId[:])
+	rt, postRemovalTip, err := tbc.RemoveExternalHeaders(ctx, msgHeaders, shouldBeCanonical, defaultUpstreamStateID[:])
 	if err != nil {
 		t.Errorf("removing headers from %d to %d when tip is %d should have succeeded but did not", start, end, canonicalHeightBefore)
 	}
@@ -2258,38 +2263,38 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 		t.Errorf("removing headers from %d to %d when tip is %d should have returned a non-nil post removal tip", start, end, canonicalHeightBefore)
 	}
 
-	stateIdRet, err = tbc.UpstreamStateId(ctx)
+	stateIDRet, err = tbc.UpstreamStateID(ctx)
 	if err != nil {
 		t.Errorf("unable to get upstream state id, err: %v", err)
 	}
 
-	if !bytes.Equal(stateIdRet[:], defaultUpstreamStateId[:]) {
+	if !bytes.Equal(stateIDRet[:], defaultUpstreamStateID[:]) {
 		t.Errorf("after successfully removing external headers with no state id specified, state id should "+
 			"have been the default upstream state id %x but got %x instead",
-			defaultUpstreamStateId[:], stateIdRet[:])
+			defaultUpstreamStateID[:], stateIDRet[:])
 	} else {
 		t.Logf("after successfully removing external headers with no state id specified, state id of "+
-			"%x is correct (set to default)", stateIdRet[:])
+			"%x is correct (set to default)", stateIDRet[:])
 	}
 
-	updateStateWithoutModificationsId := [32]byte{0x4C, 0xA1, 0x62, 0xB6}
-	err = tbc.SetUpstreamStateId(ctx, updateStateWithoutModificationsId)
+	updateStateWithoutModificationsID := [32]byte{0x4C, 0xA1, 0x62, 0xB6}
+	err = tbc.SetUpstreamStateID(ctx, updateStateWithoutModificationsID)
 	if err != nil {
 		t.Errorf("unable to set upstream state id, err: %v", err)
 	}
 
-	stateIdRet, err = tbc.UpstreamStateId(ctx)
+	stateIDRet, err = tbc.UpstreamStateID(ctx)
 	if err != nil {
 		t.Errorf("unable to get upstream state id, err: %v", err)
 	}
 
-	if !bytes.Equal(stateIdRet[:], updateStateWithoutModificationsId[:]) {
+	if !bytes.Equal(stateIDRet[:], updateStateWithoutModificationsID[:]) {
 		t.Errorf("after performing an explicit state id update without modifying header data state id should "+
 			"have been %x but got %x instead",
-			updateStateWithoutModificationsId[:], stateIdRet[:])
+			updateStateWithoutModificationsID[:], stateIDRet[:])
 	} else {
 		t.Logf("after performing an explicit state id update without modifying header data state, state id of "+
-			"%x is correct (set to default)", stateIdRet[:])
+			"%x is correct (set to default)", stateIDRet[:])
 	}
 
 	canonicalHeightAfter, canonicalAfter, err := tbc.BlockHeaderBest(ctx)
@@ -2343,7 +2348,7 @@ func TestExternalHeaderModeSimpleIncorrectRemoval(t *testing.T) {
 		t.Error(err)
 	}
 
-	it, canon, last, _, err = tbc.AddExternalHeaders(ctx, msgHeaders, defaultUpstreamStateId[:])
+	it, canon, last, _, err = tbc.AddExternalHeaders(ctx, msgHeaders, defaultUpstreamStateID[:])
 	if err != nil {
 		t.Error(err)
 	}

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -475,7 +475,7 @@ func (b *btcNode) handleRPC(ctx context.Context, conn net.Conn) error {
 	}
 }
 
-func (b *btcNode) handleMsg(ctx context.Context, p *rawpeer.RawPeer, msg wire.Message) error {
+func (b *btcNode) handleMsg(_ context.Context, p *rawpeer.RawPeer, msg wire.Message) error {
 	// b.t.Logf("%v", spew.Sdump(msg))
 	// b.t.Logf("%T", msg)
 	switch m := msg.(type) {
@@ -514,7 +514,7 @@ func (b *btcNode) handleMsg(ctx context.Context, p *rawpeer.RawPeer, msg wire.Me
 	return nil
 }
 
-func (b *btcNode) SendBlockheader(ctx context.Context, bh wire.BlockHeader) error {
+func (b *btcNode) SendBlockheader(_ context.Context, bh wire.BlockHeader) error {
 	msg := wire.NewMsgHeaders()
 	if err := msg.AddBlockHeader(&bh); err != nil {
 		return fmt.Errorf("add block header: %w", err)
@@ -1092,7 +1092,7 @@ func (b *btcNode) MineAndSend(ctx context.Context, name string, parent *chainhas
 	return blk, nil
 }
 
-func (b *btcNode) MineAndSendEmpty(ctx context.Context) error {
+func (b *btcNode) MineAndSendEmpty(_ context.Context) error {
 	b.t.Logf("send empty headers message")
 	return b.p.Write(defaultCmdTimeout, wire.NewMsgHeaders())
 }
@@ -1120,7 +1120,7 @@ func createTestMsgHeaders(headers []*tbcd.BlockHeader) *wire.MsgHeaders {
 	return msgHeaders
 }
 
-func (b *btcNode) MineAndSendFake(ctx context.Context, prevHash *chainhash.Hash, count uint32) ([]*tbcd.BlockHeader, error) {
+func (b *btcNode) MineAndSendFake(_ context.Context, prevHash *chainhash.Hash, count uint32) ([]*tbcd.BlockHeader, error) {
 	bhs := make([]*tbcd.BlockHeader, 0, count)
 	for i := range count {
 		prev := prevHash
@@ -1182,7 +1182,7 @@ type zkTxInInfo struct {
 	zkTxInfo
 
 	inIndex  int
-	utxoTxId chainhash.Hash
+	utxoTxID chainhash.Hash
 	utxoVal  uint64
 }
 
@@ -1255,7 +1255,7 @@ func zkValidateTxIn(ctx context.Context, s *Server, i *zkTxInInfo) {
 	}
 	sh := tbcd.NewScriptHashFromScript(tout)
 
-	_, err = spendingOutByTxIn(ctx, s, i.utxoTxId,
+	_, err = spendingOutByTxIn(ctx, s, i.utxoTxID,
 		*i.tx.Hash(), i.inIndex)
 	if err != nil {
 		i.errors = append(i.errors, err)
@@ -1267,54 +1267,54 @@ func zkValidateTxIn(ctx context.Context, s *Server, i *zkTxInInfo) {
 	}
 }
 
-func spendingOutByTxIn(ctx context.Context, s *Server, prevTxId, txId chainhash.Hash, index int) (tbcd.ZKSpendingOutpoint, error) {
-	spendingOps, err := s.g.db.ZKSpendingOutpoints(ctx, prevTxId)
+func spendingOutByTxIn(ctx context.Context, s *Server, prevTxID, txID chainhash.Hash, index int) (tbcd.ZKSpendingOutpoint, error) {
+	spendingOps, err := s.g.db.ZKSpendingOutpoints(ctx, prevTxID)
 	if err != nil {
 		return tbcd.ZKSpendingOutpoint{}, err
 	}
 
 	for _, so := range spendingOps {
 		spv := so.SpendingOutpoint
-		if spv != nil && spv.TxID.IsEqual(&txId) && spv.Index == uint32(index) {
+		if spv != nil && spv.TxID.IsEqual(&txID) && spv.Index == uint32(index) {
 			return so, nil
 		}
 	}
 	return tbcd.ZKSpendingOutpoint{}, database.NotFoundError("spending outpoint by txIn")
 }
 
-func spendingOutByTxOut(ctx context.Context, s *Server, txId chainhash.Hash, index int) (tbcd.ZKSpendingOutpoint, error) {
-	spendingOps, err := s.g.db.ZKSpendingOutpoints(ctx, txId)
+func spendingOutByTxOut(ctx context.Context, s *Server, txID chainhash.Hash, index int) (tbcd.ZKSpendingOutpoint, error) {
+	spendingOps, err := s.g.db.ZKSpendingOutpoints(ctx, txID)
 	if err != nil {
 		return tbcd.ZKSpendingOutpoint{}, err
 	}
 	for _, so := range spendingOps {
-		if so.TxID.IsEqual(&txId) && so.VOutIndex == uint32(index) {
+		if so.TxID.IsEqual(&txID) && so.VOutIndex == uint32(index) {
 			return so, nil
 		}
 	}
 	return tbcd.ZKSpendingOutpoint{}, database.NotFoundError("spending outpoint by txOut")
 }
 
-func spentOutByTxIn(ctx context.Context, s *Server, sh tbcd.ScriptHash, txId chainhash.Hash, inIndex int) (tbcd.ZKSpentOutput, error) {
+func spentOutByTxIn(ctx context.Context, s *Server, sh tbcd.ScriptHash, txID chainhash.Hash, inIndex int) (tbcd.ZKSpentOutput, error) {
 	spentOps, err := s.g.db.ZKSpentOutputs(ctx, sh)
 	if err != nil {
 		return tbcd.ZKSpentOutput{}, err
 	}
 	for _, so := range spentOps {
-		if so.TxID.IsEqual(&txId) && so.TxInIndex == uint32(inIndex) {
+		if so.TxID.IsEqual(&txID) && so.TxInIndex == uint32(inIndex) {
 			return so, nil
 		}
 	}
 	return tbcd.ZKSpentOutput{}, database.NotFoundError("spent outpoint")
 }
 
-func spendableOutByTxOut(ctx context.Context, s *Server, sh tbcd.ScriptHash, txId *chainhash.Hash, outIndex int) (tbcd.ZKSpendableOutput, error) {
+func spendableOutByTxOut(ctx context.Context, s *Server, sh tbcd.ScriptHash, txID *chainhash.Hash, outIndex int) (tbcd.ZKSpendableOutput, error) {
 	spendableOut, err := s.g.db.ZKSpendableOutputs(ctx, sh)
 	if err != nil {
 		return tbcd.ZKSpendableOutput{}, err
 	}
 	for _, so := range spendableOut {
-		if so.TxID.IsEqual(txId) && so.TxOutIndex == uint32(outIndex) {
+		if so.TxID.IsEqual(txID) && so.TxOutIndex == uint32(outIndex) {
 			return so, nil
 		}
 	}
@@ -1341,7 +1341,7 @@ func mustHave(ctx context.Context, t *testing.T, s *Server, blocks ...*block) er
 				if err != nil {
 					return fmt.Errorf("invalid tx hash: %w", err)
 				}
-				sis, err := s.SpentOutputsByTxId(ctx, *tx)
+				sis, err := s.SpentOutputsByTxID(ctx, *tx)
 				if err != nil {
 					return fmt.Errorf("invalid spend infos: %w", err)
 				}
@@ -1361,15 +1361,15 @@ func mustHave(ctx context.Context, t *testing.T, s *Server, blocks ...*block) er
 					return errors.New("block mismatch")
 				}
 			case 't':
-				txId, blockHash, err := tbcd.TxIdBlockHashFromTxKey(ktx)
+				txID, blockHash, err := tbcd.TxIDBlockHashFromTxKey(ktx)
 				if err != nil {
 					return fmt.Errorf("invalid tx key: %w", err)
 				}
-				_, err = s.TxById(ctx, *txId)
+				_, err = s.TxByID(ctx, *txID)
 				if err != nil {
 					return fmt.Errorf("tx by id: %w", err)
 				}
-				// db block retrieval tested by TxById
+				// db block retrieval tested by TxByID
 				if !b.Hash().IsEqual(blockHash) {
 					return errors.New("t cache block hash invalid")
 				}
@@ -1402,21 +1402,21 @@ func mustNotHave(ctx context.Context, t *testing.T, s *Server, blocks ...*block)
 				if err != nil {
 					return fmt.Errorf("invalid tx hash: %w", err)
 				}
-				_, err = s.SpentOutputsByTxId(ctx, *tx)
+				_, err = s.SpentOutputsByTxID(ctx, *tx)
 				var expected database.NotFoundError
 				if !errors.Is(err, expected) {
 					return fmt.Errorf("expected invalid spend infos %v: %w", tx, err)
 				}
 
 			case 't':
-				txId, _, err := tbcd.TxIdBlockHashFromTxKey(ktx)
+				txID, _, err := tbcd.TxIDBlockHashFromTxKey(ktx)
 				if err != nil {
 					return fmt.Errorf("invalid tx key: %w", err)
 				}
-				_, err = s.TxById(ctx, *txId)
+				_, err = s.TxByID(ctx, *txID)
 				var expected database.NotFoundError
 				if !errors.Is(err, expected) {
-					return fmt.Errorf("expected no tx by id %v: %w", txId, err)
+					return fmt.Errorf("expected no tx by id %v: %w", txID, err)
 				}
 			default:
 				return fmt.Errorf("invalid tx type %v", ktx[0])
@@ -1855,32 +1855,32 @@ func TestIndexNoFork(t *testing.T) {
 	}
 
 	// make sure genesis tx is in db
-	_, err = s.TxById(ctx, *n.gtx.Hash())
+	_, err = s.TxByID(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatalf("genesis not found: %v", err)
 	}
 	// make sure gensis was not spent
-	_, err = s.SpentOutputsByTxId(ctx, *n.gtx.Hash())
+	_, err = s.SpentOutputsByTxID(ctx, *n.gtx.Hash())
 	if err == nil {
 		t.Fatal("genesis coinbase tx should not be spent")
 	}
 
 	// Spot check tx 1 from b2
 	tx := b2.b.Transactions()[1]
-	txb2, err := s.TxById(ctx, *tx.Hash())
+	txb2, err := s.TxByID(ctx, *tx.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !btcutil.NewTx(txb2).Hash().IsEqual(tx.Hash()) {
 		t.Fatal("hash not equal")
 	}
-	si, err := s.SpentOutputsByTxId(ctx, *b1.b.Transactions()[0].Hash())
+	si, err := s.SpentOutputsByTxID(ctx, *b1.b.Transactions()[0].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = si
 	// t.Logf("%v: %v", b1.b.Transactions()[0].Hash(), spew.Sdump(si))
-	si, err = s.SpentOutputsByTxId(ctx, *b2.b.Transactions()[1].Hash())
+	si, err = s.SpentOutputsByTxID(ctx, *b2.b.Transactions()[1].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1901,7 +1901,7 @@ func TestIndexNoFork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.TxById(ctx, *n.gtx.Hash())
+	_, err = s.TxByID(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatal("expected genesis")
 	}
@@ -2144,33 +2144,33 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	}
 
 	// make sure genesis tx is in db
-	_, err = s.TxById(ctx, *n.gtx.Hash())
+	_, err = s.TxByID(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatalf("genesis not found: %v", err)
 	}
 
 	// make sure gensis was not spent
-	_, err = s.SpentOutputsByTxId(ctx, *n.gtx.Hash())
+	_, err = s.SpentOutputsByTxID(ctx, *n.gtx.Hash())
 	if err == nil {
 		t.Fatal("genesis coinbase tx should not be spent")
 	}
 
 	// Spot check tx 1 from b2
 	tx := b2.b.Transactions()[1]
-	txb2, err := s.TxById(ctx, *tx.Hash())
+	txb2, err := s.TxByID(ctx, *tx.Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !btcutil.NewTx(txb2).Hash().IsEqual(tx.Hash()) {
 		t.Fatal("hash not equal")
 	}
-	si, err := s.SpentOutputsByTxId(ctx, *b1.b.Transactions()[0].Hash())
+	si, err := s.SpentOutputsByTxID(ctx, *b1.b.Transactions()[0].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = si
 	// t.Logf("%v: %v", b1.b.Transactions()[0].Hash(), spew.Sdump(si))
-	si, err = s.SpentOutputsByTxId(ctx, *b2.b.Transactions()[1].Hash())
+	si, err = s.SpentOutputsByTxID(ctx, *b2.b.Transactions()[1].Hash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2216,7 +2216,7 @@ func TestKeystoneIndexNoFork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.TxById(ctx, *n.gtx.Hash())
+	_, err = s.TxByID(ctx, *n.gtx.Hash())
 	if err != nil {
 		t.Fatal("expected genesis")
 	}
@@ -3147,7 +3147,7 @@ func TestTransactions(t *testing.T) {
 	txOutChange := wire.NewTxOut(2000000000, changeScript)
 	redeemTx.AddTxOut(txOutChange)
 	// sign
-	lookupKey := func(a btcutil.Address) (*btcec.PrivateKey, bool, error) {
+	lookupKey := func(_ btcutil.Address) (*btcec.PrivateKey, bool, error) {
 		return payToKey, true, nil
 	}
 	sigScript, err := txscript.SignTxOutput(&chaincfg.MainNetParams,
@@ -3697,8 +3697,8 @@ func TestZKIndexFork(t *testing.T) {
 	txInfo := zkTxInfo{tx: b2.TxByIndex(1)}
 
 	// b2 tx: txIn 0
-	utxoTxId := *b1.TxByIndex(0).Hash()
-	inInfo := zkTxInInfo{txInfo, 0, utxoTxId, 5e9}
+	utxoTxID := *b1.TxByIndex(0).Hash()
+	inInfo := zkTxInInfo{txInfo, 0, utxoTxID, 5e9}
 	zki = append(zki, inInfo)
 	zkValidateTxIn(ctx, s, &inInfo)
 	if err := inInfo.Err(); err != nil {
@@ -3737,8 +3737,8 @@ func TestZKIndexFork(t *testing.T) {
 	txInfo = zkTxInfo{tx: b3.TxByIndex(1)}
 
 	// b3 tx1: txIn 0
-	utxoTxId = *b2.TxByIndex(1).Hash()
-	inInfo = zkTxInInfo{txInfo, 0, utxoTxId, 3e09}
+	utxoTxID = *b2.TxByIndex(1).Hash()
+	inInfo = zkTxInInfo{txInfo, 0, utxoTxID, 3e09}
 	zki = append(zki, inInfo)
 	zkValidateTxIn(ctx, s, &inInfo)
 	if err := inInfo.Err(); err != nil {
@@ -3765,8 +3765,8 @@ func TestZKIndexFork(t *testing.T) {
 	txInfo = zkTxInfo{tx: b3.TxByIndex(2)}
 
 	// b3 tx2: txIn 0
-	utxoTxId = *b3.TxByIndex(1).Hash()
-	inInfo = zkTxInInfo{txInfo, 0, utxoTxId, 11e08}
+	utxoTxID = *b3.TxByIndex(1).Hash()
+	inInfo = zkTxInInfo{txInfo, 0, utxoTxID, 11e08}
 	zki = append(zki, inInfo)
 	zkValidateTxIn(ctx, s, &inInfo)
 	if err := inInfo.Err(); err != nil {
@@ -3774,7 +3774,7 @@ func TestZKIndexFork(t *testing.T) {
 	}
 
 	// b3 tx2: txIn 1
-	inInfo = zkTxInInfo{txInfo, 1, utxoTxId, 19e8}
+	inInfo = zkTxInInfo{txInfo, 1, utxoTxID, 19e8}
 	zki = append(zki, inInfo)
 	zkValidateTxIn(ctx, s, &inInfo)
 	if err := inInfo.Err(); err != nil {
@@ -3910,8 +3910,8 @@ func TestZKIndexFork(t *testing.T) {
 	txInfo = zkTxInfo{tx: b2a.TxByIndex(1)}
 
 	// b2a tx: txIn 0
-	utxoTxId = *b1a.TxByIndex(0).Hash()
-	inInfo = zkTxInInfo{txInfo, 0, utxoTxId, 5e9}
+	utxoTxID = *b1a.TxByIndex(0).Hash()
+	inInfo = zkTxInInfo{txInfo, 0, utxoTxID, 5e9}
 	zki = append(zki, inInfo)
 	zkValidateTxIn(ctx, s, &inInfo)
 	if err := inInfo.Err(); err != nil {
@@ -4010,8 +4010,8 @@ func TestZKIndexFork(t *testing.T) {
 	txInfo = zkTxInfo{tx: b2b.TxByIndex(1)}
 
 	// b2b tx: txIn 0
-	utxoTxId = *b1b.TxByIndex(0).Hash()
-	inInfo = zkTxInInfo{txInfo, 0, utxoTxId, 5e9}
+	utxoTxID = *b1b.TxByIndex(0).Hash()
+	inInfo = zkTxInInfo{txInfo, 0, utxoTxID, 5e9}
 	zki = append(zki, inInfo)
 	zkValidateTxIn(ctx, s, &inInfo)
 	if err := inInfo.Err(); err != nil {

--- a/service/tbc/txindex.go
+++ b/service/tbc/txindex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -62,7 +62,7 @@ func (i *txIndexer) fixupCacheHook(_ context.Context, _ *btcutil.Block, _ indexe
 	return nil
 }
 
-func processTxs(ctx context.Context, block *btcutil.Block, direction int, txsCache map[tbcd.TxKey]*tbcd.TxValue) error {
+func processTxs(_ context.Context, block *btcutil.Block, _ int, txsCache map[tbcd.TxKey]*tbcd.TxValue) error {
 	blockHash := block.Hash()
 	txs := block.Transactions()
 	for _, tx := range txs {

--- a/service/tbc/utxoindex.go
+++ b/service/tbc/utxoindex.go
@@ -103,11 +103,11 @@ func processUtxos(block *btcutil.Block, utxos map[tbcd.Outpoint]tbcd.CacheOutput
 }
 
 func txOutFromOutPoint(ctx context.Context, db tbcd.Database, op tbcd.Outpoint) (*wire.TxOut, error) {
-	txId := op.TxIdHash()
+	txID := op.TxIDHash()
 	txIndex := op.TxIndex()
 
 	// Find block hashes
-	blockHash, err := db.BlockHashByTxId(ctx, *txId)
+	blockHash, err := db.BlockHashByTxID(ctx, *txID)
 	if err != nil {
 		return nil, fmt.Errorf("block by txid: %w", err)
 	}
@@ -116,7 +116,7 @@ func txOutFromOutPoint(ctx context.Context, db tbcd.Database, op tbcd.Outpoint) 
 		return nil, fmt.Errorf("block by hash: %w", err)
 	}
 	for _, tx := range b.Transactions() {
-		if !tx.Hash().IsEqual(txId) {
+		if !tx.Hash().IsEqual(txID) {
 			continue
 		}
 		txOuts := tx.MsgTx().TxOut

--- a/service/tbc/zkindexer.go
+++ b/service/tbc/zkindexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -89,7 +89,7 @@ func (i *zkIndexer) txOut(ctx context.Context, pop tbcd.Outpoint, c indexerCache
 
 func (i *zkIndexer) processTx(ctx context.Context, direction int, blockHeight uint32, blockHash *chainhash.Hash, tx *btcutil.Tx, c indexerCache) error {
 	cache := c.(*Cache[tbcd.ZKIndexKey, []byte]).Map()
-	txId := tx.Hash()
+	txID := tx.Hash()
 	for txInIdx, txIn := range tx.MsgTx().TxIn {
 		// Skip coinbase inputs
 		if blockchain.IsCoinBase(tx) {
@@ -127,7 +127,7 @@ func (i *zkIndexer) processTx(ctx context.Context, direction int, blockHeight ui
 
 		// Insert SpentOutput
 		spo := tbcd.NewSpentOutput(chainhash.Hash(sh), blockHeight,
-			*blockHash, *txId, txIn.PreviousOutPoint.Hash,
+			*blockHash, *txID, txIn.PreviousOutPoint.Hash,
 			txIn.PreviousOutPoint.Index, uint32(txInIdx))
 		if _, ok := cache[tbcd.ZKIndexKey(spo[:])]; ok {
 			panic(fmt.Sprintf("diagnostic: %v", spo))
@@ -137,7 +137,7 @@ func (i *zkIndexer) processTx(ctx context.Context, direction int, blockHeight ui
 		// Tx index, where spent
 		sok := tbcd.NewSpendingOutpointKey(txIn.PreviousOutPoint.Hash,
 			blockHeight, *blockHash, txIn.PreviousOutPoint.Index)
-		cache[tbcd.ZKIndexKey(sok[:])] = tbcd.NewSpendingOutpointValueSlice(*txId,
+		cache[tbcd.ZKIndexKey(sok[:])] = tbcd.NewSpendingOutpointValueSlice(*txID,
 			uint32(txInIdx))
 	}
 
@@ -166,7 +166,7 @@ func (i *zkIndexer) processTx(ctx context.Context, direction int, blockHeight ui
 
 		// SpendableOutput
 		so := tbcd.NewSpendableOutput(chainhash.Hash(sh), blockHeight,
-			*blockHash, *txId, uint32(txOutIdx))
+			*blockHash, *txID, uint32(txOutIdx))
 		cache[tbcd.ZKIndexKey(so[:])] = nil
 
 		// Outpoint to TxOut
@@ -183,7 +183,7 @@ func (i *zkIndexer) processTx(ctx context.Context, direction int, blockHeight ui
 		cache[tbcd.ZKIndexKey(op[:])] = tbcd.NewTxOut(txOut)
 
 		// Tx index, available to spend
-		sok := tbcd.NewSpendingOutpointKey(*txId, blockHeight, *blockHash,
+		sok := tbcd.NewSpendingOutpointKey(*txID, blockHeight, *blockHash,
 			uint32(txOutIdx))
 		cache[tbcd.ZKIndexKey(sok[:])] = nil
 	}

--- a/service/tbc/zkindexer_test.go
+++ b/service/tbc/zkindexer_test.go
@@ -44,7 +44,7 @@ func createFullZKDB(ctx context.Context, t *testing.T, home string, value uint64
 	cache := make(map[tbcd.ZKIndexKey][]byte, 5)
 	index := 99
 	blockHash := testutil.RandomHash()
-	txId := testutil.RandomHash()
+	txID := testutil.RandomHash()
 	prevHash := testutil.RandomHash()
 
 	// ScriptHash
@@ -56,22 +56,22 @@ func createFullZKDB(ctx context.Context, t *testing.T, home string, value uint64
 
 	// SpentOut
 	spo := tbcd.NewSpentOutput(chainhash.Hash(sh), uint32(index),
-		*blockHash, *txId, *prevHash, uint32(index-1), 0)
+		*blockHash, *txID, *prevHash, uint32(index-1), 0)
 	cache[tbcd.ZKIndexKey(spo[:])] = nil
 
 	// SpendingOut
 	sok := tbcd.NewSpendingOutpointKey(*prevHash,
 		uint32(index), *blockHash, uint32(index-1))
-	cache[tbcd.ZKIndexKey(sok[:])] = tbcd.NewSpendingOutpointValueSlice(*txId, uint32(index))
+	cache[tbcd.ZKIndexKey(sok[:])] = tbcd.NewSpendingOutpointValueSlice(*txID, uint32(index))
 
 	// SpendableOut
 	so := tbcd.NewSpendableOutput(chainhash.Hash(sh), uint32(index),
-		*blockHash, *txId, 0)
+		*blockHash, *txID, 0)
 	cache[tbcd.ZKIndexKey(so[:])] = nil
 
 	// Outpoint
-	op := tbcd.NewOutpoint(*txId, 0)
-	txOut := wire.TxOut{Value: 10, PkScript: txId[:]}
+	op := tbcd.NewOutpoint(*txID, 0)
+	txOut := wire.TxOut{Value: 10, PkScript: txID[:]}
 	cache[tbcd.ZKIndexKey(op[:])] = tbcd.NewTxOut(&txOut)
 
 	// Insert into DB
@@ -97,8 +97,8 @@ func createFullZKDB(ctx context.Context, t *testing.T, home string, value uint64
 	if value != rv {
 		t.Fatalf("expected %v, got %v", value, rv)
 	}
-	if !bytes.Equal(txId[:], rid) {
-		t.Fatalf("expected %x, got %x", txId, rid)
+	if !bytes.Equal(txID[:], rid) {
+		t.Fatalf("expected %x, got %x", txID, rid)
 	}
 
 	// ScriptHash
@@ -128,8 +128,8 @@ func createFullZKDB(ctx context.Context, t *testing.T, home string, value uint64
 	if !bytes.Equal(blockHash[:], rout.BlockHash[:]) {
 		t.Fatalf("got %x, expected %x", rout.BlockHash, blockHash)
 	}
-	if !bytes.Equal(txId[:], rout.TxID[:]) {
-		t.Fatalf("got %x, expected %x", rout.TxID, txId)
+	if !bytes.Equal(txID[:], rout.TxID[:]) {
+		t.Fatalf("got %x, expected %x", rout.TxID, txID)
 	}
 	if !bytes.Equal(prevHash[:], rout.PrevOutpointHash[:]) {
 		t.Fatalf("got %x, expected %x", rout.PrevOutpointHash, prevHash)
@@ -159,8 +159,8 @@ func createFullZKDB(ctx context.Context, t *testing.T, home string, value uint64
 	if !bytes.Equal(blockHash[:], srout.BlockHash[:]) {
 		t.Fatalf("got %x, expected %x", srout.BlockHash, blockHash)
 	}
-	if !bytes.Equal(txId[:], srout.TxID[:]) {
-		t.Fatalf("got %x, expected %x", srout.TxID, txId)
+	if !bytes.Equal(txID[:], srout.TxID[:]) {
+		t.Fatalf("got %x, expected %x", srout.TxID, txID)
 	}
 	if srout.TxOutIndex != 0 {
 		t.Fatalf("expected %v, got %v", srout.TxOutIndex, 0)
@@ -188,8 +188,8 @@ func createFullZKDB(ctx context.Context, t *testing.T, home string, value uint64
 		t.Fatalf("expected %v, got %v", sprout.VOutIndex, index)
 	}
 	sv := sprout.SpendingOutpoint
-	if !bytes.Equal(txId[:], sv.TxID[:]) {
-		t.Fatalf("expected %x, got %x", sv.TxID, txId)
+	if !bytes.Equal(txID[:], sv.TxID[:]) {
+		t.Fatalf("expected %x, got %x", sv.TxID, txID)
 	}
 	if uint32(index) != sv.Index {
 		t.Fatalf("expected %v, got %v", sv.Index, index)

--- a/ttl/ttl_test.go
+++ b/ttl/ttl_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-func callback(ctx context.Context, key any, value any) {
+func callback(_ context.Context, _ any, value any) {
 	v, ok := value.(*sync.WaitGroup)
 	if !ok {
 		panic(fmt.Sprintf("invalid value type: %T", value))
@@ -23,7 +23,7 @@ func callback(ctx context.Context, key any, value any) {
 	v.Done()
 }
 
-func callbackPanic(ctx context.Context, key any, value any) {
+func callbackPanic(_ context.Context, key any, _ any) {
 	panic(fmt.Sprintf("unexpected callback: %v", spew.Sdump(key)))
 }
 

--- a/version/useragent.go
+++ b/version/useragent.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-// srcUrl is the URL to the source code for this project.
-const srcUrl = "https://github.com/hemilabs/heminetwork"
+// srcURL is the URL to the source code for this project.
+const srcURL = "https://github.com/hemilabs/heminetwork"
 
 var (
 	// Brand is an identifier that is used to identify the organisation or
@@ -45,7 +45,7 @@ var (
 // The User-Agent value contains the component name (e.g. bfgd), version, brand,
 // operating system name (GOOS), system architecture, and source code URL.
 var userAgent = createUserAgent(Component, String(), Brand,
-	runtime.GOOS+"/"+runtime.GOARCH, "+"+srcUrl)
+	runtime.GOOS+"/"+runtime.GOARCH, "+"+srcURL)
 
 // UserAgent returns an HTTP User-Agent header value that should be used when
 // making HTTP requests.


### PR DESCRIPTION
**Summary**
Enable `revive` (https://github.com/mgechev/revive) linter in golangci-lint.

This linter contains a bunch of rules focusing on: code readability, maintainability, best practices, and correctness. It can be verbose (e.g. var-naming, unused) but can often catch very subtle bugs caused by the wrong variable being used, etc.

Some rules are based on recommendations from the Go team that are enforced in Go itself, e.g. from https://go.dev/wiki/CodeReviewComments

**Changes**
- Enable `revive` linter in `.golangci.yaml`
- Fix all issues from revive linter