### PR TITLE
popmd: add maximum fee configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implementation backed by TBC RPC
   ([#971](https://github.com/hemilabs/heminetwork/pull/971)).
 - Add multiple RPC commands to regular and authenticated TBC routes ([#1026](https://github.com/hemilabs/heminetwork/pull/1026)).
+- Add maximum fee configuration to `popmd` ([#1037](https://github.com/hemilabs/heminetwork/pull/1037)).
 
 ### Changed
 

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -229,8 +229,8 @@ type L2KeystoneBlockInfo struct {
 }
 
 type FeeEstimate struct {
-	Blocks      uint    `json:"blocks"`
-	SatsPerByte float64 `json:"sats_per_byte"`
+	Blocks       uint    `json:"blocks"`
+	SatsPerVByte float64 `json:"sats_per_vbyte"`
 }
 
 // BlockByHashRequest requests a [Block] by its hash.

--- a/bitcoin/wallet/gozer/blockstream/blockstream.go
+++ b/bitcoin/wallet/gozer/blockstream/blockstream.go
@@ -104,7 +104,7 @@ func (bs *blockstreamGozer) FeeEstimates(ctx context.Context) ([]*tbcapi.FeeEsti
 
 	frv := make([]*tbcapi.FeeEstimate, 0, len(fm))
 	for k, v := range fm {
-		frv = append(frv, &tbcapi.FeeEstimate{Blocks: k, SatsPerByte: v})
+		frv = append(frv, &tbcapi.FeeEstimate{Blocks: k, SatsPerVByte: v})
 	}
 
 	return frv, nil

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -179,8 +179,8 @@ func TestTBCGozerCalls(t *testing.T) {
 	if feeEstimate.Blocks != blocks {
 		t.Fatalf("got %v, wanted %v", feeEstimate.Blocks, blocks)
 	}
-	if feeEstimate.SatsPerByte != expectedSats {
-		t.Fatalf("got %v, wanted %v", feeEstimate.SatsPerByte, expectedSats)
+	if feeEstimate.SatsPerVByte != expectedSats {
+		t.Fatalf("got %v, wanted %v", feeEstimate.SatsPerVByte, expectedSats)
 	}
 
 	expectedAmount, _ := btcutil.NewAmount(0.01)
@@ -234,9 +234,9 @@ func TestTBCGozerCalls(t *testing.T) {
 				panic(fmt.Sprintf("got %v != wanted %v",
 					fe.Blocks, feeEstimate.Blocks))
 			}
-			if fe.SatsPerByte != feeEstimate.SatsPerByte {
+			if fe.SatsPerVByte != feeEstimate.SatsPerVByte {
 				panic(fmt.Sprintf("got %v != wanted %v",
-					fe.SatsPerByte, feeEstimate.SatsPerByte))
+					fe.SatsPerVByte, feeEstimate.SatsPerVByte))
 			}
 
 			us, err := b.UtxosByAddress(ctx, true, testAddr, 0, 0)

--- a/bitcoin/wallet/vsize_test.go
+++ b/bitcoin/wallet/vsize_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/txsizes"
+)
+
+// makeScript constructs minimal valid scripts for each address type.
+// These are structurally valid enough for IsPayTo* classification.
+
+func makeP2PKHScript() []byte {
+	// OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
+	s := make([]byte, 25)
+	s[0] = txscript.OP_DUP
+	s[1] = txscript.OP_HASH160
+	s[2] = txscript.OP_DATA_20
+	// bytes 3..22 are the pubkey hash (zeros are fine for classification)
+	s[23] = txscript.OP_EQUALVERIFY
+	s[24] = txscript.OP_CHECKSIG
+	return s
+}
+
+func makeP2WPKHScript() []byte {
+	// OP_0 <20-byte witness program>
+	s := make([]byte, 22)
+	s[0] = txscript.OP_0
+	s[1] = txscript.OP_DATA_20
+	// bytes 2..21 are the witness program
+	return s
+}
+
+func makeP2TRScript() []byte {
+	// OP_1 <32-byte witness program>
+	s := make([]byte, 34)
+	s[0] = txscript.OP_1
+	s[1] = txscript.OP_DATA_32
+	// bytes 2..33 are the witness program
+	return s
+}
+
+func makeP2SHScript() []byte {
+	// OP_HASH160 <20-byte script hash> OP_EQUAL
+	s := make([]byte, 23)
+	s[0] = txscript.OP_HASH160
+	s[1] = txscript.OP_DATA_20
+	// bytes 2..21 are the script hash
+	s[22] = txscript.OP_EQUAL
+	return s
+}
+
+// dummyTxOut returns a minimal TxOut for size estimation.
+func dummyTxOut() *wire.TxOut {
+	return wire.NewTxOut(100000, makeP2PKHScript())
+}
+
+func TestEstimateVSize(t *testing.T) {
+	txOuts := []*wire.TxOut{dummyTxOut()}
+
+	tests := []struct {
+		name      string
+		script    []byte
+		numInputs int
+		// Expected values are computed by calling EstimateVirtualSize
+		// directly with the correct input-type slot filled in.
+		wantFunc func(n int, outs []*wire.TxOut, changeSize int) int
+	}{
+		{
+			name:      "p2pkh single input",
+			script:    makeP2PKHScript(),
+			numInputs: 1,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(n, 0, 0, 0, outs, cs)
+			},
+		},
+		{
+			name:      "p2pkh multiple inputs",
+			script:    makeP2PKHScript(),
+			numInputs: 5,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(n, 0, 0, 0, outs, cs)
+			},
+		},
+		{
+			name:      "p2wpkh single input",
+			script:    makeP2WPKHScript(),
+			numInputs: 1,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(0, 0, n, 0, outs, cs)
+			},
+		},
+		{
+			name:      "p2wpkh multiple inputs",
+			script:    makeP2WPKHScript(),
+			numInputs: 3,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(0, 0, n, 0, outs, cs)
+			},
+		},
+		{
+			name:      "p2tr single input",
+			script:    makeP2TRScript(),
+			numInputs: 1,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(0, n, 0, 0, outs, cs)
+			},
+		},
+		{
+			name:      "p2tr multiple inputs",
+			script:    makeP2TRScript(),
+			numInputs: 4,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(0, n, 0, 0, outs, cs)
+			},
+		},
+		{
+			name:      "p2sh single input (nested segwit)",
+			script:    makeP2SHScript(),
+			numInputs: 1,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(0, 0, 0, n, outs, cs)
+			},
+		},
+		{
+			name:      "p2sh multiple inputs",
+			script:    makeP2SHScript(),
+			numInputs: 2,
+			wantFunc: func(n int, outs []*wire.TxOut, cs int) int {
+				return txsizes.EstimateVirtualSize(0, 0, 0, n, outs, cs)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := estimateVSize(tc.numInputs, tc.script, txOuts)
+			want := tc.wantFunc(tc.numInputs, txOuts, len(tc.script))
+			if got != want {
+				t.Errorf("estimateVSize() = %d, want %d", got, want)
+			}
+			if got <= 0 {
+				t.Errorf("estimateVSize() = %d, expected positive value", got)
+			}
+		})
+	}
+}
+
+func TestEstimateVSizeUnknownScript(t *testing.T) {
+	txOuts := []*wire.TxOut{dummyTxOut()}
+
+	// Unknown/garbage scripts should fall through to P2PKH (safe overestimate).
+	unknownScripts := []struct {
+		name   string
+		script []byte
+	}{
+		{"empty script", []byte{}},
+		{"single byte", []byte{0xff}},
+		{"op_return", []byte{txscript.OP_RETURN, 0x04, 0xde, 0xad, 0xbe, 0xef}},
+		{"random garbage", []byte{0x01, 0x02, 0x03, 0x04, 0x05}},
+	}
+
+	for _, tc := range unknownScripts {
+		t.Run(tc.name, func(t *testing.T) {
+			got := estimateVSize(1, tc.script, txOuts)
+			want := txsizes.EstimateVirtualSize(1, 0, 0, 0, txOuts, len(tc.script))
+			if got != want {
+				t.Errorf("estimateVSize() = %d, want %d (p2pkh fallback)", got, want)
+			}
+		})
+	}
+}
+
+func TestEstimateVSizeWitnessDiscount(t *testing.T) {
+	// Verify that witness types produce smaller vsize than legacy for the
+	// same number of inputs.  This is the whole point of the fix: if the
+	// old EstimateSerializeSize was used, all types would return the same
+	// (P2PKH) size.
+	txOuts := []*wire.TxOut{dummyTxOut()}
+	numInputs := 2
+
+	p2pkh := estimateVSize(numInputs, makeP2PKHScript(), txOuts)
+	p2wpkh := estimateVSize(numInputs, makeP2WPKHScript(), txOuts)
+	p2tr := estimateVSize(numInputs, makeP2TRScript(), txOuts)
+
+	if p2wpkh >= p2pkh {
+		t.Errorf("P2WPKH vsize (%d) should be less than P2PKH (%d)", p2wpkh, p2pkh)
+	}
+	if p2tr >= p2pkh {
+		t.Errorf("P2TR vsize (%d) should be less than P2PKH (%d)", p2tr, p2pkh)
+	}
+}
+
+func TestEstimateVSizeNilScript(t *testing.T) {
+	txOuts := []*wire.TxOut{dummyTxOut()}
+
+	// nil script should not panic — falls through to P2PKH default.
+	got := estimateVSize(1, nil, txOuts)
+	want := txsizes.EstimateVirtualSize(1, 0, 0, 0, txOuts, 0)
+	if got != want {
+		t.Errorf("estimateVSize(nil) = %d, want %d", got, want)
+	}
+}
+
+func TestEstimateVSizeZeroInputs(t *testing.T) {
+	txOuts := []*wire.TxOut{dummyTxOut()}
+
+	// Zero inputs should not panic; result is the base tx overhead.
+	got := estimateVSize(0, makeP2PKHScript(), txOuts)
+	if got <= 0 {
+		t.Errorf("estimateVSize(0 inputs) = %d, expected positive", got)
+	}
+}

