### PR TITLE
tbc: correct Synced() boolean for disabled indexers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   witness-inclusive after a v5 upgrade plus resync
   ([#972](https://github.com/hemilabs/heminetwork/pull/972)).
 
+- Fix inverted conditions in `synced()` causing tbcd to incorrectly report
+  itself as not-synced when an optional indexer is enabled.
+  ([#1036](https://github.com/hemilabs/heminetwork/pull/1036))
+
 ## [v2.0.0]
 
 ### Breaking Changes

--- a/service/tbc/synced_test.go
+++ b/service/tbc/synced_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package tbc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+
+	"github.com/hemilabs/heminetwork/v2/database/tbcd"
+)
+
+// syncedDB embeds stubDB and overrides the two methods synced() needs.
+type syncedDB struct {
+	stubDB
+	best    *tbcd.BlockHeader
+	missing []tbcd.BlockIdentifier
+}
+
+func (d *syncedDB) BlockHeaderBest(context.Context) (*tbcd.BlockHeader, error) {
+	return d.best, nil
+}
+
+func (d *syncedDB) BlocksMissing(context.Context, int) ([]tbcd.BlockIdentifier, error) {
+	return d.missing, nil
+}
+
+// stubIndexer implements Indexer for synced() tests.
+type stubIndexer struct {
+	bh *tbcd.BlockHeader
+}
+
+func (si *stubIndexer) Enabled() bool                                        { return true }
+func (si *stubIndexer) Indexing() bool                                       { return false }
+func (si *stubIndexer) IndexToBest(context.Context) error                    { panic("stub") }
+func (si *stubIndexer) IndexToHash(context.Context, chainhash.Hash) error    { panic("stub") }
+func (si *stubIndexer) IndexerAt(context.Context) (*tbcd.BlockHeader, error) { return si.bh, nil }
+
+func TestSynced(t *testing.T) {
+	tipHash := chainhash.Hash{0x01} // non-zero
+	staleHash := chainhash.Hash{0x02}
+
+	tipBH := &tbcd.BlockHeader{Hash: tipHash, Height: 100}
+	staleBH := &tbcd.BlockHeader{Hash: staleHash, Height: 99}
+
+	tests := []struct {
+		name      string
+		hemiIndex bool
+		zkIndex   bool
+		keystone  *tbcd.BlockHeader
+		zk        *tbcd.BlockHeader
+		wantSync  bool
+	}{
+		{
+			name:      "both indexes disabled",
+			hemiIndex: false,
+			zkIndex:   false,
+			wantSync:  true,
+		},
+		{
+			name:      "hemi enabled at tip",
+			hemiIndex: true,
+			zkIndex:   false,
+			keystone:  tipBH,
+			wantSync:  true,
+		},
+		{
+			name:      "hemi enabled behind tip",
+			hemiIndex: true,
+			zkIndex:   false,
+			keystone:  staleBH,
+			wantSync:  false,
+		},
+		{
+			name:      "zk enabled at tip",
+			hemiIndex: false,
+			zkIndex:   true,
+			zk:        tipBH,
+			wantSync:  true,
+		},
+		{
+			name:      "zk enabled behind tip",
+			hemiIndex: false,
+			zkIndex:   true,
+			zk:        staleBH,
+			wantSync:  false,
+		},
+		{
+			name:      "both enabled at tip",
+			hemiIndex: true,
+			zkIndex:   true,
+			keystone:  tipBH,
+			zk:        tipBH,
+			wantSync:  true,
+		},
+		{
+			name:      "both enabled hemi behind",
+			hemiIndex: true,
+			zkIndex:   true,
+			keystone:  staleBH,
+			zk:        tipBH,
+			wantSync:  false,
+		},
+		{
+			name:      "both enabled zk behind",
+			hemiIndex: true,
+			zkIndex:   true,
+			keystone:  tipBH,
+			zk:        staleBH,
+			wantSync:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &syncedDB{
+				best:    tipBH,
+				missing: nil,
+			}
+			s := &Server{
+				cfg: &Config{
+					HemiIndex: tt.hemiIndex,
+					ZKIndex:   tt.zkIndex,
+				},
+				g: geometryParams{db: db},
+				// UTXO and TX indexers at tip.
+				ui: &stubIndexer{bh: tipBH},
+				ti: &stubIndexer{bh: tipBH},
+			}
+			if tt.keystone != nil {
+				s.ki = &stubIndexer{bh: tt.keystone}
+			}
+			if tt.zk != nil {
+				s.zki = &stubIndexer{bh: tt.zk}
+			}
+
+			si := s.synced(t.Context())
+			if si.Synced != tt.wantSync {
+				t.Errorf("synced() = %v, want %v", si.Synced, tt.wantSync)
+			}
+		})
+	}
+}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -2857,16 +2857,11 @@ func (s *Server) synced(ctx context.Context) (si SyncInfo) {
 
 	if utxoHH.Hash.IsEqual(&bhb.Hash) && txHH.Hash.IsEqual(&bhb.Hash) &&
 		!s.indexing && !blksMissing {
-		// If keystone and zk indexers are disabled we are synced.
-		if !s.cfg.HemiIndex && !s.cfg.ZKIndex {
-			si.Synced = true
-			return si
-		}
-		if !(s.cfg.HemiIndex && si.Keystone.Hash.IsEqual(&bhb.Hash)) {
+		if s.cfg.HemiIndex && !si.Keystone.Hash.IsEqual(&bhb.Hash) {
 			// Keystone index not synced
 			return si
 		}
-		if !(s.cfg.ZKIndex && si.ZK.Hash.IsEqual(&bhb.Hash)) {
+		if s.cfg.ZKIndex && !si.ZK.Hash.IsEqual(&bhb.Hash) {
 			// ZK index not synced
 			return si
 		}


### PR DESCRIPTION
The HemiIndex and ZKIndex checks in synced() used inverted logic: !(cfg && hash.IsEqual) evaluates to true when the index is disabled, causing Synced() to always return false. This triggers the sync loop to request headers from all peers in a tight loop at tip, pegging the CPU indefinitely.

Fix the condition to skip the check when the index is disabled:
  before: !(s.cfg.Index && hash.IsEqual(&best))