### PR TITLE
gozer: fix abbreviated keystone serialization

### DIFF
--- a/bitcoin/wallet/gozer/gozer.go
+++ b/bitcoin/wallet/gozer/gozer.go
@@ -78,8 +78,8 @@ type L2KeystoneAbrev struct {
 	EPHash             api.ByteSlice `json:"ep_hash"`
 }
 
-func (a *L2KeystoneAbrev) Serialize() [72]byte {
-	var r [72]byte
+func (a *L2KeystoneAbrev) Serialize() [76]byte {
+	var r [76]byte
 	r[0] = uint8(a.Version)
 	binary.BigEndian.PutUint32(r[1:5], uint32(a.L1BlockNumber))
 	binary.BigEndian.PutUint32(r[5:9], uint32(a.L2BlockNumber))

--- a/bitcoin/wallet/wallet_test.go
+++ b/bitcoin/wallet/wallet_test.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -239,4 +240,34 @@ func TestIntegration(t *testing.T) {
 	}
 	t.Logf("TxByID: version=%v txin=%d txout=%d",
 		lookedUp.Version, len(lookedUp.TxIn), len(lookedUp.TxOut))
+}
+
+func TestAbrevKssSerialize(t *testing.T) {
+	kss := hemi.L2Keystone{
+		Version:            1,
+		L1BlockNumber:      999999999,
+		L2BlockNumber:      999999999,
+		ParentEPHash:       testutil.FillBytes("parent_ep_hash", 32),
+		PrevKeystoneEPHash: testutil.FillBytes("prev_kss_ep_hash", 32),
+		StateRoot:          testutil.FillBytes("state_root", 32),
+		EPHash:             testutil.FillBytes("ep_hash", 32),
+	}
+
+	hemiAbrev := hemi.L2KeystoneAbbreviate(kss)
+	hs := hemiAbrev.Serialize()
+
+	gozerAbrev := gozer.L2KeystoneAbrev{
+		Version:            uint(kss.Version),
+		L1BlockNumber:      uint(kss.L1BlockNumber),
+		L2BlockNumber:      uint(kss.L2BlockNumber),
+		ParentEPHash:       kss.ParentEPHash,
+		PrevKeystoneEPHash: kss.PrevKeystoneEPHash,
+		StateRoot:          kss.StateRoot,
+		EPHash:             kss.EPHash,
+	}
+	gs := gozerAbrev.Serialize()
+
+	if !bytes.Equal(gs[:], hs[:]) {
+		t.Fatal("mismatch between serialized abrev kss")
+	}
 }

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -134,9 +134,6 @@ type keystone struct {
 	keystone *hemi.L2Keystone
 	hash     *chainhash.Hash // map key
 
-	// comes from gozer
-	abbreviated *gozer.L2KeystoneBlockInfo
-
 	expires *time.Time // Used to age out of cache
 
 	// internal state                  /-----> 4
@@ -454,7 +451,6 @@ func (s *Server) reconcileKeystones(ctx context.Context) (map[chainhash.Hash]*ke
 
 		// Always add the entry to cache and rely on Error being !nil
 		// to retry later.
-		ks.abbreviated = &gks.L2KeystoneBlocks[k]
 	}
 
 	return keystones, nil


### PR DESCRIPTION
**Summary**
Minor PR to fix serialization of abbreviated keystones in `gozer`, which truncated `EPHash` to 8 bytes rather than the expected 12. This is not used in our code, but callers may find it useful, and this prevents a mismatch between `hemi` and `gozer` types.

Also remove a related field in the `keystone` type in `popm`, which was set and not used.

**Changes**
See above.