--- a/bitcoin/wallet/wallet.go
+++ b/bitcoin/wallet/wallet.go
@@ -65,12 +65,12 @@ func UtxoPickerSingle(amount, fee btcutil.Amount, utxos []*tbcapi.UTXO) (*tbcapi
 type PrevOuts map[string]*wire.TxOut
 
 // TransactionCreate builds an unsigned bitcoin transaction sending amount to
-// address, funded from utxos.  The fee is estimated from satsPerByte and the
+// address, funded from utxos.  The fee is estimated from satsPerVByte and the
 // transaction's virtual size.  Change, if non-dust, is returned to the
 // address encoded in script.  The returned PrevOuts map is keyed by outpoint
 // string and carries the pkScript and value needed for witness sighash
 // computation.
-func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerByte float64, address btcutil.Address, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, PrevOuts, error) {
+func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerVByte float64, address btcutil.Address, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, PrevOuts, error) {
 	// Create TxOut
 	payToScript, err := txscript.PayToAddrScript(address)
 	if err != nil {
@@ -83,7 +83,7 @@ func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerByte float
 
 	// Calculate fee for worst case input number and assume there is change
 	txSize := txsizes.EstimateSerializeSize(len(utxos), []*wire.TxOut{txOut}, true)
-	fee := btcutil.Amount(float64(txSize) * satsPerByte)
+	fee := btcutil.Amount(float64(txSize) * satsPerVByte)
 
 	// Find utxo list that is big enough for entire transaction
 	utxoList, err := UtxoPickerMultiple(amount, fee, utxos)
@@ -93,7 +93,7 @@ func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerByte float
 
 	// Calculate fee for real input number and assume there is change
 	txSize = txsizes.EstimateSerializeSize(len(utxoList), []*wire.TxOut{txOut}, true)
-	fee = btcutil.Amount(float64(txSize) * satsPerByte)
+	fee = btcutil.Amount(float64(txSize) * satsPerVByte)
 
 	// Assemble transaction
 	tx := wire.NewMsgTx(2) // Latest supported version
@@ -120,7 +120,7 @@ func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerByte float
 // PoPTransactionCreate builds an unsigned Proof-of-Proof transaction
 // embedding l2keystone in an OP_RETURN output.  The transaction is
 // funded from utxos with change returned to the address in script.
-func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerByte float64, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, PrevOuts, error) {
+func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerVByte float64, utxos []*tbcapi.UTXO, script []byte) (*wire.MsgTx, PrevOuts, error) {
 	// Create OP_RETURN
 	aks := hemi.L2KeystoneAbbreviate(*l2keystone)
 	popTx := pop.TransactionL2{L2Keystone: aks}
@@ -132,7 +132,7 @@ func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerB
 
 	// Calculate fee for 1 input and assume there is change
 	txSize := txsizes.EstimateSerializeSize(1, []*wire.TxOut{popTxOut}, true)
-	fee := btcutil.Amount(float64(txSize) * satsPerByte)
+	fee := btcutil.Amount(float64(txSize) * satsPerVByte)
 
 	// Find utxo that is big enough for entire transaction
 	utxo, err := UtxoPickerSingle(0, fee, utxos) // no amount, just fees

--- a/bitcoin/wallet/wallet.go
+++ b/bitcoin/wallet/wallet.go
@@ -64,6 +64,28 @@ func UtxoPickerSingle(amount, fee btcutil.Amount, utxos []*tbcapi.UTXO) (*tbcapi
 // spent amount, so the amount must be available at signing time.
 type PrevOuts map[string]*wire.TxOut
 
+// estimateVSize returns the estimated virtual size of a transaction with
+// numInputs inputs spending from the address type encoded in script.  The
+// script is classified once; all inputs are assumed to be the same type
+// (the wallet's own UTXOs).  Unknown script types fall through to P2PKH
+// which overestimates — safe for fee calculation, never underpays.
+func estimateVSize(numInputs int, script []byte, txOuts []*wire.TxOut) int {
+	changeSize := len(script)
+	switch {
+	case txscript.IsPayToTaproot(script):
+		return txsizes.EstimateVirtualSize(0, numInputs, 0, 0, txOuts, changeSize)
+	case txscript.IsPayToWitnessPubKeyHash(script):
+		return txsizes.EstimateVirtualSize(0, 0, numInputs, 0, txOuts, changeSize)
+	case txscript.IsPayToScriptHash(script):
+		// Assume P2SH-P2WPKH (nested segwit), the only P2SH variant
+		// the wallet produces.
+		return txsizes.EstimateVirtualSize(0, 0, 0, numInputs, txOuts, changeSize)
+	default:
+		// P2PKH or unknown — use legacy sizing (safe overestimate).
+		return txsizes.EstimateVirtualSize(numInputs, 0, 0, 0, txOuts, changeSize)
+	}
+}
+
 // TransactionCreate builds an unsigned bitcoin transaction sending amount to
 // address, funded from utxos.  The fee is estimated from satsPerVByte and the
 // transaction's virtual size.  Change, if non-dust, is returned to the
@@ -82,8 +104,8 @@ func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerVByte floa
 	}
 
 	// Calculate fee for worst case input number and assume there is change
-	txSize := txsizes.EstimateSerializeSize(len(utxos), []*wire.TxOut{txOut}, true)
-	fee := btcutil.Amount(float64(txSize) * satsPerVByte)
+	txVSize := estimateVSize(len(utxos), script, []*wire.TxOut{txOut})
+	fee := btcutil.Amount(float64(txVSize) * satsPerVByte)
 
 	// Find utxo list that is big enough for entire transaction
 	utxoList, err := UtxoPickerMultiple(amount, fee, utxos)
@@ -92,8 +114,8 @@ func TransactionCreate(locktime uint32, amount btcutil.Amount, satsPerVByte floa
 	}
 
 	// Calculate fee for real input number and assume there is change
-	txSize = txsizes.EstimateSerializeSize(len(utxoList), []*wire.TxOut{txOut}, true)
-	fee = btcutil.Amount(float64(txSize) * satsPerVByte)
+	txVSize = estimateVSize(len(utxoList), script, []*wire.TxOut{txOut})
+	fee = btcutil.Amount(float64(txVSize) * satsPerVByte)
 
 	// Assemble transaction
 	tx := wire.NewMsgTx(2) // Latest supported version
@@ -131,8 +153,8 @@ func PoPTransactionCreate(l2keystone *hemi.L2Keystone, locktime uint32, satsPerV
 	popTxOut := wire.NewTxOut(0, popTxOpReturn)
 
 	// Calculate fee for 1 input and assume there is change
-	txSize := txsizes.EstimateSerializeSize(1, []*wire.TxOut{popTxOut}, true)
-	fee := btcutil.Amount(float64(txSize) * satsPerVByte)
+	txVSize := estimateVSize(1, script, []*wire.TxOut{popTxOut})
+	fee := btcutil.Amount(float64(txVSize) * satsPerVByte)
 
 	// Find utxo that is big enough for entire transaction
 	utxo, err := UtxoPickerSingle(0, fee, utxos) // no amount, just fees

--- a/bitcoin/wallet/wallet_test.go
+++ b/bitcoin/wallet/wallet_test.go
@@ -179,7 +179,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	tx, prevOut, err := TransactionCreate(uint32(time.Now().Unix()),
-		btcutil.Amount(550), feeEstimateForTx.SatsPerByte, addr, utxos, pkscript)
+		btcutil.Amount(550), feeEstimateForTx.SatsPerVByte, addr, utxos, pkscript)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	popTx, prevOut, err := PoPTransactionCreate(keystone, uint32(time.Now().Unix()),
-		feeEstimateForPop.SatsPerByte+0.5, utxos, pkscript)
+		feeEstimateForPop.SatsPerVByte+0.5, utxos, pkscript)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/popmd/README.md
+++ b/cmd/popmd/README.md
@@ -186,7 +186,7 @@ To see a full list of runtime settings, execute `popmd` with the **`--help`** fl
 #         POPM_BITCOIN_SECRET    : bitcoin secret (mnemonic, seed, xpriv) (required) 
 #         POPM_BITCOIN_URL       : tbc bitcoin url to connect to (default: ws://localhost:8082/v1/ws)
 #         POPM_LOG_LEVEL         : loglevel for various packages; INFO, DEBUG and TRACE (default: popmd=INFO;popm=INFO)
-#         POPM_MAX_FEE           : maximum fee in sats/vbyte for fee estimation; overrides estimated fees higher than itself; 0 disables the cap (default: 0)
+#         POPM_MAX_FEE           : maximum fee in sats/vbyte for fee estimation, beyond which popm waits for lower fees to remine; 0 disables the cap (default: 0)
 #         POPM_OPGETH_URL        : URL for opgeth (default: localhost:9999)
 #         POPM_PPROF_ADDRESS     : address and port popm pprof listens on (open <address>/debug/pprof to see available profiles) 
 #         POPM_PROMETHEUS_ADDRESS: address and port popm prometheus listens on 

--- a/cmd/popmd/README.md
+++ b/cmd/popmd/README.md
@@ -54,8 +54,9 @@ We support running `popmd` in Docker or as a standalone binary. We provide pre-b
 
 > [!IMPORTANT]
 > Running a PoP Miner requires URLs for the following services:
->  - [BTC Gozer](../../bitcoin/wallet/README.md) with indexed keystones, such as [`tbcd`](../tbcd/README.md).
->  - [hVM-aware op-geth node](https://github.com/hemilabs/op-geth)
+>
+> * [BTC Gozer](../../bitcoin/wallet/README.md) with indexed keystones, such as [`tbcd`](../tbcd/README.md).
+> * [hVM-aware op-geth node](https://github.com/hemilabs/op-geth)
 
 ### Standalone binary (Recommended)
 
@@ -102,7 +103,7 @@ The `heminetwork` repository provides Docker files, which can be used to build D
 
 #### Prerequisites
 
-- `docker` CLI installed and setup.
+* `docker` CLI installed and setup.
 
 #### Execution
 
@@ -129,8 +130,8 @@ docker run \
 
 #### Prerequisites
 
-- [Go v1.26+](https://go.dev/dl/)
-- `make` (optional)
+* [Go v1.26+](https://go.dev/dl/)
+* `make` (optional)
 
 #### Option 1: Using Makefile
 
@@ -189,7 +190,7 @@ To see a full list of runtime settings, execute `popmd` with the **`--help`** fl
 #         POPM_PPROF_ADDRESS     : address and port popm pprof listens on (open <address>/debug/pprof to see available profiles) 
 #         POPM_PROMETHEUS_ADDRESS: address and port popm prometheus listens on 
 #         POPM_REMINE_THRESHOLD  : the number of L2 Keystones behind the latest seen that we are willing to remine, this is handy for re-orgs (default: 0)
-#         POPM_STATIC_FEE        : static fee amount in sats/byte; overrides fee estimation if greater than 0. Can be decimal (ex. 1.5 sats/byte) (default: 0)
+#         POPM_STATIC_FEE        : static fee amount in sats/vbyte; overrides fee estimation if greater than 0. Can be decimal (ex. 1.5 sats/vbyte) (default: 0)
 ```
 
 Namely, ensure the following variables are properly set:
@@ -197,19 +198,19 @@ Namely, ensure the following variables are properly set:
 > [!CAUTION]
 > Running a PoP Miner requires providing a private key for a funded Bitcoin wallet. It is important to keep this
 > private key safe and secure, to prevent loss of funds.
-> 
+>
 > It is recommended to create a new wallet specifically for use by the PoP Miner, and not to reuse existing wallets.
 
-- `POPM_BITCOIN_NETWORK`: This determines what Bitcoin network `popmd` should connect to. This defaults to `mainnet`,
+* `POPM_BITCOIN_NETWORK`: This determines what Bitcoin network `popmd` should connect to. This defaults to `mainnet`,
   however `testnet3`, `testnet4` and `localnet` are also available for test environments.
 
-- `POPM_BITCOIN_SECRET`: A funded Bitcoin address is necessary in order to sign, broadcast, and get rewarded for the
+* `POPM_BITCOIN_SECRET`: A funded Bitcoin address is necessary in order to sign, broadcast, and get rewarded for the
   transactions constructed by `popmd`. The private key for the funded wallet must be provided here.
 
-- `POPM_BITCOIN_URL`*: URL to the Bitcoin node used in order to transmit data to and from the Bitcoin
+* `POPM_BITCOIN_URL`*: URL to the Bitcoin node used in order to transmit data to and from the Bitcoin
   network. [Read more on how to run your own `tbcd` instance here](../tbcd/README.md).
 
-- `POPM_OPGETH_URL`: URL to an accessible hVM-aware op-geth instance, used to retrieve keystones from the Hemi Network.
+* `POPM_OPGETH_URL`: URL to an accessible hVM-aware op-geth instance, used to retrieve keystones from the Hemi Network.
 
 > [!NOTE]
 > \* `TBC` is currently the only functional Bitcoin node providing indexed Hemi keystones.
@@ -220,14 +221,14 @@ Namely, ensure the following variables are properly set:
 
 Hemi L2 Blocks are generated approximately every 12 seconds, and a keystone is generated every 25 blocks. As such:
 
-- `12 * 25` = `300` seconds (5 minutes) between keystones
-- `86400 / 300` = `288` keystones per day
+* `12 * 25` = `300` seconds (5 minutes) between keystones
+* `86400 / 300` = `288` keystones per day
 
 Considering that each transaction created by the PoP Miner has a size of `284 vB` and presuming an average bitcoin
 transaction fee of `3 sats/vB`:
 
-- `284 * 3` = `852 sats` per PoP transaction
-- `852 * 288` = `245376 sats` or `0.00245376 BTC` per day
+* `284 * 3` = `852 sats` per PoP transaction
+* `852 * 288` = `245376 sats` or `0.00245376 BTC` per day
 
 The value of BTC can fluctuate heavily, but presuming a cost of `110,000 USD / BTC`, it would cost `~270 USD` per day
 to run `popmd` on mainnet - assuming the PoP Miner broadcasts a transaction for every generated Hemi keystone.

--- a/cmd/popmd/README.md
+++ b/cmd/popmd/README.md
@@ -178,7 +178,7 @@ To see a full list of runtime settings, execute `popmd` with the **`--help`** fl
 
 ```shell
 ./bin/popmd --h
-# Hemi Proof-of-Proof Miner v2.0.0-dev+76217560a (popmd, go1.24.5 linux/amd64)
+# Hemi Proof-of-Proof Miner v2.1.0-dev+02712517a (popmd, go1.26.3 darwin/arm64)
 # Usage:
 #         help (this help)
 # Environment:
@@ -186,6 +186,7 @@ To see a full list of runtime settings, execute `popmd` with the **`--help`** fl
 #         POPM_BITCOIN_SECRET    : bitcoin secret (mnemonic, seed, xpriv) (required) 
 #         POPM_BITCOIN_URL       : tbc bitcoin url to connect to (default: ws://localhost:8082/v1/ws)
 #         POPM_LOG_LEVEL         : loglevel for various packages; INFO, DEBUG and TRACE (default: popmd=INFO;popm=INFO)
+#         POPM_MAX_FEE           : maximum fee in sats/vbyte for fee estimation; overrides estimated fees higher than itself; 0 disables the cap (default: 0)
 #         POPM_OPGETH_URL        : URL for opgeth (default: localhost:9999)
 #         POPM_PPROF_ADDRESS     : address and port popm pprof listens on (open <address>/debug/pprof to see available profiles) 
 #         POPM_PROMETHEUS_ADDRESS: address and port popm prometheus listens on 

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -89,7 +89,7 @@ var (
 		"POPM_MAX_FEE": config.Config{
 			Value:        &cfg.MaxFee,
 			DefaultValue: float64(0),
-			Help:         "maximum fee in sats/vbyte for fee estimation; overrides estimated fees higher than itself; 0 disables the cap",
+			Help:         "maximum fee in sats/vbyte for fee estimation, beyond which popm waits for lower fees to remine; 0 disables the cap",
 			Print:        config.PrintAll,
 		},
 	}

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -86,6 +86,12 @@ var (
 			Help:         "static fee amount in sats/vbyte; overrides fee estimation if greater than 0. Can be decimal (ex. 1.5 sats/vbyte)",
 			Print:        config.PrintAll,
 		},
+		"POPM_MAX_FEE": config.Config{
+			Value:        &cfg.MaxFee,
+			DefaultValue: float64(0),
+			Help:         "maximum fee in sats/vbyte for fee estimation; overrides estimated fees higher than itself; 0 disables the cap",
+			Print:        config.PrintAll,
+		},
 	}
 )
 

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -83,7 +83,7 @@ var (
 		"POPM_STATIC_FEE": config.Config{
 			Value:        &cfg.StaticFee,
 			DefaultValue: float64(0),
-			Help:         "static fee amount in sats/byte; overrides fee estimation if greater than 0. Can be decimal (ex. 1.5 sats/byte)",
+			Help:         "static fee amount in sats/vbyte; overrides fee estimation if greater than 0. Can be decimal (ex. 1.5 sats/vbyte)",
 			Print:        config.PrintAll,
 		},
 	}

--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -196,16 +196,16 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 	case tbcapi.CmdFeeEstimateRequest:
 		resp = tbcapi.FeeEstimateResponse{
 			FeeEstimates: []*tbcapi.FeeEstimate{
-				{Blocks: 1, SatsPerByte: 1},
-				{Blocks: 2, SatsPerByte: 1},
-				{Blocks: 3, SatsPerByte: 1},
-				{Blocks: 4, SatsPerByte: 1},
-				{Blocks: 5, SatsPerByte: 1},
-				{Blocks: 6, SatsPerByte: 1},
-				{Blocks: 7, SatsPerByte: 1},
-				{Blocks: 8, SatsPerByte: 1},
-				{Blocks: 9, SatsPerByte: 1},
-				{Blocks: 10, SatsPerByte: 1},
+				{Blocks: 1, SatsPerVByte: 1},
+				{Blocks: 2, SatsPerVByte: 1},
+				{Blocks: 3, SatsPerVByte: 1},
+				{Blocks: 4, SatsPerVByte: 1},
+				{Blocks: 5, SatsPerVByte: 1},
+				{Blocks: 6, SatsPerVByte: 1},
+				{Blocks: 7, SatsPerVByte: 1},
+				{Blocks: 8, SatsPerVByte: 1},
+				{Blocks: 9, SatsPerVByte: 1},
+				{Blocks: 10, SatsPerVByte: 1},
 			},
 		}
 	case tbcapi.CmdTxByIdRequest:

--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -35,10 +35,11 @@ import (
 
 type TBCMockHandler struct {
 	mockHandler
-	keystones map[chainhash.Hash]*hemi.L2KeystoneAbrev
-	btcTip    uint
-	utxoNum   uint
-	kssMtx    sync.RWMutex
+	keystones   map[chainhash.Hash]*hemi.L2KeystoneAbrev
+	btcTip      uint
+	utxoNum     uint
+	feeEstimate float64
+	kssMtx      sync.RWMutex
 }
 
 func (f *TBCMockHandler) GetKeystones() map[chainhash.Hash]*hemi.L2KeystoneAbrev {
@@ -47,6 +48,12 @@ func (f *TBCMockHandler) GetKeystones() map[chainhash.Hash]*hemi.L2KeystoneAbrev
 	maps.Copy(cpy, f.keystones)
 	f.kssMtx.RUnlock()
 	return cpy
+}
+
+func (f *TBCMockHandler) SetFeeEstimate(fee float64) {
+	f.kssMtx.Lock()
+	f.feeEstimate = fee
+	f.kssMtx.Unlock()
 }
 
 func NewMockTBC(pctx context.Context, errCh chan error, msgCh chan string, keystones map[chainhash.Hash]*hemi.L2KeystoneAbrev, btcTip, utxoNum uint) *TBCMockHandler {
@@ -58,9 +65,10 @@ func NewMockTBC(pctx context.Context, errCh chan error, msgCh chan string, keyst
 			pctx:  pctx,
 			conns: make([]*websocket.Conn, 0),
 		},
-		keystones: keystones,
-		btcTip:    btcTip,
-		utxoNum:   utxoNum,
+		keystones:   keystones,
+		btcTip:      btcTip,
+		utxoNum:     utxoNum,
+		feeEstimate: 1,
 	}
 	th.handleFunc = th.mockTBCHandleFunc
 	th.server = httptest.NewServer(&th)
@@ -194,18 +202,21 @@ func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.M
 		}
 
 	case tbcapi.CmdFeeEstimateRequest:
+		f.kssMtx.RLock()
+		fee := f.feeEstimate
+		f.kssMtx.RUnlock()
 		resp = tbcapi.FeeEstimateResponse{
 			FeeEstimates: []*tbcapi.FeeEstimate{
-				{Blocks: 1, SatsPerVByte: 1},
-				{Blocks: 2, SatsPerVByte: 1},
-				{Blocks: 3, SatsPerVByte: 1},
-				{Blocks: 4, SatsPerVByte: 1},
-				{Blocks: 5, SatsPerVByte: 1},
-				{Blocks: 6, SatsPerVByte: 1},
-				{Blocks: 7, SatsPerVByte: 1},
-				{Blocks: 8, SatsPerVByte: 1},
-				{Blocks: 9, SatsPerVByte: 1},
-				{Blocks: 10, SatsPerVByte: 1},
+				{Blocks: 1, SatsPerVByte: fee},
+				{Blocks: 2, SatsPerVByte: fee},
+				{Blocks: 3, SatsPerVByte: fee},
+				{Blocks: 4, SatsPerVByte: fee},
+				{Blocks: 5, SatsPerVByte: fee},
+				{Blocks: 6, SatsPerVByte: fee},
+				{Blocks: 7, SatsPerVByte: fee},
+				{Blocks: 8, SatsPerVByte: fee},
+				{Blocks: 9, SatsPerVByte: fee},
+				{Blocks: 10, SatsPerVByte: fee},
 			},
 		}
 	case tbcapi.CmdTxByIdRequest:

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -414,7 +414,7 @@ func (s *Server) estimateFee(ctx context.Context) (*tbcapi.FeeEstimate, error) {
 	// Apply max fee cap if configured
 	if s.cfg.MaxFee > 0 && feeAmount.SatsPerVByte > s.cfg.MaxFee {
 		return nil, FeeMaxExceededError(fmt.Sprintf(
-			"Fee estimate of %.2f sats/vB exceeds max fee of %.2f sats/vB",
+			"fee estimate of %.2f sats/vB exceeds max fee of %.2f sats/vB",
 			feeAmount.SatsPerVByte, s.cfg.MaxFee))
 	}
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -60,7 +60,7 @@ const (
 	defaultMinReconnectDelay = 5 * time.Second
 	defaultMaxReconnectDelay = 43 * time.Second
 
-	minRelayFee = 1                // sats/byte
+	minRelayFee = 1                // sats/vbyte
 	maxBlockAge = 30 * time.Second // XXX make this configurable?
 )
 
@@ -314,7 +314,7 @@ func (s *Server) createKeystoneTx(ctx context.Context, ks *hemi.L2Keystone) (*wi
 
 	// Build transaction.
 	popTx, prevOut, err := wallet.PoPTransactionCreate(ks, uint32(btcHeight),
-		feeAmount.SatsPerByte, utxos, payToScript)
+		feeAmount.SatsPerVByte, utxos, payToScript)
 	if err != nil {
 		return nil, fmt.Errorf("create transaction: %w", err)
 	}
@@ -376,8 +376,8 @@ func (s *Server) estimateFee(ctx context.Context) (*tbcapi.FeeEstimate, error) {
 
 	if s.cfg.StaticFee != 0 {
 		return &tbcapi.FeeEstimate{
-			Blocks:      s.cfg.BitcoinConfirmations,
-			SatsPerByte: s.cfg.StaticFee,
+			Blocks:       s.cfg.BitcoinConfirmations,
+			SatsPerVByte: s.cfg.StaticFee,
 		}, nil
 	}
 	// Estimate BTC fees.

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -56,6 +56,7 @@ const (
 	defaultL2KeystoneMaxAge       = 4 * time.Hour
 	defaultL2KeystonePollTimeout  = 13 * time.Second
 	defaultL2KeystoneRetryTimeout = 15 * time.Second
+	defaultL2KeystoneFeeRetry     = 5 * time.Minute
 
 	defaultMinReconnectDelay = 5 * time.Second
 	defaultMaxReconnectDelay = 43 * time.Second
@@ -120,6 +121,19 @@ func NewDefaultConfig() *Config {
 	}
 }
 
+type FeeMaxExceededError string
+
+func (fme FeeMaxExceededError) Error() string {
+	return string(fme)
+}
+
+func (fme FeeMaxExceededError) Is(target error) bool {
+	_, ok := target.(FeeMaxExceededError)
+	return ok
+}
+
+var ErrFeeMaxExceeded = FeeMaxExceededError("fee exceeded")
+
 type keystoneState int
 
 const (
@@ -135,6 +149,7 @@ type keystone struct {
 	keystone *hemi.L2Keystone
 	hash     *chainhash.Hash // map key
 
+	retry   *time.Time // Used to delay mining if fees are high
 	expires *time.Time // Used to age out of cache
 
 	// internal state                  /-----> 4
@@ -398,12 +413,9 @@ func (s *Server) estimateFee(ctx context.Context) (*tbcapi.FeeEstimate, error) {
 
 	// Apply max fee cap if configured
 	if s.cfg.MaxFee > 0 && feeAmount.SatsPerVByte > s.cfg.MaxFee {
-		log.Infof("Fee estimate of %.2f sats/vB exceeds max fee, using %.2f sats/vB",
-			feeAmount.SatsPerVByte, s.cfg.MaxFee)
-		return &tbcapi.FeeEstimate{
-			Blocks:       feeAmount.Blocks,
-			SatsPerVByte: s.cfg.MaxFee,
-		}, nil
+		return nil, FeeMaxExceededError(fmt.Sprintf(
+			"Fee estimate of %.2f sats/vB exceeds max fee of %.2f sats/vB",
+			feeAmount.SatsPerVByte, s.cfg.MaxFee))
 	}
 
 	return feeAmount, nil
@@ -432,6 +444,7 @@ func (s *Server) reconcileKeystones(ctx context.Context) (map[chainhash.Hash]*ke
 		keystones[*h] = &keystone{
 			keystone: &kr.L2Keystones[k],
 			hash:     h,
+			retry:    timestamp(0), // ready to mine immediately
 		}
 	}
 
@@ -683,10 +696,19 @@ func (s *Server) mine(ctx context.Context) error {
 	for _, ks := range s.keystones {
 		switch ks.state {
 		case keystoneStateNew, keystoneStateError:
+			if !time.Now().After(*ks.retry) {
+				if time.Now().After(*ks.expires) {
+					delete(s.keystones, *ks.hash)
+				}
+				continue
+			}
 			err := s.createAndBroadcastKeystone(ctx, ks.keystone)
 			if err != nil {
 				log.Errorf("new keystone: %v", err)
 				ks.state = keystoneStateError
+				if errors.Is(err, ErrFeeMaxExceeded) {
+					ks.retry = timestamp(defaultL2KeystoneFeeRetry)
+				}
 			} else {
 				ks.state = keystoneStateBroadcast
 			}
@@ -694,6 +716,7 @@ func (s *Server) mine(ctx context.Context) error {
 			// Do nothing, wait for mined.
 		case keystoneStateMined:
 			// Remove if older than max age
+			// XXX (AL-CT): should we check this in every case?
 			if time.Now().After(*ks.expires) {
 				delete(s.keystones, *ks.hash)
 			}

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -89,6 +89,7 @@ type Config struct {
 	BitcoinSource           string
 	BitcoinURL              string
 	LogLevel                string
+	MaxFee                  float64
 	Network                 string
 	OpgethURL               string
 	PprofListenAddress      string
@@ -193,6 +194,11 @@ func NewServer(cfg *Config) (*Server, error) {
 	if cfg.StaticFee != 0 && cfg.StaticFee < minRelayFee {
 		return nil, fmt.Errorf("static fee set to %v, minimum is %v",
 			cfg.StaticFee, minRelayFee)
+	}
+
+	if cfg.MaxFee != 0 && cfg.MaxFee < minRelayFee {
+		return nil, fmt.Errorf("max fee set to %v, minimum is %v",
+			cfg.MaxFee, minRelayFee)
 	}
 
 	switch strings.ToLower(cfg.Network) {
@@ -388,6 +394,16 @@ func (s *Server) estimateFee(ctx context.Context) (*tbcapi.FeeEstimate, error) {
 	feeAmount, err := gozer.FeeByConfirmations(s.cfg.BitcoinConfirmations, feeEstimates)
 	if err != nil {
 		return nil, fmt.Errorf("fee by confirmations: %w", err)
+	}
+
+	// Apply max fee cap if configured
+	if s.cfg.MaxFee > 0 && feeAmount.SatsPerVByte > s.cfg.MaxFee {
+		log.Infof("Fee estimate of %.2f sats/vB exceeds max fee, using %.2f sats/vB",
+			feeAmount.SatsPerVByte, s.cfg.MaxFee)
+		return &tbcapi.FeeEstimate{
+			Blocks:       feeAmount.Blocks,
+			SatsPerVByte: s.cfg.MaxFee,
+		}, nil
 	}
 
 	return feeAmount, nil

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -462,6 +462,140 @@ func TestStaticFee(t *testing.T) {
 	}
 }
 
+func TestMaxFeeRemine(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
+	defer cancel()
+
+	_, kssList := testutil.MakeSharedKeystones(wantedKeystones)
+	btcTip := uint(kssList[len(kssList)-1].L1BlockNumber)
+
+	errCh := make(chan error, 10)
+	msgCh := make(chan string, 10)
+
+	// Create opgeth test server with the request handler.
+	opgeth := mock.NewMockOpGeth(ctx, errCh, msgCh, kssList, defaultL2KeystonesCount)
+	defer opgeth.Shutdown()
+
+	emptyMap := make(map[chainhash.Hash]*hemi.L2KeystoneAbrev, 0)
+
+	// Create tbc test server with the request handler.
+	mtbc := mock.NewMockTBC(ctx, errCh, msgCh, emptyMap, btcTip, 100)
+	defer mtbc.Shutdown()
+
+	mtbc.SetFeeEstimate(100.0)
+
+	// Setup pop miner
+	cfg := NewDefaultConfig()
+	cfg.BitcoinSource = "tbc"
+	cfg.BitcoinURL = "ws" + strings.TrimPrefix(mtbc.URL(), "http")
+	cfg.OpgethURL = "ws" + strings.TrimPrefix(opgeth.URL(), "http")
+	cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
+	cfg.LogLevel = "popm=TRACE; mock=TRACE"
+	cfg.MaxFee = 50.0
+
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create pop miner
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// keystone expiration is forced below
+	s.cfg.l2KeystoneMaxAge = mock.InfiniteDuration
+
+	// Start pop miner
+	go func() {
+		if err := s.Run(ctx); !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	now := time.Now()
+
+	expectedMsg := map[string]int{
+		"kss_subscribe":              1,
+		"kss_getLatestKeystones":     1,
+		tbcapi.CmdFeeEstimateRequest: wantedKeystones,
+	}
+
+	// receive messages and errors from opgeth and tbc
+	err = testutil.MessageListener(t, expectedMsg, errCh, msgCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that all keystones are waiting to be retried
+
+	s.mtx.Lock()
+
+	if len(s.keystones) != wantedKeystones {
+		t.Fatalf("cached keystones %v wanted %v", len(s.keystones), wantedKeystones)
+	}
+
+	for i := range s.keystones {
+		if s.keystones[i].state != keystoneStateError {
+			t.Fatalf("expected kss state %d, got %d",
+				keystoneStateError, s.keystones[i].state)
+		}
+		if !s.keystones[i].retry.After(now) {
+			t.Fatalf("keystone not delayed, retry set to %v",
+				time.Until(s.keystones[i].retry.UTC()))
+		}
+	}
+	// add an extra keystone that should expire and be removed
+	fakeHash := testutil.RandomHash()
+	s.keystones[*fakeHash] = &keystone{
+		hash:    fakeHash,
+		state:   keystoneStateError,
+		retry:   timestamp(defaultL2KeystoneFeeRetry),
+		expires: timestamp(0),
+	}
+	s.mtx.Unlock()
+
+	// Manually try to mine and make sure we fail since fees are still high
+	if err := s.mine(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mtx.Lock()
+	if len(s.keystones) != wantedKeystones {
+		t.Fatalf("cached keystones %v wanted %v", len(s.keystones), wantedKeystones)
+	}
+
+	for i := range s.keystones {
+		if s.keystones[i].state != keystoneStateError {
+			t.Fatalf("expected kss state %d, got %d",
+				keystoneStateError, s.keystones[i].state)
+		}
+		if !s.keystones[i].retry.After(now) {
+			t.Fatalf("keystone not delayed, retry set to %v",
+				time.Until(s.keystones[i].retry.UTC()))
+		}
+		// reset retry
+		s.keystones[i].retry = timestamp(0)
+	}
+	s.mtx.Unlock()
+
+	// lower fees
+	mtbc.SetFeeEstimate(5.0)
+
+	s.workC <- struct{}{}
+
+	// messages we expect to receive
+	expectedMsg = map[string]int{
+		tbcapi.CmdTxBroadcastRequest: wantedKeystones,
+	}
+
+	// receive messages and errors from opgeth and tbc
+	err = testutil.MessageListener(t, expectedMsg, errCh, msgCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMaxFee(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
@@ -513,20 +647,16 @@ func TestMaxFee(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	// Test that high fee estimate gets capped to MaxFee
-	fee, err := s.estimateFee(ctx)
-	if err != nil {
-		t.Fatal(err)
+	// Test that high fee estimate returns FeeMaxExceededError
+	_, err = s.estimateFee(ctx)
+	if !errors.Is(err, ErrFeeMaxExceeded) {
+		t.Fatalf("expected error %v, got %v", ErrFeeMaxExceeded, err)
 	}
 
-	if fee.SatsPerVByte != 10.0 {
-		t.Fatalf("expected fee of 10, got %v", fee.SatsPerVByte)
-	}
-
-	// Test that fee below MaxFee is not modified
+	// Test that fee below MaxFee is returned without error
 	mtbc.SetFeeEstimate(5.0)
 
-	fee, err = s.estimateFee(ctx)
+	fee, err := s.estimateFee(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -462,6 +462,88 @@ func TestStaticFee(t *testing.T) {
 	}
 }
 
+func TestMaxFee(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 10)
+	msgCh := make(chan string, 10)
+
+	_, kssList := testutil.MakeSharedKeystones(1)
+	btcTip := uint(kssList[len(kssList)-1].L1BlockNumber)
+
+	emptyMap := make(map[chainhash.Hash]*hemi.L2KeystoneAbrev, 0)
+
+	mtbc := mock.NewMockTBC(ctx, errCh, msgCh, emptyMap, btcTip, 100)
+	mtbc.SetFeeEstimate(50.0)
+	defer mtbc.Shutdown()
+
+	// Setup pop miner with max fee of 10 sats/vbyte
+	cfg := NewDefaultConfig()
+	cfg.BitcoinSource = "tbc"
+	cfg.BitcoinURL = "ws" + strings.TrimPrefix(mtbc.URL(), "http")
+	cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
+	cfg.MaxFee = 10.0
+
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gozerReady := make(chan struct{})
+	go func() {
+		err := s.gozer.Run(ctx, func() {
+			gozerReady <- struct{}{}
+		})
+		if err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	// Wait for gozer to be ready
+	select {
+	case <-gozerReady:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	// Test that high fee estimate gets capped to MaxFee
+	fee, err := s.estimateFee(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fee.SatsPerVByte != 10.0 {
+		t.Fatalf("expected fee of 10, got %v", fee.SatsPerVByte)
+	}
+
+	// Test that fee below MaxFee is not modified
+	mtbc.SetFeeEstimate(5.0)
+
+	fee, err = s.estimateFee(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fee.SatsPerVByte != 5.0 {
+		t.Fatalf("expected fee of 5, got %v", fee.SatsPerVByte)
+	}
+
+	// Test that MaxFee of 0 disables the cap
+	s.cfg.MaxFee = 0
+
+	mtbc.SetFeeEstimate(100.0)
+
+	fee, err = s.estimateFee(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fee.SatsPerVByte != 100.0 {
+		t.Fatalf("expected fee of 100, got %v", fee.SatsPerVByte)
+	}
+}
+
 func TestOpgethReconnect(t *testing.T) {
 	const (
 		minDelay = 250 * time.Millisecond

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -457,8 +457,8 @@ func TestStaticFee(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if fee.SatsPerByte != 1.5 {
-		t.Fatalf("expected fee of 1.5 sats/byte, got %v sats/byte", fee.SatsPerByte)
+	if fee.SatsPerVByte != 1.5 {
+		t.Fatalf("expected fee of 1.5 sats/vbyte, got %v sats/vbyte", fee.SatsPerVByte)
 	}
 }
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -483,6 +483,12 @@ func TestMaxFee(t *testing.T) {
 	cfg.BitcoinSource = "tbc"
 	cfg.BitcoinURL = "ws" + strings.TrimPrefix(mtbc.URL(), "http")
 	cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
+	cfg.MaxFee = 0.5
+
+	if _, err := NewServer(cfg); err == nil {
+		t.Fatal("expected error")
+	}
+
 	cfg.MaxFee = 10.0
 
 	s, err := NewServer(cfg)

--- a/service/tbc/mempoolfees.go
+++ b/service/tbc/mempoolfees.go
@@ -110,8 +110,8 @@ func (m *Mempool) GetRecommendedFees(ctx context.Context) ([]*tbcapi.FeeEstimate
 	recFees := make([]*tbcapi.FeeEstimate, 6)
 	for k := range 6 {
 		recFees[k] = &tbcapi.FeeEstimate{
-			Blocks:      uint(k + 1),
-			SatsPerByte: defaultMinFee,
+			Blocks:       uint(k + 1),
+			SatsPerVByte: defaultMinFee,
 		}
 	}
 
@@ -125,7 +125,7 @@ func (m *Mempool) GetRecommendedFees(ctx context.Context) ([]*tbcapi.FeeEstimate
 			if err != nil {
 				return nil, err
 			}
-			recFees[k].SatsPerByte = math.Max(defaultMinFee, prevMedianFee)
+			recFees[k].SatsPerVByte = math.Max(defaultMinFee, prevMedianFee)
 		} else {
 			break
 		}


### PR DESCRIPTION
**Summary**
Adds a maximum fee configuration to `popm`. This allows the runner to set a maximum allowed fee estimate. If the estimated fee is higher than the configured maximum, the keystone is marked and we retry mining it after `5 minutes` with (hopefully) lower fees.

Also changed the usage of the expression `sats/byte` to `sats/vbyte` when it comes to fees. While for legacy transactions `bytes` and `vB` can be used interchangeably, this makes it clearer and more consistent with the rest of the ecosystem. 

**Changes**
- Add `MaxFee` to `popm` config.
- Add `POPM_MAX_FEE` to `popmd` config.
- Change usage of `sats/byte` in the codebase to `sats/vbyte`.
