### PR TITLE
popm: fix panic during prom polling with nil geth client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   itself as not-synced when an optional indexer is enabled.
   ([#1036](https://github.com/hemilabs/heminetwork/pull/1036))
 
+- Fix bug in `popm` that led to a panic when prometheus called geth before
+ the client was set ([#1030](https://github.com/hemilabs/heminetwork/pull/1030)).
+
 ## [v2.0.0]
 
 ### Breaking Changes

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -575,13 +575,14 @@ func (s *Server) connectOpgeth(pctx context.Context) error {
 	defer connCancel()
 
 	var err error
-	s.opgethClient, err = ethclient.DialContext(connCtx, s.cfg.OpgethURL)
+	opgethClient, err := ethclient.DialContext(connCtx, s.cfg.OpgethURL)
 	if err != nil {
 		return err
 	}
-	defer s.opgethClient.Close()
+	defer opgethClient.Close()
 
 	s.mtx.Lock()
+	s.opgethClient = opgethClient
 	s.promHealth.GethConnected = true
 	s.mtx.Unlock()
 	defer func() {
@@ -616,7 +617,7 @@ func (s *Server) connectOpgeth(pctx context.Context) error {
 	})
 
 	<-ctx.Done()
-	s.opgethClient.Close()
+	opgethClient.Close()
 
 	// Wait for exit
 	s.opgethWG.Wait()
@@ -763,6 +764,12 @@ func (s *Server) promPoll(pctx context.Context) error {
 		s.mtx.Lock()
 		gozer := s.gozer
 		if gozer == nil {
+			// Not ready
+			s.promHealth = health{}
+			s.mtx.Unlock()
+			continue
+		}
+		if s.opgethClient == nil {
 			// Not ready
 			s.promHealth = health{}
 			s.mtx.Unlock()

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -77,6 +78,29 @@ func TestPopMiner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestPromPollBeforeOpgeth(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+		defer cancel()
+
+		// Setup pop miner
+		cfg := NewDefaultConfig()
+		cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
+
+		// Create pop miner
+		s, err := NewServer(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// if we try to do opgeth calls before we have connected at least
+		// once, this will panic.
+		if err := s.promPoll(ctx); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("unexpected error %v", err)
+		}
+	})
 }
 
 func TestTickingPopMiner(t *testing.T) {


### PR DESCRIPTION
**Summary**
Fixes a potential panic where `prometheus` will try and make `op-geth` calls before we set the client.

**Changes**
- Set `op-geth` client behind mutex.
- Check if client is nil when polling.
- Add `TestPromPollBeforeOpgeth`.
