### PR TITLE
tbc: add missing rpc commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `TxByID` to the `gozer.Gozer` interface with `tbcGozer`
   implementation backed by TBC RPC
   ([#971](https://github.com/hemilabs/heminetwork/pull/971)).
+- Add multiple RPC commands to regular and authenticated TBC routes ([#1026](https://github.com/hemilabs/heminetwork/pull/1026)).
 
 ### Changed
 

--- a/api/tbcadminapi/tbcadminapi.go
+++ b/api/tbcadminapi/tbcadminapi.go
@@ -21,6 +21,9 @@ const (
 
 	CmdSyncIndexersToHashRequest = "tbcadmin-sync-indexers-to-hash-request"
 
+	CmdBlockHeadersInsertRequest  = "tbcadmin-block-headers-insert-request"
+	CmdBlockHeadersInsertResponse = "tbcadmin-block-headers-insert-response"
+
 	// Job lifecycle
 	CmdJobStatusRequest = "tbcadmin-job-status-request"
 
@@ -89,16 +92,29 @@ type SyncIndexersToHashRequest struct {
 	Hash chainhash.Hash `json:"hash"`
 }
 
-var commands = map[protocol.Command]reflect.Type{
-	CmdJobStatusRequest:      reflect.TypeFor[JobStatusRequest](),
-	CmdJobCancelRequest:      reflect.TypeFor[JobCancelRequest](),
-	CmdJobCancelResponse:     reflect.TypeFor[JobCancelResponse](),
-	CmdJobListRequest:        reflect.TypeFor[JobListRequest](),
-	CmdJobListResponse:       reflect.TypeFor[JobListResponse](),
-	CmdJobSubscribeRequest:   reflect.TypeFor[JobSubscribeRequest](),
-	CmdJobUpdateNotification: reflect.TypeFor[JobUpdateNotification](),
+type BlockHeadersInsertRequest struct {
+	BlockHeaders []tbcapi.BlockHeader `json:"block_headers"`
+}
 
-	CmdSyncIndexersToHashRequest: reflect.TypeFor[SyncIndexersToHashRequest](),
+type BlockHeadersInsertResponse struct {
+	InsertType      string              `json:"insert_type"`
+	CanonicalHeader *tbcapi.BlockHeader `json:"canonical_header"`
+	LastHeader      *tbcapi.BlockHeader `json:"last_header"`
+	InsertedCount   uint32              `json:"inserted_count"`
+	Error           *protocol.Error     `json:"error,omitempty"`
+}
+
+var commands = map[protocol.Command]reflect.Type{
+	CmdJobStatusRequest:           reflect.TypeFor[JobStatusRequest](),
+	CmdJobCancelRequest:           reflect.TypeFor[JobCancelRequest](),
+	CmdJobCancelResponse:          reflect.TypeFor[JobCancelResponse](),
+	CmdJobListRequest:             reflect.TypeFor[JobListRequest](),
+	CmdJobListResponse:            reflect.TypeFor[JobListResponse](),
+	CmdJobSubscribeRequest:        reflect.TypeFor[JobSubscribeRequest](),
+	CmdJobUpdateNotification:      reflect.TypeFor[JobUpdateNotification](),
+	CmdBlockHeadersInsertRequest:  reflect.TypeFor[BlockHeadersInsertRequest](),
+	CmdBlockHeadersInsertResponse: reflect.TypeFor[BlockHeadersInsertResponse](),
+	CmdSyncIndexersToHashRequest:  reflect.TypeFor[SyncIndexersToHashRequest](),
 }
 
 func init() {

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -53,6 +53,21 @@ const (
 	CmdBlockHeaderBestRequest  = "tbcapi-block-header-best-request"
 	CmdBlockHeaderBestResponse = "tbcapi-block-header-best-response"
 
+	CmdBlockHeaderByHashRawRequest  = "tbcapi-block-header-by-hash-raw-request"
+	CmdBlockHeaderByHashRawResponse = "tbcapi-block-header-by-hash-raw-response"
+
+	CmdBlockHeaderByHashRequest  = "tbcapi-block-header-by-hash-request"
+	CmdBlockHeaderByHashResponse = "tbcapi-block-header-by-hash-response"
+
+	CmdFullBlockAvailableRequest  = "tbcapi-full-block-available-request"
+	CmdFullBlockAvailableResponse = "tbcapi-full-block-available-response"
+
+	CmdScriptHashAvailableToSpendRequest  = "tbcapi-script-hash-available-to-spend-request"
+	CmdScriptHashAvailableToSpendResponse = "tbcapi-script-hash-available-to-spend-response"
+
+	CmdSyncStatusRequest  = "tbcapi-sync-status-request"
+	CmdSyncStatusResponse = "tbcapi-sync-status-response"
+
 	CmdBalanceByAddressRequest  = "tbcapi-balance-by-address-request"
 	CmdBalanceByAddressResponse = "tbcapi-balance-by-address-response"
 
@@ -73,6 +88,12 @@ const (
 
 	CmdTxBroadcastRawRequest  = "tbcapi-tx-broadcast-raw-request"
 	CmdTxBroadcastRawResponse = "tbcapi-tx-broadcast-raw-response"
+
+	CmdBlockHashByTxIDRequest  = "tbcapi-block-hash-by-tx-id-request"
+	CmdBlockHashByTxIDResponse = "tbcapi-block-hash-by-tx-id-response"
+
+	CmdBlockInTxIndexRequest  = "tbcapi-block-in-tx-index-request"
+	CmdBlockInTxIndexResponse = "tbcapi-block-in-tx-index-response"
 
 	CmdBlockInsertRequest  = "tbcapi-block-insert-request"
 	CmdBlockInsertResponse = "tbcapi-block-insert-response"
@@ -195,6 +216,11 @@ type Block struct {
 	Txs    []Tx           `json:"txs"`
 }
 
+type HashHeight struct {
+	Hash   chainhash.Hash `json:"hash"`
+	Height uint64         `json:"height"`
+}
+
 type L2KeystoneBlockInfo struct {
 	L2KeystoneAbrev       *hemi.L2KeystoneAbrev `json:"l2_keystone_abrev"`
 	L2KeystoneBlockHash   *chainhash.Hash       `json:"l2_keystone_block_hash"`
@@ -261,6 +287,58 @@ type BlockHeaderBestResponse struct {
 	Height      uint64          `json:"height"`
 	BlockHeader *BlockHeader    `json:"block_header"`
 	Error       *protocol.Error `json:"error,omitempty"`
+}
+
+type BlockHeaderByHashRawRequest struct {
+	Hash chainhash.Hash `json:"hash"`
+}
+
+type BlockHeaderByHashRawResponse struct {
+	Height      uint64          `json:"height"`
+	BlockHeader api.ByteSlice   `json:"block_header"`
+	Error       *protocol.Error `json:"error,omitempty"`
+}
+
+type BlockHeaderByHashRequest struct {
+	Hash chainhash.Hash `json:"hash"`
+}
+
+type BlockHeaderByHashResponse struct {
+	Height      uint64          `json:"height"`
+	BlockHeader *BlockHeader    `json:"block_header"`
+	Error       *protocol.Error `json:"error,omitempty"`
+}
+
+type FullBlockAvailableRequest struct {
+	Hash chainhash.Hash `json:"hash"`
+}
+
+type FullBlockAvailableResponse struct {
+	Available bool            `json:"available"`
+	Error     *protocol.Error `json:"error,omitempty"`
+}
+
+type ScriptHashAvailableToSpendRequest struct {
+	TxID  chainhash.Hash `json:"tx_id"`
+	Index uint32         `json:"index"`
+}
+
+type ScriptHashAvailableToSpendResponse struct {
+	Available bool            `json:"available"`
+	Error     *protocol.Error `json:"error,omitempty"`
+}
+
+type SyncStatusRequest struct{}
+
+type SyncStatusResponse struct {
+	Synced         bool            `json:"synced"`
+	AtLeastMissing int             `json:"at_least_missing"`
+	BlockHeader    HashHeight      `json:"blockheader_index_height"`
+	Keystone       HashHeight      `json:"keystone_index_height"`
+	Tx             HashHeight      `json:"tx_index_height"`
+	Utxo           HashHeight      `json:"utxo_index_height"`
+	ZK             HashHeight      `json:"zk_index_height"`
+	Error          *protocol.Error `json:"error,omitempty"`
 }
 
 type BalanceByAddressRequest struct {
@@ -332,6 +410,24 @@ type TxBroadcastRawRequest struct {
 type TxBroadcastRawResponse struct {
 	TxID  *chainhash.Hash `json:"tx_id"`
 	Error *protocol.Error `json:"error,omitempty"`
+}
+
+type BlockHashByTxIDRequest struct {
+	TxID chainhash.Hash `json:"tx_id"`
+}
+
+type BlockHashByTxIDResponse struct {
+	BlockHash *chainhash.Hash `json:"block_hash"`
+	Error     *protocol.Error `json:"error,omitempty"`
+}
+
+type BlockInTxIndexRequest struct {
+	BlockHash chainhash.Hash `json:"block_hash"`
+}
+
+type BlockInTxIndexResponse struct {
+	Indexed bool            `json:"indexed"`
+	Error   *protocol.Error `json:"error,omitempty"`
 }
 
 type BlockInsertRequest struct {
@@ -602,6 +698,16 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdBlockHeaderBestRawResponse:               reflect.TypeFor[BlockHeaderBestRawResponse](),
 	CmdBlockHeaderBestRequest:                   reflect.TypeFor[BlockHeaderBestRequest](),
 	CmdBlockHeaderBestResponse:                  reflect.TypeFor[BlockHeaderBestResponse](),
+	CmdBlockHeaderByHashRawRequest:              reflect.TypeFor[BlockHeaderByHashRawRequest](),
+	CmdBlockHeaderByHashRawResponse:             reflect.TypeFor[BlockHeaderByHashRawResponse](),
+	CmdBlockHeaderByHashRequest:                 reflect.TypeFor[BlockHeaderByHashRequest](),
+	CmdBlockHeaderByHashResponse:                reflect.TypeFor[BlockHeaderByHashResponse](),
+	CmdFullBlockAvailableRequest:                reflect.TypeFor[FullBlockAvailableRequest](),
+	CmdFullBlockAvailableResponse:               reflect.TypeFor[FullBlockAvailableResponse](),
+	CmdScriptHashAvailableToSpendRequest:        reflect.TypeFor[ScriptHashAvailableToSpendRequest](),
+	CmdScriptHashAvailableToSpendResponse:       reflect.TypeFor[ScriptHashAvailableToSpendResponse](),
+	CmdSyncStatusRequest:                        reflect.TypeFor[SyncStatusRequest](),
+	CmdSyncStatusResponse:                       reflect.TypeFor[SyncStatusResponse](),
 	CmdBalanceByAddressRequest:                  reflect.TypeFor[BalanceByAddressRequest](),
 	CmdBalanceByAddressResponse:                 reflect.TypeFor[BalanceByAddressResponse](),
 	CmdUTXOsByAddressRawRequest:                 reflect.TypeFor[UTXOsByAddressRawRequest](),
@@ -616,6 +722,10 @@ var commands = map[protocol.Command]reflect.Type{
 	CmdTxBroadcastResponse:                      reflect.TypeFor[TxBroadcastResponse](),
 	CmdTxBroadcastRawRequest:                    reflect.TypeFor[TxBroadcastRawRequest](),
 	CmdTxBroadcastRawResponse:                   reflect.TypeFor[TxBroadcastRawResponse](),
+	CmdBlockHashByTxIDRequest:                   reflect.TypeFor[BlockHashByTxIDRequest](),
+	CmdBlockHashByTxIDResponse:                  reflect.TypeFor[BlockHashByTxIDResponse](),
+	CmdBlockInTxIndexRequest:                    reflect.TypeFor[BlockInTxIndexRequest](),
+	CmdBlockInTxIndexResponse:                   reflect.TypeFor[BlockInTxIndexResponse](),
 	CmdBlockInsertRequest:                       reflect.TypeFor[BlockInsertRequest](),
 	CmdBlockInsertResponse:                      reflect.TypeFor[BlockInsertResponse](),
 	CmdBlockInsertRawRequest:                    reflect.TypeFor[BlockInsertRawRequest](),

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -1671,32 +1671,12 @@ func (l *ldb) BlockInTxIndex(ctx context.Context, hash chainhash.Hash) (bool, er
 	log.Tracef("BlockInTxIndex")
 	defer log.Tracef("BlockInTxIndex exit")
 
-	blocks := make([]*chainhash.Hash, 0, 2)
 	txDB := l.pool[level.TransactionsDB]
 	var blkid [33]byte
 	blkid[0] = 'b'
 	copy(blkid[1:], hash[:])
-	it := txDB.NewIterator(util.BytesPrefix(blkid[:]), nil)
-	defer it.Release()
-	for it.Next() {
-		block, err := chainhash.NewHash(it.Key()[33:])
-		if err != nil {
-			return false, err
-		}
-		blocks = append(blocks, block)
-	}
-	if err := it.Error(); err != nil {
-		return false, fmt.Errorf("blocks by id iterator: %w", err)
-	}
-	switch len(blocks) {
-	case 0:
-		return false, nil
-	case 1:
-		return true, nil
-	default:
-		panic(fmt.Sprintf("invalid blocks count %v: %v",
-			len(blocks), spew.Sdump(blocks)))
-	}
+
+	return txDB.Has(blkid[:], nil)
 }
 
 func (l *ldb) ScriptHashesByOutpoint(ctx context.Context, ops []*tbcd.Outpoint, result func(tbcd.Outpoint, tbcd.ScriptHash) error) error {
@@ -1730,6 +1710,9 @@ func (l *ldb) ScriptHashByOutpoint(ctx context.Context, op tbcd.Outpoint) (*tbcd
 	uDB := l.pool[level.OutputsDB]
 	scriptHash, err := uDB.Get(op[:], nil)
 	if err != nil {
+		if errors.Is(err, leveldb.ErrNotFound) {
+			return nil, database.NotFoundError(fmt.Sprintf("not found %s", op))
+		}
 		return nil, fmt.Errorf("script hash by outpoint: %w", err)
 	}
 

--- a/service/tbc/admin_rpc.go
+++ b/service/tbc/admin_rpc.go
@@ -9,14 +9,17 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
+	"github.com/hemilabs/heminetwork/v2/api/tbcadminapi"
 	tapi "github.com/hemilabs/heminetwork/v2/api/tbcadminapi"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 )
@@ -136,6 +139,10 @@ func (s *Server) handleAdminWebsocket(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getTBCAdminAPICommandHandler(cmd protocol.Command, payload any, ws *tbcAdminWs) func(ctx context.Context) (any, string, error) {
 	switch cmd {
+	case tapi.CmdBlockHeadersInsertRequest:
+		return func(ctx context.Context) (any, string, error) {
+			return s.handleBlockHeadersInsertRequest(ctx, payload.(*tapi.BlockHeadersInsertRequest))
+		}
 	case tapi.CmdSyncIndexersToHashRequest:
 		return func(ctx context.Context) (any, string, error) {
 			return s.handleSyncIndexersToHashRequest(ctx, ws.sessionID, payload.(*tapi.SyncIndexersToHashRequest))
@@ -356,6 +363,70 @@ func (s *Server) handleJobStatusRequest(_ context.Context, req *tapi.JobStatusRe
 	return &tapi.JobUpdateNotification{
 		Job: info,
 	}, nil
+}
+
+func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.BlockHeadersInsertRequest) (any, string, error) {
+	log.Tracef("handleBlockHeadersInsertRequest")
+	defer log.Tracef("handleBlockHeadersInsertRequest exit")
+
+	// Convert TBC API blockheaders to wire
+	wireHeaders := wire.MsgHeaders{}
+	for i, bh := range req.BlockHeaders {
+		v64, err := strconv.ParseUint(bh.Bits, 16, 32)
+		if err != nil {
+			return &tbcadminapi.BlockHeadersInsertResponse{
+				Error: protocol.RequestErrorf(
+					"error converting bits (header index %d): %s", i, err),
+			}, "", nil
+		}
+
+		wh := &wire.BlockHeader{
+			Version:    bh.Version,
+			PrevBlock:  bh.PrevHash,
+			MerkleRoot: bh.MerkleRoot,
+			Timestamp:  time.Unix(bh.Timestamp, 0),
+			Bits:       uint32(v64),
+			Nonce:      bh.Nonce,
+		}
+
+		if err := wireHeaders.AddBlockHeader(wh); err != nil {
+			e := protocol.NewInternalError(err)
+			return &tbcadminapi.BlockHeadersInsertResponse{
+				Error: e.ProtocolError(),
+			}, "", e
+		}
+	}
+
+	// Insert headers
+	it, cbh, lbh, n, err := s.BlockHeadersInsert(ctx, &wireHeaders)
+	if err != nil {
+		return &tbcadminapi.BlockHeadersInsertResponse{
+			Error: protocol.Errorf("error inserting headers: %s", err),
+		}, "", nil
+	}
+
+	// Convert tbcd headers to wire
+	wcbh, err := cbh.Wire()
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcadminapi.BlockHeadersInsertResponse{
+			Error: e.ProtocolError(),
+		}, "", e
+	}
+	wlbh, err := lbh.Wire()
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcadminapi.BlockHeadersInsertResponse{
+			Error: e.ProtocolError(),
+		}, "", e
+	}
+
+	return tapi.BlockHeadersInsertResponse{
+		InsertType:      it.String(),
+		CanonicalHeader: wireBlockHeaderToTBC(wcbh),
+		LastHeader:      wireBlockHeaderToTBC(wlbh),
+		InsertedCount:   uint32(n),
+	}, "", nil
 }
 
 func (s *Server) handleSyncIndexersToHashRequest(_ context.Context, sessionID string, req *tapi.SyncIndexersToHashRequest) (any, string, error) {

--- a/service/tbc/admin_rpc.go
+++ b/service/tbc/admin_rpc.go
@@ -19,7 +19,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
-	"github.com/hemilabs/heminetwork/v2/api/tbcadminapi"
 	tapi "github.com/hemilabs/heminetwork/v2/api/tbcadminapi"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 )
@@ -374,7 +373,7 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 	for i, bh := range req.BlockHeaders {
 		v64, err := strconv.ParseUint(bh.Bits, 16, 32)
 		if err != nil {
-			return &tbcadminapi.BlockHeadersInsertResponse{
+			return &tapi.BlockHeadersInsertResponse{
 				Error: protocol.RequestErrorf(
 					"error converting bits (header index %d): %s", i, err),
 			}, "", nil
@@ -391,7 +390,7 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 
 		if err := wireHeaders.AddBlockHeader(wh); err != nil {
 			e := protocol.NewInternalError(err)
-			return &tbcadminapi.BlockHeadersInsertResponse{
+			return &tapi.BlockHeadersInsertResponse{
 				Error: e.ProtocolError(),
 			}, "", e
 		}
@@ -400,7 +399,7 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 	// Insert headers
 	it, cbh, lbh, n, err := s.BlockHeadersInsert(ctx, &wireHeaders)
 	if err != nil {
-		return &tbcadminapi.BlockHeadersInsertResponse{
+		return &tapi.BlockHeadersInsertResponse{
 			Error: protocol.Errorf("error inserting headers: %s", err),
 		}, "", nil
 	}
@@ -409,14 +408,14 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 	wcbh, err := cbh.Wire()
 	if err != nil {
 		e := protocol.NewInternalError(err)
-		return &tbcadminapi.BlockHeadersInsertResponse{
+		return &tapi.BlockHeadersInsertResponse{
 			Error: e.ProtocolError(),
 		}, "", e
 	}
 	wlbh, err := lbh.Wire()
 	if err != nil {
 		e := protocol.NewInternalError(err)
-		return &tbcadminapi.BlockHeadersInsertResponse{
+		return &tapi.BlockHeadersInsertResponse{
 			Error: e.ProtocolError(),
 		}, "", e
 	}

--- a/service/tbc/admin_rpc.go
+++ b/service/tbc/admin_rpc.go
@@ -140,7 +140,8 @@ func (s *Server) getTBCAdminAPICommandHandler(cmd protocol.Command, payload any,
 	switch cmd {
 	case tapi.CmdBlockHeadersInsertRequest:
 		return func(ctx context.Context) (any, string, error) {
-			return s.handleBlockHeadersInsertRequest(ctx, payload.(*tapi.BlockHeadersInsertRequest))
+			res, err := s.handleBlockHeadersInsertRequest(ctx, payload.(*tapi.BlockHeadersInsertRequest))
+			return res, "", err
 		}
 	case tapi.CmdSyncIndexersToHashRequest:
 		return func(ctx context.Context) (any, string, error) {
@@ -364,7 +365,7 @@ func (s *Server) handleJobStatusRequest(_ context.Context, req *tapi.JobStatusRe
 	}, nil
 }
 
-func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.BlockHeadersInsertRequest) (any, string, error) {
+func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.BlockHeadersInsertRequest) (any, error) {
 	log.Tracef("handleBlockHeadersInsertRequest")
 	defer log.Tracef("handleBlockHeadersInsertRequest exit")
 
@@ -376,7 +377,7 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 			return &tapi.BlockHeadersInsertResponse{
 				Error: protocol.RequestErrorf(
 					"error converting bits (header index %d): %s", i, err),
-			}, "", nil
+			}, nil
 		}
 
 		wh := &wire.BlockHeader{
@@ -392,7 +393,7 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 			e := protocol.NewInternalError(err)
 			return &tapi.BlockHeadersInsertResponse{
 				Error: e.ProtocolError(),
-			}, "", e
+			}, e
 		}
 	}
 
@@ -401,7 +402,7 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 	if err != nil {
 		return &tapi.BlockHeadersInsertResponse{
 			Error: protocol.Errorf("error inserting headers: %s", err),
-		}, "", nil
+		}, nil
 	}
 
 	// Convert tbcd headers to wire
@@ -410,14 +411,14 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 		e := protocol.NewInternalError(err)
 		return &tapi.BlockHeadersInsertResponse{
 			Error: e.ProtocolError(),
-		}, "", e
+		}, e
 	}
 	wlbh, err := lbh.Wire()
 	if err != nil {
 		e := protocol.NewInternalError(err)
 		return &tapi.BlockHeadersInsertResponse{
 			Error: e.ProtocolError(),
-		}, "", e
+		}, e
 	}
 
 	return tapi.BlockHeadersInsertResponse{
@@ -425,7 +426,7 @@ func (s *Server) handleBlockHeadersInsertRequest(ctx context.Context, req *tapi.
 		CanonicalHeader: wireBlockHeaderToTBC(wcbh),
 		LastHeader:      wireBlockHeaderToTBC(wlbh),
 		InsertedCount:   uint32(n),
-	}, "", nil
+	}, nil
 }
 
 func (s *Server) handleSyncIndexersToHashRequest(_ context.Context, sessionID string, req *tapi.SyncIndexersToHashRequest) (any, string, error) {

--- a/service/tbc/admin_rpc_test.go
+++ b/service/tbc/admin_rpc_test.go
@@ -493,9 +493,7 @@ func TestAdminRPCCommands(t *testing.T) {
 
 func TestAdminRPCBlockHeadersInsert(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 
 	type testTableItem struct {
 		name      string
@@ -680,9 +678,7 @@ func TestAdminRPCBlockHeadersInsert(t *testing.T) {
 
 func TestAdminRPCSyncIndexersToHash(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 
 	adminURL, s, n := createLocalTBCServer(ctx, t, testJWTString)
 

--- a/service/tbc/admin_rpc_test.go
+++ b/service/tbc/admin_rpc_test.go
@@ -10,23 +10,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/juju/loggo/v2"
 
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
 	"github.com/hemilabs/heminetwork/v2/api/tbcadminapi"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
+	"github.com/hemilabs/heminetwork/v2/database/tbcd"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil"
-	"github.com/hemilabs/heminetwork/v2/service/tbc/peer/rawpeer"
 )
 
 var (
@@ -48,69 +48,6 @@ func createAdminToken(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return signed
-}
-
-func createTbcAdminServer(ctx context.Context, t *testing.T, seeds []string) (*Server, string) {
-	t.Helper()
-
-	cfg := &Config{
-		AutoIndex:               false,
-		BlockCacheSize:          "10mb",
-		BlockheaderCacheSize:    "1mb",
-		BlockSanity:             false,
-		LevelDBHome:             t.TempDir(),
-		MaxCachedTxs:            1000,
-		PeersWanted:             len(seeds),
-		PrometheusListenAddress: "",
-		ListenAddress:           "127.0.0.1:0",
-		Network:                 networkLocalnet,
-		NotificationBlocking:    true,
-		Seeds:                   seeds,
-		JWTSecret:               testJWTString,
-		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
-	}
-	_ = loggo.ConfigureLoggers(cfg.LogLevel)
-	s, err := NewServer(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// subscribe to tbc notifications
-	l, err := s.SubscribeNotifications(ctx, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer l.Unsubscribe()
-
-	go func() {
-		err := s.Run(ctx)
-		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, rawpeer.ErrNoConn) {
-			panic(err)
-		}
-	}()
-
-	// Wait for http service to start up
-	var tbcURL string
-	for {
-		msg, err := l.Listen(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Log(msg)
-		if msg.Error != nil {
-			t.Fatal(msg.Error)
-		}
-		// TBC sends a notification when the http service has started.
-		if !msg.Is(NotificationService("", "")) {
-			continue
-		}
-		if addr := s.HTTPAddress(); addr != nil {
-			tbcURL = addr.String()
-			break
-		}
-	}
-	adminURL := fmt.Sprintf("http://%s%s", tbcURL, tbcadminapi.RouteAdminWs)
-	return s, adminURL
 }
 
 func dialAdmin(ctx context.Context, t *testing.T, url string) *websocket.Conn {
@@ -282,7 +219,7 @@ func TestAdminJWTAuthentication(t *testing.T) {
 		},
 	}
 
-	_, adminURL := createTbcAdminServer(ctx, t, nil)
+	adminURL, _, _ := createLocalTBCServer(ctx, t, testJWTString)
 
 	for _, tti := range testTable {
 		t.Run(tti.name, func(t *testing.T) {
@@ -320,7 +257,7 @@ func TestAdminRPCCommands(t *testing.T) {
 		postCheck func(*protocol.WSConn, protocol.Message) error
 	}
 
-	s, adminURL := createTbcAdminServer(ctx, t, nil)
+	adminURL, s, _ := createLocalTBCServer(ctx, t, testJWTString)
 
 	var ws sync.WaitGroup
 	ws.Add(1)
@@ -501,8 +438,8 @@ func TestAdminRPCCommands(t *testing.T) {
 				if resp.Error != nil {
 					return fmt.Errorf("unexpected error: %w", resp.Error)
 				}
-				if resp.Height != 0 {
-					return fmt.Errorf("expected height 0, got %d", resp.Height)
+				if resp.Height != 3 {
+					return fmt.Errorf("expected height 3, got %d", resp.Height)
 				}
 				return nil
 			},
@@ -522,8 +459,8 @@ func TestAdminRPCCommands(t *testing.T) {
 				if resp.Error != nil {
 					return fmt.Errorf("unexpected error: %w", resp.Error)
 				}
-				if resp.Height != 0 {
-					return fmt.Errorf("expected height 0, got %d", resp.Height)
+				if resp.Height != 3 {
+					return fmt.Errorf("expected height 3, got %d", resp.Height)
 				}
 				if resp.BlockHeader == nil {
 					return errors.New("expected non-nil block header")
@@ -554,83 +491,200 @@ func TestAdminRPCCommands(t *testing.T) {
 	}
 }
 
+func TestAdminRPCBlockHeadersInsert(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer func() {
+		cancel()
+	}()
+
+	type testTableItem struct {
+		name      string
+		request   tbcadminapi.BlockHeadersInsertRequest
+		postCheck func(*tbcadminapi.BlockHeadersInsertResponse) error
+	}
+
+	adminURL, _, n := createLocalTBCServer(ctx, t, testJWTString)
+
+	b3 := n.blocksAtHeight[3][0]
+	b3h := wireBlockHeaderToTBC(&b3.MsgBlock().Header)
+	validHeader := tbcapi.BlockHeader{
+		Version:    1,
+		PrevHash:   *b3.Hash(),
+		MerkleRoot: chainhash.Hash{0xff, 0xff},
+		Timestamp:  time.Now().Unix(),
+		Bits:       strconv.FormatUint(uint64(123456780), 16),
+		Nonce:      12345,
+	}
+
+	fork := validHeader
+	fork.Nonce = 54321
+	wfork := wire.NewBlockHeader(1, &fork.PrevHash, &fork.MerkleRoot, 123456780, fork.Nonce)
+	fork.Timestamp = wfork.Timestamp.Unix()
+
+	forkExtend := fork
+	forkExtend.Bits = strconv.FormatUint(uint64(123456789), 16) // higher diff
+	forkExtend.PrevHash = wfork.BlockHash()
+	forkExtend.Timestamp = time.Now().Unix()
+
+	invalidBitsHeader := validHeader
+	invalidBitsHeader.Bits = "invalidbits"
+
+	testTable := []testTableItem{
+		{
+			name: "valid",
+			request: tbcadminapi.BlockHeadersInsertRequest{
+				BlockHeaders: []tbcapi.BlockHeader{*b3h, validHeader},
+			},
+			postCheck: func(resp *tbcadminapi.BlockHeadersInsertResponse) error {
+				if resp.Error != nil {
+					return resp.Error
+				}
+				if *resp.CanonicalHeader != validHeader {
+					return fmt.Errorf("wanted canonical header %v, got %v",
+						validHeader, resp.CanonicalHeader)
+				}
+				if *resp.LastHeader != validHeader {
+					return fmt.Errorf("wanted last header %v, got %v",
+						validHeader, resp.LastHeader)
+				}
+				if resp.InsertType != tbcd.ITChainExtend.String() {
+					return fmt.Errorf("wanted IT %s, got %s",
+						tbcd.ITChainExtend, resp.InsertType)
+				}
+				if resp.InsertedCount != 1 {
+					return fmt.Errorf("wanted insert count %d, got %d",
+						1, resp.InsertedCount)
+				}
+				return nil
+			},
+		},
+		{
+			name: "fork extend",
+			request: tbcadminapi.BlockHeadersInsertRequest{
+				BlockHeaders: []tbcapi.BlockHeader{fork},
+			},
+			postCheck: func(resp *tbcadminapi.BlockHeadersInsertResponse) error {
+				if resp.Error != nil {
+					return resp.Error
+				}
+				if *resp.CanonicalHeader != validHeader {
+					return fmt.Errorf("wanted canonical header %v, got %v",
+						validHeader, resp.CanonicalHeader)
+				}
+				if *resp.LastHeader != fork {
+					return fmt.Errorf("wanted last header %v, got %v",
+						fork, resp.LastHeader)
+				}
+				if resp.InsertType != tbcd.ITForkExtend.String() {
+					return fmt.Errorf("wanted IT %s, got %s",
+						tbcd.ITForkExtend, resp.InsertType)
+				}
+				if resp.InsertedCount != 1 {
+					return fmt.Errorf("wanted insert count %d, got %d",
+						1, resp.InsertedCount)
+				}
+				return nil
+			},
+		},
+		{
+			name: "chain fork",
+			request: tbcadminapi.BlockHeadersInsertRequest{
+				BlockHeaders: []tbcapi.BlockHeader{forkExtend},
+			},
+			postCheck: func(resp *tbcadminapi.BlockHeadersInsertResponse) error {
+				if resp.Error != nil {
+					return resp.Error
+				}
+				if *resp.CanonicalHeader != forkExtend {
+					return fmt.Errorf("wanted canonical header %v, got %v",
+						forkExtend, resp.CanonicalHeader)
+				}
+				if *resp.LastHeader != forkExtend {
+					return fmt.Errorf("wanted last header %v, got %v",
+						forkExtend, resp.LastHeader)
+				}
+				if resp.InsertType != tbcd.ITChainFork.String() {
+					return fmt.Errorf("wanted IT %s, got %s",
+						tbcd.ITChainFork, resp.InsertType)
+				}
+				if resp.InsertedCount != 1 {
+					return fmt.Errorf("wanted insert count %d, got %d",
+						1, resp.InsertedCount)
+				}
+				return nil
+			},
+		},
+		{
+			name: "duplicate",
+			request: tbcadminapi.BlockHeadersInsertRequest{
+				BlockHeaders: []tbcapi.BlockHeader{validHeader},
+			},
+			postCheck: func(resp *tbcadminapi.BlockHeadersInsertResponse) error {
+				if resp.Error == nil {
+					return errors.New("expected error")
+				}
+				return nil
+			},
+		},
+		{
+			name: "invalid bits",
+			request: tbcadminapi.BlockHeadersInsertRequest{
+				BlockHeaders: []tbcapi.BlockHeader{invalidBitsHeader},
+			},
+			postCheck: func(resp *tbcadminapi.BlockHeadersInsertResponse) error {
+				if resp.Error == nil {
+					return errors.New("expected error")
+				}
+				return nil
+			},
+		},
+		{
+			name: "empty headers",
+			request: tbcadminapi.BlockHeadersInsertRequest{
+				BlockHeaders: []tbcapi.BlockHeader{},
+			},
+			postCheck: func(resp *tbcadminapi.BlockHeadersInsertResponse) error {
+				if resp.Error == nil {
+					return errors.New("expected error")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tti := range testTable {
+		t.Run(tti.name, func(t *testing.T) {
+			c := dialAdmin(ctx, t, adminURL)
+			defer c.CloseNow()
+
+			assertPing(ctx, t, c, tbcapi.CmdPingRequest)
+
+			tws := &tbcWs{conn: protocol.NewWSConn(c)}
+
+			if err := tbcadminapi.Write(ctx, tws.conn, "someid", tti.request); err != nil {
+				t.Fatal(err)
+			}
+
+			msg := readAdminMessage(ctx, t, c)
+			var resp tbcadminapi.BlockHeadersInsertResponse
+			if err := json.Unmarshal(msg.Payload, &resp); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := tti.postCheck(&resp); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestAdminRPCSyncIndexersToHash(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
 	defer func() {
 		cancel()
 	}()
 
-	n, err := newFakeNode(t)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err := n.Stop()
-		if err != nil {
-			t.Logf("node stop: %v", err)
-		}
-	}()
-	go func() {
-		err := n.Run(ctx)
-		if !testutil.ErrorIsOneOf(err, []error{net.ErrClosed, context.Canceled, rawpeer.ErrNoConn}) {
-			panic(err)
-		}
-	}()
-
-	s, adminURL := createTbcAdminServer(ctx, t, []string{n.Address()})
-
-	// Subscribe to tbc notifications
-	l, err := s.SubscribeNotifications(ctx, 10)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer l.Unsubscribe()
-
-	// wait for node to connect as peer
-	select {
-	case <-ctx.Done():
-		t.Fatal(ctx.Err())
-	case <-n.msgCh:
-	}
-
-	// g ->  b1 ->  b2 -> b3
-
-	parent := chaincfg.RegressionNetParams.GenesisHash
-	address := n.address
-	b1, err := n.MineAndSend(ctx, "b1", parent, address, MineNoKeystones)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b2, err := n.MineAndSend(ctx, "b2", b1.Hash(), address, MineNoKeystones)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b3, err := n.MineAndSend(ctx, "b3", b2.Hash(), address, MineNoKeystones)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make sure tbc downloads blocks
-	if err := n.MineAndSendEmpty(ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for tbc to insert all blocks
-	if err := s.waitForBlocks(ctx, l, n.blocksAtHeight); err != nil {
-		t.Fatal(err)
-	}
-	l.Unsubscribe()
-
-	// Verify linear indexing. Current TxIndex is sitting at genesis
-
-	// genesis -> b3 should work with negative direction (cdiff is less than target)
-	direction, err := indexIsLinear(ctx, s.g, *s.g.chain.GenesisHash, *b3.Hash())
-	if err != nil {
-		t.Fatalf("expected success g -> b3, got %v", err)
-	}
-	if direction <= 0 {
-		t.Fatalf("expected 1 going from genesis to b3, got %v", direction)
-	}
+	adminURL, s, n := createLocalTBCServer(ctx, t, testJWTString)
 
 	// Connect to admin RPC
 	c := dialAdmin(ctx, t, adminURL)
@@ -639,6 +693,7 @@ func TestAdminRPCSyncIndexersToHash(t *testing.T) {
 	assertPing(ctx, t, c, tbcapi.CmdPingRequest)
 	tws := &tbcWs{conn: protocol.NewWSConn(c)}
 
+	b3 := n.blocksAtHeight[3][0]
 	req := tbcadminapi.SyncIndexersToHashRequest{
 		Hash: *b3.Hash(),
 	}
@@ -670,7 +725,9 @@ func TestAdminRPCSyncIndexersToHash(t *testing.T) {
 		}
 	}
 
-	err = mustHave(ctx, t, s, n.genesis, b1, b2, b3)
+	b1 := n.blocksAtHeight[1][0]
+	b2 := n.blocksAtHeight[2][0]
+	err := mustHave(ctx, t, s, n.genesis, b1, b2, b3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -693,7 +750,7 @@ func TestAdminRPCSyncIndexersToHash(t *testing.T) {
 	t.Logf("b3: %v", b3)
 
 	// b3 -> genesis should work with positive direction (cdiff is greater than target)
-	direction, err = indexIsLinear(ctx, s.g, *b3.Hash(), *s.g.chain.GenesisHash)
+	direction, err := indexIsLinear(ctx, s.g, *b3.Hash(), *s.g.chain.GenesisHash)
 	if err != nil {
 		t.Fatalf("expected success b3 -> genesis, got %v", err)
 	}
@@ -721,7 +778,7 @@ func TestAdminRPCNotFound(t *testing.T) {
 		postCheck func(msg protocol.Message) error
 	}
 
-	_, adminURL := createTbcAdminServer(ctx, t, nil)
+	adminURL, _, _ := createLocalTBCServer(ctx, t, testJWTString)
 	fakeID := "fakeID"
 
 	testTable := []testTableItem{

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -82,6 +82,26 @@ func (s *Server) getTBCAPICommandHandler(cmd protocol.Command, payload any) func
 		return func(ctx context.Context) (any, error) {
 			return s.handleBlockHeaderBestRequest(ctx, payload.(*tbcapi.BlockHeaderBestRequest))
 		}
+	case tbcapi.CmdBlockHeaderByHashRawRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleBlockHeaderByHashRawRequest(ctx, payload.(*tbcapi.BlockHeaderByHashRawRequest))
+		}
+	case tbcapi.CmdBlockHeaderByHashRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleBlockHeaderByHashRequest(ctx, payload.(*tbcapi.BlockHeaderByHashRequest))
+		}
+	case tbcapi.CmdFullBlockAvailableRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleFullBlockAvailableRequest(ctx, payload.(*tbcapi.FullBlockAvailableRequest))
+		}
+	case tbcapi.CmdScriptHashAvailableToSpendRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleScriptHashAvailableToSpendRequest(ctx, payload.(*tbcapi.ScriptHashAvailableToSpendRequest))
+		}
+	case tbcapi.CmdSyncStatusRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleSyncStatusRequest(ctx, payload.(*tbcapi.SyncStatusRequest))
+		}
 	case tbcapi.CmdBalanceByAddressRequest:
 		return func(ctx context.Context) (any, error) {
 			return s.handleBalanceByAddressRequest(ctx, payload.(*tbcapi.BalanceByAddressRequest))
@@ -109,6 +129,14 @@ func (s *Server) getTBCAPICommandHandler(cmd protocol.Command, payload any) func
 	case tbcapi.CmdTxBroadcastRawRequest:
 		return func(ctx context.Context) (any, error) {
 			return s.handleTxBroadcastRawRequest(ctx, payload.(*tbcapi.TxBroadcastRawRequest))
+		}
+	case tbcapi.CmdBlockHashByTxIDRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleBlockHashByTxIdRequest(ctx, payload.(*tbcapi.BlockHashByTxIDRequest))
+		}
+	case tbcapi.CmdBlockInTxIndexRequest:
+		return func(ctx context.Context) (any, error) {
+			return s.handleBlockInTxIndexRequest(ctx, payload.(*tbcapi.BlockInTxIndexRequest))
 		}
 	case tbcapi.CmdBlockInsertRequest:
 		return func(ctx context.Context) (any, error) {
@@ -401,6 +429,118 @@ func (s *Server) handleBlockHeaderBestRequest(ctx context.Context, _ *tbcapi.Blo
 	}, nil
 }
 
+func (s *Server) handleBlockHeaderByHashRawRequest(ctx context.Context, req *tbcapi.BlockHeaderByHashRawRequest) (any, error) {
+	log.Tracef("handleBlockHeaderByHashRawRequest")
+	defer log.Tracef("handleBlockHeaderByHashRawRequest exit")
+
+	blockHeader, height, err := s.BlockHeaderByHash(ctx, req.Hash)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return &tbcapi.BlockHeaderByHashRawResponse{
+				Error: protocol.NotFoundError("block header", req.Hash),
+			}, nil
+		}
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockHeaderByHashRawResponse{
+			Error: e.ProtocolError(),
+		}, e
+	}
+
+	b := h2b(blockHeader)
+	return &tbcapi.BlockHeaderByHashRawResponse{
+		Height:      height,
+		BlockHeader: b[:],
+	}, nil
+}
+
+func (s *Server) handleBlockHeaderByHashRequest(ctx context.Context, req *tbcapi.BlockHeaderByHashRequest) (any, error) {
+	log.Tracef("handleBlockHeaderByHashRequest")
+	defer log.Tracef("handleBlockHeaderByHashRequest exit")
+
+	blockHeader, height, err := s.BlockHeaderByHash(ctx, req.Hash)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return &tbcapi.BlockHeaderByHashResponse{
+				Error: protocol.NotFoundError("block header", req.Hash),
+			}, nil
+		}
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockHeaderByHashResponse{
+			Error: e.ProtocolError(),
+		}, e
+	}
+
+	return &tbcapi.BlockHeaderByHashResponse{
+		Height:      height,
+		BlockHeader: wireBlockHeaderToTBC(blockHeader),
+	}, nil
+}
+
+func (s *Server) handleFullBlockAvailableRequest(ctx context.Context, req *tbcapi.FullBlockAvailableRequest) (any, error) {
+	log.Tracef("handleFullBlockAvailableRequest")
+	defer log.Tracef("handleFullBlockAvailableRequest exit")
+
+	available, err := s.FullBlockAvailable(ctx, req.Hash)
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcapi.FullBlockAvailableResponse{
+			Error: e.ProtocolError(),
+		}, e
+	}
+
+	return &tbcapi.FullBlockAvailableResponse{
+		Available: available,
+	}, nil
+}
+
+func (s *Server) handleScriptHashAvailableToSpendRequest(ctx context.Context, req *tbcapi.ScriptHashAvailableToSpendRequest) (any, error) {
+	log.Tracef("handleScriptHashAvailableToSpendRequest")
+	defer log.Tracef("handleScriptHashAvailableToSpendRequest exit")
+
+	available, err := s.ScriptHashAvailableToSpend(ctx, req.TxID, req.Index)
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcapi.ScriptHashAvailableToSpendResponse{
+			Error: e.ProtocolError(),
+		}, e
+	}
+
+	return &tbcapi.ScriptHashAvailableToSpendResponse{
+		Available: available,
+	}, nil
+}
+
+func (s *Server) handleSyncStatusRequest(ctx context.Context, _ *tbcapi.SyncStatusRequest) (any, error) {
+	log.Tracef("handleSyncStatusRequest")
+	defer log.Tracef("handleSyncStatusRequest exit")
+
+	si := s.Synced(ctx)
+	return &tbcapi.SyncStatusResponse{
+		Synced:         si.Synced,
+		AtLeastMissing: si.AtLeastMissing,
+		BlockHeader: tbcapi.HashHeight{
+			Hash:   si.BlockHeader.Hash,
+			Height: si.BlockHeader.Height,
+		},
+		Keystone: tbcapi.HashHeight{
+			Hash:   si.Keystone.Hash,
+			Height: si.Keystone.Height,
+		},
+		Tx: tbcapi.HashHeight{
+			Hash:   si.Tx.Hash,
+			Height: si.Tx.Height,
+		},
+		Utxo: tbcapi.HashHeight{
+			Hash:   si.Utxo.Hash,
+			Height: si.Utxo.Height,
+		},
+		ZK: tbcapi.HashHeight{
+			Hash:   si.ZK.Hash,
+			Height: si.ZK.Height,
+		},
+	}, nil
+}
+
 func (s *Server) handleBalanceByAddressRequest(ctx context.Context, req *tbcapi.BalanceByAddressRequest) (any, error) {
 	log.Tracef("handleBalanceByAddressRequest")
 	defer log.Tracef("handleBalanceByAddressRequest exit")
@@ -592,6 +732,41 @@ func (s *Server) handleTxBroadcastRawRequest(ctx context.Context, req *tbcapi.Tx
 	}
 
 	return &tbcapi.TxBroadcastRawResponse{TxID: txid}, nil
+}
+
+func (s *Server) handleBlockHashByTxIdRequest(ctx context.Context, req *tbcapi.BlockHashByTxIDRequest) (any, error) {
+	log.Tracef("handleBlockHashByTxIdRequest")
+	defer log.Tracef("handleBlockHashByTxIdRequest exit")
+
+	hash, err := s.BlockHashByTxId(ctx, req.TxID)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return &tbcapi.BlockHashByTxIDResponse{
+				Error: protocol.NotFoundError("tx", req.TxID),
+			}, nil
+		}
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockHashByTxIDResponse{
+			Error: e.ProtocolError(),
+		}, e
+	}
+
+	return &tbcapi.BlockHashByTxIDResponse{BlockHash: hash}, nil
+}
+
+func (s *Server) handleBlockInTxIndexRequest(ctx context.Context, req *tbcapi.BlockInTxIndexRequest) (any, error) {
+	log.Tracef("handleBlockInTxIndexRequest")
+	defer log.Tracef("handleBlockInTxIndexRequest exit")
+
+	indexed, err := s.BlockInTxIndex(ctx, req.BlockHash)
+	if err != nil {
+		e := protocol.NewInternalError(err)
+		return &tbcapi.BlockInTxIndexResponse{
+			Error: e.ProtocolError(),
+		}, e
+	}
+
+	return &tbcapi.BlockInTxIndexResponse{Indexed: indexed}, nil
 }
 
 func (s *Server) handleBlockInsertRequest(ctx context.Context, req *tbcapi.BlockInsertRequest) (any, error) {

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -2119,9 +2119,7 @@ func TestNotFoundError(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithTimeout(t.Context(), 7*time.Second)
-	defer func() {
-		cancel()
-	}()
+	defer cancel()
 
 	var dupErr database.DuplicateError
 

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +41,7 @@ import (
 	"github.com/hemilabs/heminetwork/v2/hemi"
 	"github.com/hemilabs/heminetwork/v2/hemi/pop"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil"
+	"github.com/hemilabs/heminetwork/v2/service/tbc/peer/rawpeer"
 )
 
 func bytes2Tx(b []byte) (*wire.MsgTx, error) {
@@ -2036,11 +2039,7 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 }
 
 func assertPing(ctx context.Context, t *testing.T, c *websocket.Conn, cmd protocol.Command) {
-	var v protocol.Message
-	err := wsjson.Read(ctx, c, &v)
-	if err != nil {
-		t.Fatal(err)
-	}
+	v := callTbc(ctx, t, c, nil)
 
 	if v.Header.Command != cmd {
 		t.Fatalf("unexpected command: %s", v.Header.Command)
@@ -2127,18 +2126,19 @@ func TestNotFoundError(t *testing.T) {
 
 	// Connect tbc service
 	cfg := &Config{
-		AutoIndex:            false,
-		BlockCacheSize:       "10mb",
-		BlockheaderCacheSize: "1mb",
-		BlockSanity:          false,
-		HemiIndex:            true,
-		LevelDBHome:          t.TempDir(),
-		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
-		MaxCachedTxs:            1000, // XXX
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		BlockheaderCacheSize:    "1mb",
+		BlockSanity:             false,
+		HemiIndex:               true,
+		LevelDBHome:             t.TempDir(),
+		ListenAddress:           "127.0.0.1:0",
+		MaxCachedTxs:            1000,
 		Network:                 networkLocalnet,
 		PrometheusListenAddress: "",
 		Seeds:                   []string{"192.0.2.1:8333"},
 		NotificationBlocking:    true,
+		// LogLevel:                "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 	}
 	_ = loggo.ConfigureLoggers(cfg.LogLevel)
 	s, err := NewServer(cfg)
@@ -2166,12 +2166,15 @@ func TestNotFoundError(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		t.Log(msg)
 		if msg.Error != nil {
 			t.Fatal(msg.Error)
 		}
-		// If we insert genesis, then TBC has finished starting up
-		if msg.Is(NotificationBlock(chainhash.Hash{})) {
-			break
+		// TBC sends a notification when the http service has started.
+		if msg.Is(NotificationService("", "")) {
+			if msg.ID == "tbc_http_server" && msg.Msg == "ready" {
+				break
+			}
 		}
 	}
 
@@ -2300,6 +2303,51 @@ func TestNotFoundError(t *testing.T) {
 			},
 			expectedError: *protocol.NotFoundError("keystone", emptyHash),
 		},
+		{
+			name: "BlockHashByTxId",
+			handler: func(ctx context.Context) (*protocol.Error, error) {
+				req := tbcapi.BlockHashByTxIDRequest{
+					TxID: emptyHash,
+				}
+				res, err := s.handleBlockHashByTxIdRequest(ctx, &req)
+				val, ok := res.(*tbcapi.BlockHashByTxIDResponse)
+				if !ok {
+					return nil, fmt.Errorf("unexpected type: %T", res)
+				}
+				return val.Error, err
+			},
+			expectedError: *protocol.NotFoundError("tx", emptyHash),
+		},
+		{
+			name: "BlockHeaderByHash",
+			handler: func(ctx context.Context) (*protocol.Error, error) {
+				req := tbcapi.BlockHeaderByHashRequest{
+					Hash: emptyHash,
+				}
+				res, err := s.handleBlockHeaderByHashRequest(ctx, &req)
+				val, ok := res.(*tbcapi.BlockHeaderByHashResponse)
+				if !ok {
+					return nil, fmt.Errorf("unexpected type: %T", res)
+				}
+				return val.Error, err
+			},
+			expectedError: *protocol.NotFoundError("block header", emptyHash),
+		},
+		{
+			name: "BlockHeaderByHashRaw",
+			handler: func(ctx context.Context) (*protocol.Error, error) {
+				req := tbcapi.BlockHeaderByHashRawRequest{
+					Hash: emptyHash,
+				}
+				res, err := s.handleBlockHeaderByHashRawRequest(ctx, &req)
+				val, ok := res.(*tbcapi.BlockHeaderByHashRawResponse)
+				if !ok {
+					return nil, fmt.Errorf("unexpected type: %T", res)
+				}
+				return val.Error, err
+			},
+			expectedError: *protocol.NotFoundError("block header", emptyHash),
+		},
 	}
 
 	for _, tti := range testTable {
@@ -2313,6 +2361,416 @@ func TestNotFoundError(t *testing.T) {
 				t.Fatalf("unexpected error %v != %v",
 					resp.Message, tti.expectedError.Message)
 			}
+		})
+	}
+}
+
+func createLocalTBCServer(ctx context.Context, t *testing.T) (string, *Server, *btcNode) {
+	t.Helper()
+
+	n, err := newFakeNode(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := n.Stop()
+		if err != nil {
+			t.Logf("node stop: %v", err)
+		}
+	}()
+	go func() {
+		err := n.Run(ctx)
+		if !testutil.ErrorIsOneOf(err, []error{net.ErrClosed, context.Canceled, rawpeer.ErrNoConn}) {
+			panic(err)
+		}
+	}()
+
+	cfg := &Config{
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		BlockheaderCacheSize:    "1mb",
+		BlockSanity:             false,
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            1000,
+		PeersWanted:             1,
+		PrometheusListenAddress: "",
+		ListenAddress:           "127.0.0.1:0",
+		Network:                 networkLocalnet,
+		NotificationBlocking:    true,
+		Seeds:                   []string{n.Address()},
+		// LogLevel:             "tbcd=TRACE:tbc=TRACE:level=DEBUG",
+	}
+	_ = loggo.ConfigureLoggers(cfg.LogLevel)
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// subscribe to tbc notifications
+	l, err := s.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, rawpeer.ErrNoConn) {
+			panic(err)
+		}
+	}()
+
+	// Wait for http service to start up
+	var tbcURL string
+	for {
+		msg, err := l.Listen(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(msg)
+		if msg.Error != nil {
+			t.Fatal(msg.Error)
+		}
+		// TBC sends a notification when the http service has started.
+		if !msg.Is(NotificationService("", "")) {
+			continue
+		}
+
+		if msg.ID != "tbc_http_server" || msg.Msg != "ready" {
+			continue
+		}
+
+		if addr := s.HTTPAddress(); addr != nil {
+			tbcURL = addr.String()
+			break
+		}
+	}
+
+	tbcAddr := fmt.Sprintf("http://%s%s", tbcURL, tbcapi.RouteWebsocket)
+
+	// wait for node to connect as peer
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-n.msgCh:
+	}
+
+	// g ->  b1 ->  b2 -> b3
+
+	parent := chaincfg.RegressionNetParams.GenesisHash
+	address := n.address
+	b1, err := n.MineAndSend(ctx, "b1", parent, address, MineNoKeystones)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := n.MineAndSend(ctx, "b2", b1.Hash(), address, MineNoKeystones)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b3, err := n.MineAndSend(ctx, "b3", b2.Hash(), address, MineNoKeystones)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure tbc downloads blocks
+	if err := n.MineAndSendEmpty(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for tbc to insert all blocks
+	if err := s.waitForBlocks(ctx, l, n.blocksAtHeight); err != nil {
+		t.Fatal(err)
+	}
+	l.Unsubscribe()
+
+	// Verify linear indexing. Current TxIndex is sitting at genesis
+
+	// genesis -> b3 should work with negative direction (cdiff is less than target)
+	direction, err := indexIsLinear(ctx, s.g, *s.g.chain.GenesisHash, *b3.Hash())
+	if err != nil {
+		t.Fatalf("expected success g -> b3, got %v", err)
+	}
+	if direction <= 0 {
+		t.Fatalf("expected 1 going from genesis to b3, got %v", direction)
+	}
+
+	return tbcAddr, s, n
+}
+
+func callTbc(ctx context.Context, t *testing.T, c *websocket.Conn, msg any) protocol.Message {
+	t.Helper()
+
+	if msg != nil {
+		tws := &tbcWs{
+			conn: protocol.NewWSConn(c),
+		}
+
+		err := tbcapi.Write(ctx, tws.conn, "someid", msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var v protocol.Message
+	if err := wsjson.Read(ctx, c, &v); err != nil {
+		t.Fatal(err)
+	}
+
+	return v
+}
+
+func compareResponse(t *testing.T, cmd protocol.Command, v protocol.Message, expected any) {
+	t.Helper()
+
+	respType, ok := tbcapi.APICommands()[cmd]
+	if !ok {
+		t.Fatalf("unknown command %s", cmd)
+	}
+
+	if v.Header.Command != cmd {
+		t.Fatalf("received unexpected command: %s", v.Header.Command)
+	}
+
+	target := reflect.New(respType).Interface()
+	if err := json.Unmarshal(v.Payload, &target); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := deep.Equal(target, expected); len(diff) != 0 {
+		t.Fatalf("got %v, wanted %v: diff %s", target, expected, diff)
+	}
+}
+
+func getRandomUtxoLocal(ctx context.Context, s *Server, n *btcNode) (*tbcd.Utxo, error) {
+	for addr := range n.keys {
+		utxos, err := s.UtxosByAddress(ctx, false, addr, 0, 1)
+		if err != nil {
+			return nil, err
+		}
+		if len(utxos) != 0 {
+			return &utxos[0], nil
+		}
+	}
+	return nil, errors.New("no suitable utxo found")
+}
+
+func getRandomTxIDLocal(n *btcNode) (*chainhash.Hash, *chainhash.Hash, error) {
+	for i := n.height; i > 0; i-- {
+		blk := n.blocksAtHeight[i][0]
+		for t := range blk.txs {
+			txID, expectedHash, err := tbcd.TxIdBlockHashFromTxKey(t)
+			if err != nil {
+				continue
+			}
+			return txID, expectedHash, nil
+		}
+	}
+	return nil, nil, errors.New("no suitable tx found")
+}
+
+func TestRPCRequestsLocal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
+	defer cancel()
+
+	type testTableItem struct {
+		name        string
+		requestFunc func(*testing.T) (any, any)
+		expectedCmd protocol.Command
+	}
+
+	tbcUrl, tbcServer, n := createLocalTBCServer(ctx, t)
+
+	indexAll(ctx, t, tbcServer)
+
+	// Get a random TX and associated block
+	txID, expectedHash, err := getRandomTxIDLocal(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get a random UTXO
+	utxo, err := getRandomUtxoLocal(ctx, tbcServer, n)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []testTableItem{
+		{
+			name:        "BlockHashByTxID",
+			expectedCmd: tbcapi.CmdBlockHashByTxIDResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.BlockHashByTxIDRequest{TxID: *txID}
+				expectedResp := &tbcapi.BlockHashByTxIDResponse{BlockHash: expectedHash}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "BlockHashByTxID Not Found",
+			expectedCmd: tbcapi.CmdBlockHashByTxIDResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.BlockHashByTxIDRequest{TxID: chainhash.Hash{}}
+				expectedResp := &tbcapi.BlockHashByTxIDResponse{
+					Error: protocol.NotFoundError("tx", chainhash.Hash{}),
+				}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "BlockInTxIndex",
+			expectedCmd: tbcapi.CmdBlockInTxIndexResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.BlockInTxIndexRequest{BlockHash: *expectedHash}
+				expectedResp := &tbcapi.BlockInTxIndexResponse{Indexed: true}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "BlockInTxIndex Negative",
+			expectedCmd: tbcapi.CmdBlockInTxIndexResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.BlockInTxIndexRequest{BlockHash: chainhash.Hash{}}
+				expectedResp := &tbcapi.BlockInTxIndexResponse{Indexed: false}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "FullBlockAvailable",
+			expectedCmd: tbcapi.CmdFullBlockAvailableResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.FullBlockAvailableRequest{Hash: *expectedHash}
+				expectedResp := &tbcapi.FullBlockAvailableResponse{Available: true}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "FullBlockAvailable Negative",
+			expectedCmd: tbcapi.CmdFullBlockAvailableResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.FullBlockAvailableRequest{Hash: chainhash.Hash{}}
+				expectedResp := &tbcapi.FullBlockAvailableResponse{Available: false}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "BlockHeaderByHash",
+			expectedCmd: tbcapi.CmdBlockHeaderByHashResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				bh, height, err := tbcServer.BlockHeaderByHash(ctx, *expectedHash)
+				if err != nil {
+					t.Fatal(err)
+				}
+				request := &tbcapi.BlockHeaderByHashRequest{Hash: *expectedHash}
+				expectedResp := &tbcapi.BlockHeaderByHashResponse{
+					Height:      height,
+					BlockHeader: wireBlockHeaderToTBC(bh),
+				}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "BlockHeaderByHash Not Found",
+			expectedCmd: tbcapi.CmdBlockHeaderByHashResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.BlockHeaderByHashRequest{Hash: chainhash.Hash{}}
+				expectedResp := &tbcapi.BlockHeaderByHashResponse{
+					Error: protocol.NotFoundError("block header", chainhash.Hash{}),
+				}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "BlockHeaderByHashRaw",
+			expectedCmd: tbcapi.CmdBlockHeaderByHashRawResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				bh, height, err := tbcServer.BlockHeaderByHash(ctx, *expectedHash)
+				if err != nil {
+					t.Fatal(err)
+				}
+				request := &tbcapi.BlockHeaderByHashRawRequest{Hash: *expectedHash}
+				expectedResp := &tbcapi.BlockHeaderByHashRawResponse{
+					Height:      height,
+					BlockHeader: new(h2b(bh))[:],
+				}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "BlockHeaderByHashRaw Not Found",
+			expectedCmd: tbcapi.CmdBlockHeaderByHashRawResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.BlockHeaderByHashRawRequest{Hash: chainhash.Hash{}}
+				expectedResp := &tbcapi.BlockHeaderByHashRawResponse{
+					Error: protocol.NotFoundError("block header", chainhash.Hash{}),
+				}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "ScriptHashAvailableToSpend",
+			expectedCmd: tbcapi.CmdScriptHashAvailableToSpendResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.ScriptHashAvailableToSpendRequest{
+					TxID:  *utxo.ChainHash(),
+					Index: utxo.OutputIndex(),
+				}
+				expectedResp := &tbcapi.ScriptHashAvailableToSpendResponse{Available: true}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "ScriptHashAvailableToSpend Negative",
+			expectedCmd: tbcapi.CmdScriptHashAvailableToSpendResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.ScriptHashAvailableToSpendRequest{
+					TxID:  chainhash.Hash{},
+					Index: 0,
+				}
+				expectedResp := &tbcapi.ScriptHashAvailableToSpendResponse{Available: false}
+				return request, expectedResp
+			},
+		},
+		{
+			name:        "SyncStatus",
+			expectedCmd: tbcapi.CmdSyncStatusResponse,
+			requestFunc: func(t *testing.T) (any, any) {
+				request := &tbcapi.SyncStatusRequest{}
+				height, bh, err := tbcServer.BlockHeaderBest(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				bestHH := tbcapi.HashHeight{
+					Height: height,
+					Hash:   bh.BlockHash(),
+				}
+				expectedResp := &tbcapi.SyncStatusResponse{
+					Synced:         true,
+					AtLeastMissing: 0,
+					BlockHeader:    bestHH,
+					Tx:             bestHH,
+					Utxo:           bestHH,
+				}
+				return request, expectedResp
+			},
+		},
+	}
+
+	for _, tti := range tests {
+		t.Run(tti.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+
+			c, _, err := websocket.Dial(ctx, tbcUrl, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.CloseNow()
+
+			assertPing(ctx, t, c, tbcapi.CmdPingRequest)
+
+			req, expected := tti.requestFunc(t)
+
+			v := callTbc(ctx, t, c, req)
+			compareResponse(t, tti.expectedCmd, v, expected)
 		})
 	}
 }

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/hemilabs/heminetwork/v2/api"
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
+	"github.com/hemilabs/heminetwork/v2/api/tbcadminapi"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin"
 	"github.com/hemilabs/heminetwork/v2/database"
@@ -2365,7 +2366,7 @@ func TestNotFoundError(t *testing.T) {
 	}
 }
 
-func createLocalTBCServer(ctx context.Context, t *testing.T) (string, *Server, *btcNode) {
+func createLocalTBCServer(ctx context.Context, t *testing.T, jwtSecret string) (string, *Server, *btcNode) {
 	t.Helper()
 
 	n, err := newFakeNode(t)
@@ -2397,6 +2398,7 @@ func createLocalTBCServer(ctx context.Context, t *testing.T) (string, *Server, *
 		ListenAddress:           "127.0.0.1:0",
 		Network:                 networkLocalnet,
 		NotificationBlocking:    true,
+		JWTSecret:               jwtSecret,
 		Seeds:                   []string{n.Address()},
 		// LogLevel:             "tbcd=TRACE:tbc=TRACE:level=DEBUG",
 	}
@@ -2446,7 +2448,11 @@ func createLocalTBCServer(ctx context.Context, t *testing.T) (string, *Server, *
 		}
 	}
 
-	tbcAddr := fmt.Sprintf("http://%s%s", tbcURL, tbcapi.RouteWebsocket)
+	route := tbcapi.RouteWebsocket
+	if jwtSecret != "" {
+		route = tbcadminapi.RouteAdminWs
+	}
+	tbcAddr := fmt.Sprintf("http://%s%s", tbcURL, route)
 
 	// wait for node to connect as peer
 	select {
@@ -2578,7 +2584,7 @@ func TestRPCRequestsLocal(t *testing.T) {
 		expectedCmd protocol.Command
 	}
 
-	tbcUrl, tbcServer, n := createLocalTBCServer(ctx, t)
+	tbcUrl, tbcServer, n := createLocalTBCServer(ctx, t, "")
 
 	indexAll(ctx, t, tbcServer)
 

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2241,6 +2241,9 @@ func (s *Server) ScriptHashAvailableToSpend(ctx context.Context, txId chainhash.
 	op := tbcd.NewOutpoint(txIdBytes, index)
 	sh, err := s.g.db.ScriptHashByOutpoint(ctx, op)
 	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
**Summary**
Fixes #978. Adds several missing RPC calls to the regular and authenticated `TBC` routes.

Also addresses two bugs:
1. In `ScriptHashAvailableToSpend` an `error` was returned instead of `false` when the outpoint wasn't found.
2. In `BlockInTxIndex` the check was done incorrectly, always returning an `error`.

These two calls are used in precompiles in `op-geth`, so I have created issues to be careful when updating TBC there: [here](https://github.com/hemilabs/op-geth/issues/85) and [here](https://github.com/hemilabs/op-geth/issues/86).

Also added a few utility testing functions that can allow for simplifying and improving testing of our RPC calls, and created an issue for it: #1027 

**Changes**

RPC calls added:
- `BlockHashByTxId`
- `BlockInTxIndex`
- `FullBlockAvailable`
- `BlockHeaderByHash`
- `BlockHeaderByHashRaw`
- `BlockHashByTxId`
- `ScriptHashAvailableToSpend`
- `SyncStatus`

Authenticated RPC calls added:
- `BlockHeadersInsert`
