### PR TITLE
tbc: add read-only lru cache to utxo indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add generic `lru` package with cost-based LRU cache (`lru.Cache[K,V]`)
   ([#1034](https://github.com/hemilabs/heminetwork/pull/1034)).
+- Add utxo read LRU cache (`TBC_UTXO_READ_CACHE_SIZE`) to reduce LevelDB
+  reads during UTXO fixup; cleared when indexer reaches tip
+  ([#1035](https://github.com/hemilabs/heminetwork/pull/1035)).
 - Add ZK indexers.
 - Add RPC request method whitelist to hproxy ([#691](https://github.com/hemilabs/heminetwork/pull/691)).
 - Add TBC notification system ([#725](https://github.com/hemilabs/heminetwork/pull/725)).

--- a/cmd/tbcd/tbcd.go
+++ b/cmd/tbcd/tbcd.go
@@ -107,6 +107,12 @@ var (
 			Help:         "maximum cached zk rows during indexing",
 			Print:        config.PrintAll,
 		},
+		"TBC_UTXO_READ_CACHE_SIZE": config.Config{
+			Value:        &cfg.UtxoReadCacheSize,
+			DefaultValue: "1gb",
+			Help:         "size of utxo read LRU cache (0 to disable)",
+			Print:        config.PrintAll,
+		},
 		"TBC_MEMPOOL_ENABLED": config.Config{
 			Value:        &cfg.MempoolEnabled,
 			DefaultValue: true,

--- a/lru/lru.go
+++ b/lru/lru.go
@@ -18,11 +18,12 @@ const EntryOverhead = 128
 
 // Stats contains cache statistics.
 type Stats struct {
-	Hits   int `json:"hits"`
-	Misses int `json:"misses"`
-	Purges int `json:"purges"`
-	Cost   int `json:"cost"`  // current total cost
-	Items  int `json:"items"` // current entry count
+	Hits    int `json:"hits"`
+	Misses  int `json:"misses"`
+	Purges  int `json:"purges"`
+	Cost    int `json:"cost"`     // current total cost
+	MaxCost int `json:"max_cost"` // configured cost budget
+	Items   int `json:"items"`    // current entry count
 }
 
 type entry[K comparable, V any] struct {
@@ -191,11 +192,12 @@ func (c *Cache[K, V]) Stats() Stats {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	return Stats{
-		Hits:   c.hits,
-		Misses: c.misses,
-		Purges: c.purges,
-		Cost:   c.totalCost,
-		Items:  len(c.m),
+		Hits:    c.hits,
+		Misses:  c.misses,
+		Purges:  c.purges,
+		Cost:    c.totalCost,
+		MaxCost: c.maxCost,
+		Items:   len(c.m),
 	}
 }
 

--- a/service/tbc/indexer.go
+++ b/service/tbc/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -84,6 +84,7 @@ type indexer interface {
 	process(ctx context.Context, direction int, block *btcutil.Block, c indexerCache) error // Process block
 	commit(ctx context.Context, direction int, hash chainhash.Hash, c indexerCache) error   // Commit index cache to disk
 	fixupCacheHook(ctx context.Context, block *btcutil.Block, c indexerCache) error         // Fixup cache
+	onSyncComplete()                                                                        // Called after sync reaches target
 }
 
 // indexerCache exposes Cache management functions.
@@ -129,7 +130,11 @@ func (c *indexerCommon) IndexToBest(ctx context.Context) error {
 	}
 	defer c.indexing.Store(0)
 
-	return c.toBest(ctx)
+	if err := c.toBest(ctx); err != nil {
+		return err
+	}
+	c.p.onSyncComplete()
+	return nil
 }
 
 func (c *indexerCommon) IndexToHash(ctx context.Context, hash chainhash.Hash) error {
@@ -143,7 +148,11 @@ func (c *indexerCommon) IndexToHash(ctx context.Context, hash chainhash.Hash) er
 	}
 	defer c.indexing.Store(0)
 
-	return c.windOrUnwind(ctx, hash)
+	if err := c.windOrUnwind(ctx, hash); err != nil {
+		return err
+	}
+	c.p.onSyncComplete()
+	return nil
 }
 
 func (c *indexerCommon) IndexerAt(ctx context.Context) (*tbcd.BlockHeader, error) {

--- a/service/tbc/indexer.go
+++ b/service/tbc/indexer.go
@@ -85,6 +85,7 @@ type indexer interface {
 	commit(ctx context.Context, direction int, hash chainhash.Hash, c indexerCache) error   // Commit index cache to disk
 	fixupCacheHook(ctx context.Context, block *btcutil.Block, c indexerCache) error         // Fixup cache
 	onSyncComplete()                                                                        // Called after sync reaches target
+	readCacheInfo() string                                                                  // Optional read cache stats for log line
 }
 
 // indexerCache exposes Cache management functions.
@@ -454,7 +455,8 @@ func (c *indexerCommon) parseBlocks(ctx context.Context, endHash *chainhash.Hash
 		// Try not to overshoot the cache to prevent costly allocations
 		_, _, pct := cache.Stats()
 		if bh.Height%10000 == 0 || pct > percentage || blocksProcessed == 1 {
-			log.Infof("%v indexer: %v cache %v%%", c, hh, pct)
+			log.Infof("%v indexer: %v cache %v%%%v", c, hh, pct,
+				c.p.readCacheInfo())
 		}
 
 		// Exit if we processed the provided end hash or hit 95% cache full.
@@ -526,7 +528,8 @@ func (c *indexerCommon) parseBlocksReverse(ctx context.Context, endHash *chainha
 		// Try not to overshoot the cache to prevent costly allocations
 		_, _, pct := cache.Stats()
 		if bh.Height%10000 == 0 || pct > percentage || blocksProcessed == 1 {
-			log.Infof("%v unindexer: %v cache %v%%", c, hh, pct)
+			log.Infof("%v unindexer: %v cache %v%%%v", c, hh, pct,
+				c.p.readCacheInfo())
 		}
 
 		// Move to previous block

--- a/service/tbc/keystoneindex.go
+++ b/service/tbc/keystoneindex.go
@@ -69,6 +69,8 @@ func (i *keystoneIndexer) fixupCacheHook(_ context.Context, _ *btcutil.Block, _ 
 
 func (i *keystoneIndexer) onSyncComplete() {}
 
+func (i *keystoneIndexer) readCacheInfo() string { return "" }
+
 // BlockKeystonesByHash returns all keystones within a block. If hash is not
 // nil then it returns *only* the keystone transactions where the L2
 // abbreviated hash is equal to the provided hash.

--- a/service/tbc/keystoneindex.go
+++ b/service/tbc/keystoneindex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -66,6 +66,8 @@ func (i *keystoneIndexer) fixupCacheHook(_ context.Context, _ *btcutil.Block, _ 
 	// Not needed for keystone indexer.
 	return nil
 }
+
+func (i *keystoneIndexer) onSyncComplete() {}
 
 // BlockKeystonesByHash returns all keystones within a block. If hash is not
 // nil then it returns *only* the keystone transactions where the L2

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -281,6 +281,7 @@ type Server struct {
 		mempoolCount, mempoolSize int
 		blockCache                tbcd.CacheStats
 		headerCache               tbcd.CacheStats
+		utxoReadCache             lru.Stats
 		diskFree                  uint64
 	} // periodically updated by promPoll
 	isRunning     bool
@@ -897,6 +898,36 @@ func (s *Server) promHeaderCacheItems() float64 {
 	return deucalion.IntToFloat(s.prom.headerCache.Items)
 }
 
+func (s *Server) promUtxoReadCacheHits() float64 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return deucalion.IntToFloat(s.prom.utxoReadCache.Hits)
+}
+
+func (s *Server) promUtxoReadCacheMisses() float64 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return deucalion.IntToFloat(s.prom.utxoReadCache.Misses)
+}
+
+func (s *Server) promUtxoReadCachePurges() float64 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return deucalion.IntToFloat(s.prom.utxoReadCache.Purges)
+}
+
+func (s *Server) promUtxoReadCacheSize() float64 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return deucalion.IntToFloat(s.prom.utxoReadCache.Cost)
+}
+
+func (s *Server) promUtxoReadCacheItems() float64 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return deucalion.IntToFloat(s.prom.utxoReadCache.Items)
+}
+
 func (s *Server) promDiskFree() float64 {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -931,6 +962,9 @@ func (s *Server) promPoll(ctx context.Context) error {
 		s.prom.connected, s.prom.good, s.prom.bad = s.pm.Stats()
 		s.prom.blockCache = s.g.db.BlockCacheStats()
 		s.prom.headerCache = s.g.db.BlockHeaderCacheStats()
+		if s.utxoReadCache != nil {
+			s.prom.utxoReadCache = s.utxoReadCache.Stats()
+		}
 		if s.cfg.MempoolEnabled {
 			s.prom.mempoolCount, s.prom.mempoolSize = s.mempool.stats(ctx)
 		}
@@ -2948,6 +2982,20 @@ func (s *Server) dbOpen(ctx context.Context) error {
 				cs.Hits, cs.Misses, cs.Purges, cs.Items)
 			s.utxoReadCache.Clear()
 		}
+	}, func() string {
+		if s.utxoReadCache == nil {
+			return ""
+		}
+		cs := s.utxoReadCache.Stats()
+		fill := 0
+		if cs.MaxCost > 0 {
+			fill = cs.Cost * 100 / cs.MaxCost
+		}
+		hitPct := 0
+		if total := cs.Hits + cs.Misses; total > 0 {
+			hitPct = cs.Hits * 100 / total
+		}
+		return fmt.Sprintf(" rcache hits %v%% usage %v%%", hitPct, fill)
 	})
 
 	// Initialize utxo read cache if configured.
@@ -2957,7 +3005,7 @@ func (s *Server) dbOpen(ctx context.Context) error {
 			return fmt.Errorf("utxo read cache size: %w", err)
 		}
 		if rcSize > 0 {
-			s.utxoReadCache, err = lru.New[tbcd.Outpoint, tbcd.ScriptHash](
+			s.utxoReadCache, err = lru.New(
 				int(rcSize),
 				func(_ tbcd.Outpoint, _ tbcd.ScriptHash) int {
 					// Outpoint=37 + ScriptHash=32 + overhead
@@ -2968,7 +3016,7 @@ func (s *Server) dbOpen(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("utxo read cache: %w", err)
 			}
-			log.Infof("utxo read cache: %v", humanize.Bytes(rcSize))
+			log.Infof("utxo read cache: %s", s.cfg.UtxoReadCacheSize)
 		}
 	}
 
@@ -3107,6 +3155,31 @@ func (s *Server) Collectors() []prometheus.Collector {
 				Name:      "block_cache_items",
 				Help:      "Number of cached blocks",
 			}, s.promBlockCacheItems),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "utxo_read_cache_hits",
+				Help:      "Utxo read cache hits",
+			}, s.promUtxoReadCacheHits),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "utxo_read_cache_misses",
+				Help:      "Utxo read cache misses",
+			}, s.promUtxoReadCacheMisses),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "utxo_read_cache_purges",
+				Help:      "Utxo read cache purges",
+			}, s.promUtxoReadCachePurges),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "utxo_read_cache_size",
+				Help:      "Utxo read cache size in bytes",
+			}, s.promUtxoReadCacheSize),
+			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+				Namespace: s.cfg.PrometheusNamespace,
+				Name:      "utxo_read_cache_items",
+				Help:      "Number of utxo read cache entries",
+			}, s.promUtxoReadCacheItems),
 			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 				Namespace: s.cfg.PrometheusNamespace,
 				Name:      "disk_free",

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -42,6 +42,7 @@ import (
 	dbnames "github.com/hemilabs/heminetwork/v2/database/level"
 	"github.com/hemilabs/heminetwork/v2/database/tbcd"
 	"github.com/hemilabs/heminetwork/v2/database/tbcd/level"
+	"github.com/hemilabs/heminetwork/v2/lru"
 	"github.com/hemilabs/heminetwork/v2/service/deucalion"
 	"github.com/hemilabs/heminetwork/v2/service/pprof"
 	"github.com/hemilabs/heminetwork/v2/service/tbc/peer/rawpeer"
@@ -189,6 +190,7 @@ type Config struct {
 	PprofListenAddress      string
 	Seeds                   []string
 	ZKIndex                 bool
+	UtxoReadCacheSize       string // LRU read cache for utxo fixup; "0" or "" disables
 
 	// Admin API
 	JWTSecret string // Hex-encoded JWT token for admin RPC authentication
@@ -211,6 +213,7 @@ func NewDefaultConfig() *Config {
 		MaxCachedKeystones:   defaultMaxCachedKeystones,
 		MaxCachedTxs:         defaultMaxCachedTxs,
 		MaxCachedZK:          defaultMaxZK,
+		UtxoReadCacheSize:    "1gb",
 		MempoolEnabled:       true,
 		NotificationBlocking: false, // Default anyway, but dangerous so be explicit
 		PeersWanted:          defaultPeersWanted,
@@ -228,6 +231,10 @@ type Server struct {
 
 	// fixup cache strategy
 	fixupCache func(ctx context.Context, b *btcutil.Block, utxos map[tbcd.Outpoint]tbcd.CacheOutput) error // XXX move this into utxoindexer.go
+
+	// utxo read cache survives across write cache flushes, reducing
+	// LevelDB reads for long-lived UTXOs. Cleared at tip.
+	utxoReadCache *lru.Cache[tbcd.Outpoint, tbcd.ScriptHash]
 
 	// stats
 	printTime      time.Time
@@ -2934,7 +2941,37 @@ func (s *Server) dbOpen(ctx context.Context) error {
 	case 3:
 		s.fixupCache = s.fixupCacheChannel
 	}
-	s.ui = NewUtxoIndexer(s.g, s.cfg.MaxCachedTxs, s.fixupCache)
+	s.ui = NewUtxoIndexer(s.g, s.cfg.MaxCachedTxs, s.fixupCache, func() {
+		if s.utxoReadCache != nil {
+			cs := s.utxoReadCache.Stats()
+			log.Infof("utxo read cache at tip: hits %v misses %v purges %v items %v",
+				cs.Hits, cs.Misses, cs.Purges, cs.Items)
+			s.utxoReadCache.Clear()
+		}
+	})
+
+	// Initialize utxo read cache if configured.
+	if s.cfg.UtxoReadCacheSize != "" && s.cfg.UtxoReadCacheSize != "0" {
+		rcSize, err := humanize.ParseBytes(s.cfg.UtxoReadCacheSize)
+		if err != nil {
+			return fmt.Errorf("utxo read cache size: %w", err)
+		}
+		if rcSize > 0 {
+			s.utxoReadCache, err = lru.New[tbcd.Outpoint, tbcd.ScriptHash](
+				int(rcSize),
+				func(_ tbcd.Outpoint, _ tbcd.ScriptHash) int {
+					// Outpoint=37 + ScriptHash=32 + overhead
+					return 37 + 32 + lru.EntryOverhead
+				},
+				0,
+			)
+			if err != nil {
+				return fmt.Errorf("utxo read cache: %w", err)
+			}
+			log.Infof("utxo read cache: %v", humanize.Bytes(rcSize))
+		}
+	}
+
 	s.ti = NewTxIndexer(s.g, s.cfg.MaxCachedTxs)
 	if s.cfg.HemiIndex {
 		s.ki = NewKeystoneIndexer(s.g, s.cfg.MaxCachedKeystones,

--- a/service/tbc/txindex.go
+++ b/service/tbc/txindex.go
@@ -64,6 +64,8 @@ func (i *txIndexer) fixupCacheHook(_ context.Context, _ *btcutil.Block, _ indexe
 
 func (i *txIndexer) onSyncComplete() {}
 
+func (i *txIndexer) readCacheInfo() string { return "" }
+
 func processTxs(ctx context.Context, block *btcutil.Block, direction int, txsCache map[tbcd.TxKey]*tbcd.TxValue) error {
 	blockHash := block.Hash()
 	txs := block.Transactions()

--- a/service/tbc/txindex.go
+++ b/service/tbc/txindex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -61,6 +61,8 @@ func (i *txIndexer) fixupCacheHook(_ context.Context, _ *btcutil.Block, _ indexe
 	// Not needed for tx indexer.
 	return nil
 }
+
+func (i *txIndexer) onSyncComplete() {}
 
 func processTxs(ctx context.Context, block *btcutil.Block, direction int, txsCache map[tbcd.TxKey]*tbcd.TxValue) error {
 	blockHash := block.Hash()

--- a/service/tbc/utxoindex.go
+++ b/service/tbc/utxoindex.go
@@ -22,9 +22,10 @@ import (
 type utxoIndexer struct {
 	indexerCommon
 
-	cacheCapacity    int
-	fixupHook        fixupCacheFunc
-	syncCompleteHook func() // called by framework after sync reaches target
+	cacheCapacity     int
+	fixupHook         fixupCacheFunc
+	syncCompleteHook  func() // called by framework after sync reaches target
+	readCacheInfoHook func() string
 }
 
 var (
@@ -34,11 +35,12 @@ var (
 
 type fixupCacheFunc func(context.Context, *btcutil.Block, map[tbcd.Outpoint]tbcd.CacheOutput) error
 
-func NewUtxoIndexer(g geometryParams, cacheLen int, f fixupCacheFunc, syncComplete func()) Indexer {
+func NewUtxoIndexer(g geometryParams, cacheLen int, f fixupCacheFunc, syncComplete func(), readCacheInfo func() string) Indexer {
 	uxi := &utxoIndexer{
-		cacheCapacity:    cacheLen,
-		fixupHook:        f,
-		syncCompleteHook: syncComplete,
+		cacheCapacity:     cacheLen,
+		fixupHook:         f,
+		syncCompleteHook:  syncComplete,
+		readCacheInfoHook: readCacheInfo,
 	}
 	uxi.indexerCommon = indexerCommon{
 		name:    "utxo",
@@ -80,6 +82,13 @@ func (i *utxoIndexer) onSyncComplete() {
 	if i.syncCompleteHook != nil {
 		i.syncCompleteHook()
 	}
+}
+
+func (i *utxoIndexer) readCacheInfo() string {
+	if i.readCacheInfoHook != nil {
+		return i.readCacheInfoHook()
+	}
+	return ""
 }
 
 func processUtxos(block *btcutil.Block, utxos map[tbcd.Outpoint]tbcd.CacheOutput) error {

--- a/service/tbc/utxoindex.go
+++ b/service/tbc/utxoindex.go
@@ -22,8 +22,9 @@ import (
 type utxoIndexer struct {
 	indexerCommon
 
-	cacheCapacity int
-	fixupHook     fixupCacheFunc
+	cacheCapacity    int
+	fixupHook        fixupCacheFunc
+	syncCompleteHook func() // called by framework after sync reaches target
 }
 
 var (
@@ -33,10 +34,11 @@ var (
 
 type fixupCacheFunc func(context.Context, *btcutil.Block, map[tbcd.Outpoint]tbcd.CacheOutput) error
 
-func NewUtxoIndexer(g geometryParams, cacheLen int, f fixupCacheFunc) Indexer {
+func NewUtxoIndexer(g geometryParams, cacheLen int, f fixupCacheFunc, syncComplete func()) Indexer {
 	uxi := &utxoIndexer{
-		cacheCapacity: cacheLen,
-		fixupHook:     f,
+		cacheCapacity:    cacheLen,
+		fixupHook:        f,
+		syncCompleteHook: syncComplete,
 	}
 	uxi.indexerCommon = indexerCommon{
 		name:    "utxo",
@@ -72,6 +74,12 @@ func (i *utxoIndexer) commit(ctx context.Context, direction int, atHash chainhas
 func (i *utxoIndexer) fixupCacheHook(ctx context.Context, block *btcutil.Block, c indexerCache) error {
 	cache := c.(*Cache[tbcd.Outpoint, tbcd.CacheOutput])
 	return i.fixupHook(ctx, block, cache.Map())
+}
+
+func (i *utxoIndexer) onSyncComplete() {
+	if i.syncCompleteHook != nil {
+		i.syncCompleteHook()
+	}
 }
 
 func processUtxos(block *btcutil.Block, utxos map[tbcd.Outpoint]tbcd.CacheOutput) error {
@@ -189,6 +197,16 @@ func (s *Server) fetchOPParallel(ctx context.Context, c chan struct{}, w *sync.W
 		}()
 	}
 
+	// Check read cache before hitting LevelDB.
+	if s.utxoReadCache != nil {
+		if sh, ok := s.utxoReadCache.Get(op); ok {
+			s.mtx.Lock()
+			utxos[op] = tbcd.NewDeleteCacheOutput(sh, op.TxIndex())
+			s.mtx.Unlock()
+			return
+		}
+	}
+
 	sh, err := s.g.db.ScriptHashByOutpoint(ctx, op)
 	if err != nil {
 		// This happens when a transaction is created and spent in the
@@ -198,6 +216,12 @@ func (s *Server) fetchOPParallel(ctx context.Context, c chan struct{}, w *sync.W
 		log.Debugf("db missing pkscript: %v", op)
 		return
 	}
+
+	// Populate read cache on DB hit.
+	if s.utxoReadCache != nil {
+		s.utxoReadCache.Put(op, *sh)
+	}
+
 	s.mtx.Lock()
 	utxos[op] = tbcd.NewDeleteCacheOutput(*sh, op.TxIndex())
 	s.mtx.Unlock()
@@ -246,12 +270,26 @@ func (s *Server) fixupCacheSerial(ctx context.Context, b *btcutil.Block, utxos m
 				continue
 			}
 
+			// Check read cache before DB.
+			if s.utxoReadCache != nil {
+				if sh, ok := s.utxoReadCache.Get(op); ok {
+					utxos[op] = tbcd.NewDeleteCacheOutput(sh, op.TxIndex())
+					continue
+				}
+			}
+
 			sh, err := s.g.db.ScriptHashByOutpoint(ctx, op)
 			if err != nil {
 				// This happens when a transaction is created
 				// and spent in the same block.
 				continue
 			}
+
+			// Populate read cache on DB hit.
+			if s.utxoReadCache != nil {
+				s.utxoReadCache.Put(op, *sh)
+			}
+
 			// utxo not found, retrieve pkscript from database.
 			utxos[op] = tbcd.NewDeleteCacheOutput(*sh, op.TxIndex())
 		}
@@ -276,11 +314,23 @@ func (s *Server) fixupCacheBatched(ctx context.Context, b *btcutil.Block, utxos 
 				continue
 			}
 
+			// Check read cache before adding to batch.
+			if s.utxoReadCache != nil {
+				if sh, ok := s.utxoReadCache.Get(op); ok {
+					utxos[op] = tbcd.NewDeleteCacheOutput(sh, op.TxIndex())
+					continue
+				}
+			}
+
 			ops = append(ops, &op)
 		}
 	}
 	found := func(op tbcd.Outpoint, sh tbcd.ScriptHash) error {
 		utxos[op] = tbcd.NewDeleteCacheOutput(sh, op.TxIndex())
+		// Populate read cache on DB hit.
+		if s.utxoReadCache != nil {
+			s.utxoReadCache.Put(op, sh)
+		}
 		return nil
 	}
 	return s.g.db.ScriptHashesByOutpoint(ctx, ops, found)

--- a/service/tbc/utxoindex_cache_test.go
+++ b/service/tbc/utxoindex_cache_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package tbc
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+
+	"github.com/hemilabs/heminetwork/v2/database/tbcd"
+	"github.com/hemilabs/heminetwork/v2/lru"
+)
+
+// utxoReadCacheSizeOf matches production sizeOf in tbc.go.
+func utxoReadCacheSizeOf(_ tbcd.Outpoint, _ tbcd.ScriptHash) int {
+	return 37 + 32 + lru.EntryOverhead
+}
+
+func makeOutpoint(txIdx byte, outIdx uint32) tbcd.Outpoint {
+	var h chainhash.Hash
+	h[0] = txIdx
+	return tbcd.NewOutpoint(h, outIdx)
+}
+
+func makeScriptHash(b byte) tbcd.ScriptHash {
+	var sh tbcd.ScriptHash
+	sh[0] = b
+	return sh
+}
+
+func TestUtxoReadCachePutGet(t *testing.T) {
+	const budget = 10 * (37 + 32 + lru.EntryOverhead) // room for 10 entries
+	c, err := lru.New[tbcd.Outpoint, tbcd.ScriptHash](budget, utxoReadCacheSizeOf, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	op := makeOutpoint(1, 0)
+	sh := makeScriptHash(0xaa)
+	c.Put(op, sh)
+
+	got, ok := c.Get(op)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got != sh {
+		t.Fatalf("expected %x, got %x", sh, got)
+	}
+
+	s := c.Stats()
+	if s.Hits != 1 || s.Misses != 0 || s.Items != 1 {
+		t.Fatalf("unexpected stats: %+v", s)
+	}
+}
+
+func TestUtxoReadCacheLRUEviction(t *testing.T) {
+	const n = 5
+	const budget = n * (37 + 32 + lru.EntryOverhead) // exactly n entries
+	c, err := lru.New[tbcd.Outpoint, tbcd.ScriptHash](budget, utxoReadCacheSizeOf, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fill cache to capacity.
+	for i := range n {
+		c.Put(makeOutpoint(byte(i), 0), makeScriptHash(byte(i)))
+	}
+	if c.Len() != n {
+		t.Fatalf("expected %d items, got %d", n, c.Len())
+	}
+
+	// Touch entry 0 to make it MRU.
+	c.Get(makeOutpoint(0, 0))
+
+	// Insert entry n — should evict entry 1 (LRU), not entry 0.
+	c.Put(makeOutpoint(byte(n), 0), makeScriptHash(byte(n)))
+
+	if c.Len() != n {
+		t.Fatalf("expected %d items after eviction, got %d", n, c.Len())
+	}
+
+	// Entry 0 survived (was MRU).
+	if _, ok := c.Get(makeOutpoint(0, 0)); !ok {
+		t.Fatal("expected entry 0 to survive (MRU)")
+	}
+
+	// Entry 1 evicted (was LRU).
+	if _, ok := c.Get(makeOutpoint(1, 0)); ok {
+		t.Fatal("expected entry 1 evicted (LRU)")
+	}
+
+	// New entry present.
+	if _, ok := c.Get(makeOutpoint(byte(n), 0)); !ok {
+		t.Fatal("expected new entry present")
+	}
+
+	s := c.Stats()
+	if s.Purges != 1 {
+		t.Fatalf("expected 1 purge, got %d", s.Purges)
+	}
+}
+
+func TestUtxoReadCacheSimulateFlushCycle(t *testing.T) {
+	// Simulate: write cache fills, flushes, clears. Read cache survives.
+	// Next batch re-reads same UTXOs — should hit read cache, not DB.
+	const budget = 100 * (37 + 32 + lru.EntryOverhead)
+	readCache, err := lru.New[tbcd.Outpoint, tbcd.ScriptHash](budget, utxoReadCacheSizeOf, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Batch 1: "DB reads" populate the read cache.
+	for i := range 10 {
+		op := makeOutpoint(byte(i), 0)
+		sh := makeScriptHash(byte(i))
+		readCache.Put(op, sh) // simulate DB hit → cache populate
+	}
+
+	s := readCache.Stats()
+	if s.Items != 10 {
+		t.Fatalf("batch 1: expected 10 items, got %d", s.Items)
+	}
+
+	// Simulate write cache flush + clear. Read cache NOT cleared.
+	// (Write cache is a separate object; nothing happens to readCache.)
+
+	// Batch 2: same outpoints re-read — should all hit read cache.
+	for i := range 10 {
+		op := makeOutpoint(byte(i), 0)
+		_, ok := readCache.Get(op)
+		if !ok {
+			t.Fatalf("batch 2: expected cache hit for outpoint %d", i)
+		}
+	}
+
+	s = readCache.Stats()
+	if s.Hits != 10 {
+		t.Fatalf("expected 10 hits in batch 2, got %d", s.Hits)
+	}
+	if s.Misses != 0 {
+		t.Fatalf("expected 0 misses in batch 2, got %d", s.Misses)
+	}
+}
+
+func TestUtxoReadCachePurgeOnSyncComplete(t *testing.T) {
+	const budget = 100 * (37 + 32 + lru.EntryOverhead)
+	readCache, err := lru.New[tbcd.Outpoint, tbcd.ScriptHash](budget, utxoReadCacheSizeOf, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Populate.
+	for i := range 20 {
+		readCache.Put(makeOutpoint(byte(i), 0), makeScriptHash(byte(i)))
+	}
+	if readCache.Len() != 20 {
+		t.Fatalf("expected 20 items, got %d", readCache.Len())
+	}
+
+	// Wire the hook the same way Server does.
+	cleared := false
+	hook := func() {
+		readCache.Clear()
+		cleared = true
+	}
+
+	// Create a utxoIndexer with the hook.
+	uxi := &utxoIndexer{
+		syncCompleteHook: hook,
+	}
+
+	// Framework calls onSyncComplete.
+	uxi.onSyncComplete()
+
+	if !cleared {
+		t.Fatal("syncCompleteHook was not called")
+	}
+	if readCache.Len() != 0 {
+		t.Fatalf("expected empty cache after purge, got %d", readCache.Len())
+	}
+
+	// Cache is usable again after clear.
+	readCache.Put(makeOutpoint(0xff, 0), makeScriptHash(0xff))
+	if readCache.Len() != 1 {
+		t.Fatalf("expected 1 item after re-use, got %d", readCache.Len())
+	}
+}
+
+func TestUtxoReadCacheNilHookSafe(t *testing.T) {
+	// onSyncComplete with nil hook must not panic.
+	uxi := &utxoIndexer{}
+	uxi.onSyncComplete() // should be a no-op
+}

--- a/service/tbc/utxoindex_test.go
+++ b/service/tbc/utxoindex_test.go
@@ -5,12 +5,22 @@
 package tbc
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/juju/loggo/v2"
 
 	"github.com/hemilabs/heminetwork/v2/database/tbcd"
+	"github.com/hemilabs/heminetwork/v2/internal/testutil"
 	"github.com/hemilabs/heminetwork/v2/lru"
+	"github.com/hemilabs/heminetwork/v2/service/tbc/peer/rawpeer"
 )
 
 // utxoReadCacheSizeOf matches production sizeOf in tbc.go.
@@ -192,4 +202,178 @@ func TestUtxoReadCacheNilHookSafe(t *testing.T) {
 	// onSyncComplete with nil hook must not panic.
 	uxi := &utxoIndexer{}
 	uxi.onSyncComplete() // should be a no-op
+}
+
+func TestUtxoReadCacheInfoHook(t *testing.T) {
+	const budget = 10 * (37 + 32 + lru.EntryOverhead)
+	c, err := lru.New[tbcd.Outpoint, tbcd.ScriptHash](budget, utxoReadCacheSizeOf, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	uxi := &utxoIndexer{
+		readCacheInfoHook: func() string {
+			cs := c.Stats()
+			fill := 0
+			if cs.MaxCost > 0 {
+				fill = cs.Cost * 100 / cs.MaxCost
+			}
+			hitPct := 0
+			if total := cs.Hits + cs.Misses; total > 0 {
+				hitPct = cs.Hits * 100 / total
+			}
+			return fmt.Sprintf(" rcache hits %v%% usage %v%%", hitPct, fill)
+		},
+	}
+
+	// Empty cache — 0 hits, 0% fill.
+	info := uxi.readCacheInfo()
+	if info != " rcache hits 0% usage 0%" {
+		t.Fatalf("unexpected empty info: %q", info)
+	}
+
+	// Populate 5 entries.
+	for i := range 5 {
+		c.Put(makeOutpoint(byte(i), 0), makeScriptHash(byte(i)))
+	}
+	// Hit 3 of them.
+	for i := range 3 {
+		c.Get(makeOutpoint(byte(i), 0))
+	}
+
+	info = uxi.readCacheInfo()
+	if info != " rcache hits 100% usage 50%" {
+		t.Fatalf("unexpected info: %q", info)
+	}
+}
+
+func TestUtxoReadCacheInfoNilHook(t *testing.T) {
+	uxi := &utxoIndexer{}
+	if info := uxi.readCacheInfo(); info != "" {
+		t.Fatalf("expected empty string, got %q", info)
+	}
+}
+
+func TestLRUStatsMaxCost(t *testing.T) {
+	const budget = 1000
+	c, err := lru.New[string, string](budget, func(k, v string) int {
+		return len(k) + len(v) + lru.EntryOverhead
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := c.Stats()
+	if s.MaxCost != budget {
+		t.Fatalf("expected MaxCost %d, got %d", budget, s.MaxCost)
+	}
+}
+
+func TestUtxoReadCacheIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	n, err := newFakeNode(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := n.Stop(); err != nil {
+			t.Logf("node stop: %v", err)
+		}
+	}()
+
+	go func() {
+		if err := n.Run(ctx); !testutil.ErrorIsOneOf(err, []error{net.ErrClosed, context.Canceled, rawpeer.ErrNoConn}) {
+			panic(err)
+		}
+	}()
+
+	cfg := &Config{
+		AutoIndex:               false,
+		BlockSanity:             false,
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            3, // small write cache to force flushes
+		Network:                 networkLocalnet,
+		PeersWanted:             1,
+		PrometheusListenAddress: "",
+		MempoolEnabled:          false,
+		Seeds:                   []string{n.Address()},
+		NotificationBlocking:    true,
+		UtxoReadCacheSize:       "1mb",
+	}
+	_ = loggo.ConfigureLoggers(cfg.LogLevel)
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := s.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, rawpeer.ErrNoConn) && !errors.Is(err, net.ErrClosed) {
+			panic(err)
+		}
+	}()
+
+	// Wait for peer connection.
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-n.msgCh:
+	}
+
+	const blockCount = 20
+	blocks := make([]*block, blockCount)
+
+	prevHash := chaincfg.RegressionNetParams.GenesisHash
+	for i := 1; i <= blockCount; i++ {
+		blk, err := n.MineAndSend(ctx, "b"+strconv.Itoa(i), prevHash, n.address, MineWithMultiple)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prevHash = blk.Hash()
+		blocks[i-1] = blk
+	}
+
+	if err := n.MineAndSendEmpty(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.waitForBlocks(ctx, l, n.blocksAtHeight); err != nil {
+		t.Fatal(err)
+	}
+	l.Unsubscribe()
+
+	// Index to tip — fixup strategies will exercise the read cache.
+	if err := s.SyncIndexersToHash(ctx, *blocks[blockCount-1].Hash()); err != nil {
+		t.Fatal(err)
+	}
+
+	// After sync completes, onSyncComplete clears items but stats survive.
+	if s.utxoReadCache == nil {
+		t.Fatal("expected utxoReadCache to be initialized after Run")
+	}
+	cs := s.utxoReadCache.Stats()
+
+	t.Logf("read cache stats: hits=%d misses=%d purges=%d items=%d cost=%d",
+		cs.Hits, cs.Misses, cs.Purges, cs.Items, cs.Cost)
+
+	// The cache must have been exercised during fixup.
+	if cs.Hits+cs.Misses == 0 {
+		t.Fatal("expected read cache to be exercised during indexing (hits+misses > 0)")
+	}
+
+	// onSyncComplete should have cleared the cache.
+	if cs.Items != 0 {
+		t.Fatalf("expected 0 items after sync complete, got %d", cs.Items)
+	}
+	if cs.Cost != 0 {
+		t.Fatalf("expected 0 cost after sync complete, got %d", cs.Cost)
+	}
 }

--- a/service/tbc/zkindexer.go
+++ b/service/tbc/zkindexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -233,3 +233,5 @@ func (i *zkIndexer) fixupCacheHook(_ context.Context, _ *btcutil.Block, _ indexe
 	// Not needed for zk indexer.
 	return nil
 }
+
+func (i *zkIndexer) onSyncComplete() {}

--- a/service/tbc/zkindexer.go
+++ b/service/tbc/zkindexer.go
@@ -235,3 +235,5 @@ func (i *zkIndexer) fixupCacheHook(_ context.Context, _ *btcutil.Block, _ indexe
 }
 
 func (i *zkIndexer) onSyncComplete() {}
+
+func (i *zkIndexer) readCacheInfo() string { return "" }


### PR DESCRIPTION
Add a read-through LRU cache for UTXO script hash lookups that survives across write cache flushes. Reduces LevelDB reads in
all four fixup strategies for long-lived UTXOs that are repeatedly re-read after each flush cycle.
    
Add onSyncComplete() to the indexer interface. The framework calls it automatically after IndexToBest and IndexToHash complete. The utxo indexer clears its read cache via this hook; all other indexers are no-ops.

depends on #1034 
