### PR TITLE
tbc: fix panic on empty p2p inv message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Fix a remote crash vulnerability in `tbc` caused by the first element
+  of an inventory message list being accessed before ensuring the slice
+  isn't empty ([#1039](https://github.com/hemilabs/heminetwork/pull/1039)).
+
 ### Breaking Changes
 
 - Rename `TBC_BLOCKHEADER_CACHE_SIZE` environment variable to
@@ -99,9 +105,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug in `popm` that led to a panic when prometheus called geth before
  the client was set ([#1030](https://github.com/hemilabs/heminetwork/pull/1030)).
-
-- Fix `tbc` accessing the first element of an inventory message list before
- ensuring it isn't empty. ([#1039](https://github.com/hemilabs/heminetwork/pull/1039))
 
 ## [v2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in `popm` that led to a panic when prometheus called geth before
  the client was set ([#1030](https://github.com/hemilabs/heminetwork/pull/1030)).
 
+- Fix `tbc` accessing the first element of an inventory message list before
+ ensuring it isn't empty. ([#1039](https://github.com/hemilabs/heminetwork/pull/1039))
+
 ## [v2.0.0]
 
 ### Breaking Changes

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1884,7 +1884,10 @@ func (s *Server) handleBlock(ctx context.Context, p *rawpeer.RawPeer, msg *wire.
 	return nil
 }
 
-func (s *Server) handleInv(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgInv, raw []byte) error {
+func (s *Server) handleInv(ctx context.Context, p *rawpeer.RawPeer, msg *wire.MsgInv, _ []byte) error {
+	if len(msg.InvList) == 0 {
+		return nil
+	}
 	switch msg.InvList[0].Type {
 	case wire.InvTypeTx:
 	case wire.InvTypeBlock:

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"sort"
 	"strconv"
@@ -39,6 +40,7 @@ import (
 	"github.com/hemilabs/heminetwork/v2/database/tbcd/level"
 	"github.com/hemilabs/heminetwork/v2/hemi/pop"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil"
+	"github.com/hemilabs/heminetwork/v2/service/tbc/peer/rawpeer"
 )
 
 const (
@@ -2453,5 +2455,83 @@ func TestExternalHeaderModeRunReturnsTypedError(t *testing.T) {
 	}
 	if ehn.Op != "Run" {
 		t.Fatalf("expected operation Run, got %s", ehn.Op)
+	}
+}
+
+func TestEmptyInvMessage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 17*time.Second)
+	defer cancel()
+
+	n, err := newFakeNode(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := n.Stop()
+		if err != nil {
+			t.Logf("node stop: %v", err)
+		}
+	}()
+
+	go func() {
+		if err := n.Run(ctx); !testutil.ErrorIsOneOf(err, []error{net.ErrClosed, context.Canceled, rawpeer.ErrNoConn}) {
+			panic(err)
+		}
+	}()
+
+	// Connect tbc service
+	cfg := &Config{
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		HeaderCacheSize:         "1mb",
+		BlockSanity:             false,
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            1000, // XXX
+		Network:                 networkLocalnet,
+		PeersWanted:             1,
+		PrometheusListenAddress: "",
+		Seeds:                   []string{n.Address()},
+		NotificationBlocking:    true,
+		// LogLevel:             "tbcd=TRACE:tbc=TRACE:level=DEBUG",
+	}
+	_ = loggo.ConfigureLoggers(cfg.LogLevel)
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, rawpeer.ErrNoConn) {
+			panic(err)
+		}
+	}()
+
+	// wait for node to connect as peer
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-n.msgCh:
+	}
+
+	if err := n.SendMsg(ctx, wire.NewMsgInv()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := n.SendMsg(ctx, wire.NewMsgPing(10)); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for node to connect as peer
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case msg := <-n.msgCh:
+			if msg == "pong" {
+				return
+			}
+		}
 	}
 }

--- a/service/tbc/tbcfork_test.go
+++ b/service/tbc/tbcfork_test.go
@@ -1092,6 +1092,11 @@ func (b *btcNode) MineAndSend(ctx context.Context, name string, parent *chainhas
 	return blk, nil
 }
 
+func (b *btcNode) SendMsg(ctx context.Context, msg wire.Message) error {
+	b.t.Logf("send wire msg %s", msg.Command())
+	return b.p.Write(defaultCmdTimeout, msg)
+}
+
 func (b *btcNode) MineAndSendEmpty(ctx context.Context) error {
 	b.t.Logf("send empty headers message")
 	return b.p.Write(defaultCmdTimeout, wire.NewMsgHeaders())


### PR DESCRIPTION
**Summary**
Fixes a bug where `TBC` would access the first element of an inventory message list from a peer before ensuring it wasn't empty.

**Changes**
- Check if the list is empty and skip if true.
