### PR TITLE
popm: add e2e test

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -190,7 +190,7 @@ func SkipIfNoDocker(t *testing.T) {
 	}
 
 	if !val {
-		t.Skip("skipping docker tests")
+		t.Skip("HEMI_DOCKER_TESTS unset; skipping docker tests")
 	}
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -208,7 +208,7 @@ func CreateBitcoind(ctx context.Context) testcontainers.Container {
 
 	name := "bitcoind-" + id
 	req := testcontainers.ContainerRequest{
-		Image:        "kylemanna/bitcoind",
+		Image:        "kylemanna/bitcoind@sha256:46904e5c985f0148ca07a7702d17299fb5fa0678cb4a091c080c11ac78e92617",
 		Cmd:          []string{"bitcoind", "-regtest=1", "-debug=1", "-rpcallowip=0.0.0.0/0", "-rpcbind=0.0.0.0:18443", "-txindex=1", "-noonion", "-listenonion=0", "-fallbackfee=0.01", "-peerbloomfilters=1", "-debug"},
 		ExposedPorts: []string{"18443", "18444"},
 		WaitingFor:   wait.ForLog("dnsseed thread exit").WithPollInterval(1 * time.Second),

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -5,13 +5,22 @@
 package testutil
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/hemilabs/heminetwork/v2/hemi"
 )
@@ -170,4 +179,81 @@ func ErrorIsOneOf(err error, errs []error) bool {
 		}
 	}
 	return false
+}
+
+// SkipIfNoDocker skips tests when the proper flag is not set.
+func SkipIfNoDocker(t *testing.T) {
+	envValue := os.Getenv("HEMI_DOCKER_TESTS")
+	val, err := strconv.ParseBool(envValue)
+	if envValue != "" && err != nil {
+		t.Fatal(err)
+	}
+
+	if !val {
+		t.Skip("skipping docker tests")
+	}
+}
+
+type StdoutLogConsumer struct {
+	Name string // name of service
+}
+
+func (t *StdoutLogConsumer) Accept(l testcontainers.Log) {
+	fmt.Printf("%s: %s", t.Name, string(l.Content))
+}
+
+// CreateBitcoind starts a new bitcoind container using testcontainers.
+func CreateBitcoind(ctx context.Context) testcontainers.Container {
+	id := hex.EncodeToString(RandomBytes(6))
+
+	name := "bitcoind-" + id
+	req := testcontainers.ContainerRequest{
+		Image:        "kylemanna/bitcoind",
+		Cmd:          []string{"bitcoind", "-regtest=1", "-debug=1", "-rpcallowip=0.0.0.0/0", "-rpcbind=0.0.0.0:18443", "-txindex=1", "-noonion", "-listenonion=0", "-fallbackfee=0.01", "-peerbloomfilters=1", "-debug"},
+		ExposedPorts: []string{"18443", "18444"},
+		WaitingFor:   wait.ForLog("dnsseed thread exit").WithPollInterval(1 * time.Second),
+		LogConsumerCfg: &testcontainers.LogConsumerConfig{
+			Consumers: []testcontainers.LogConsumer{
+				&StdoutLogConsumer{
+					Name: name,
+				},
+			},
+		},
+		Name: name,
+	}
+
+	bitcoindContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return bitcoindContainer
+}
+
+// RunBitcoindCommand executes a bitcoind command.
+func RunBitcoindCommand(ctx context.Context, bitcoindContainer testcontainers.Container, cmd []string) (string, error) {
+	exitCode, result, err := bitcoindContainer.Exec(ctx, cmd)
+	if err != nil {
+		return "", err
+	}
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, result)
+	if err != nil {
+		return "", err
+	}
+
+	if exitCode != 0 {
+		return "", fmt.Errorf("error code received: %d", exitCode)
+	}
+
+	if len(buf.String()) == 0 {
+		return "", nil
+	}
+
+	// first 8 bytes are header, there is also a newline character at the end of the response
+	return buf.String()[8 : len(buf.String())-1], nil
 }

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -350,8 +350,8 @@ func (s *Server) createKeystoneTx(ctx context.Context, ks *hemi.L2Keystone) (*wi
 }
 
 func (s *Server) broadcastKeystone(pctx context.Context, popTx *wire.MsgTx) error {
-	log.Tracef("mineKeystone")
-	defer log.Tracef("mineKeystone exit")
+	log.Tracef("broadcastKeystone")
+	defer log.Tracef("broadcastKeystone exit")
 
 	log.Infof("Broadcasting PoP tx %s with hash %v", s.params.Name, popTx.TxHash())
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -6,20 +6,26 @@ package popm
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/juju/loggo/v2"
 
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
+	"github.com/hemilabs/heminetwork/v2/bitcoin"
 	"github.com/hemilabs/heminetwork/v2/hemi"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil/mock"
+	"github.com/hemilabs/heminetwork/v2/service/tbc"
 )
 
 const wantedKeystones = 20
@@ -744,6 +750,292 @@ func TestOpgethReconnect(t *testing.T) {
 				t.Fatal("reconnected too fast")
 			}
 			return
+		}
+	}
+}
+
+func TestPopMinerE2E(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+
+	const (
+		secret      = "72a2c41c84147325ce3c0f37697ef1e670c7169063dda89be9995c3c5219740f"
+		otherSecret = "72a2c41c84147325ce3c0f37697ef1e670c7169063dda89be9995c3c5219ffff"
+		kssCount    = 4
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
+	defer cancel()
+
+	// Create bitcoind container
+	bitcoindContainer := testutil.CreateBitcoind(ctx)
+
+	// Generate miner address to fund with BTC from mining
+	_, _, btcAddress, err := bitcoin.KeysAndAddressFromHexString(
+		secret,
+		&chaincfg.RegressionNetParams,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate secondary address
+	_, _, otherAddress, err := bitcoin.KeysAndAddressFromHexString(
+		otherSecret,
+		&chaincfg.RegressionNetParams,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate blockCount blocks that fund the miner's wallet
+	_, err = testutil.RunBitcoindCommand(ctx, bitcoindContainer, []string{
+		"bitcoin-cli",
+		"-regtest=1",
+		"generatetoaddress",
+		strconv.FormatUint(kssCount, 10),
+		btcAddress.EncodeAddress(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate 100 more blocks to reach coinbase maturity. We send to
+	// another address to prevent the wallet from selection UTXOs that
+	// maybe not yet be ready for spending.
+	_, err = testutil.RunBitcoindCommand(ctx, bitcoindContainer, []string{
+		"bitcoin-cli",
+		"-regtest=1",
+		"generatetoaddress",
+		"100",
+		otherAddress.EncodeAddress(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mappedPeerPort, err := bitcoindContainer.MappedPort(ctx, "18444")
+	if err != nil {
+		t.Errorf("error getting mapped port %v", err)
+	}
+
+	tbcCfg := &tbc.Config{
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		HeaderCacheSize:         "1mb",
+		HemiIndex:               true,
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            1000,
+		MaxCachedKeystones:      1000,
+		Network:                 "localnet",
+		ListenAddress:           "127.0.0.1:0",
+		PeersWanted:             1,
+		PrometheusListenAddress: "",
+		MempoolEnabled:          true,
+		NotificationBlocking:    true,
+		// LogLevel:                "tbc=TRACE",
+		Seeds: []string{
+			"127.0.0.1:" + mappedPeerPort.Port(),
+		},
+	}
+
+	if err := loggo.ConfigureLoggers(tbcCfg.LogLevel); err != nil {
+		t.Fatal(err)
+	}
+
+	tbcServer, err := tbc.NewServer(tbcCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := tbcServer.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	// Start TBC
+	go func() {
+		err := tbcServer.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	// Wait until TBC inserts all blocks
+	var insertCount int
+	for {
+		notif, err := l.Listen(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if notif.Is(tbc.NotificationBlock(chainhash.Hash{})) {
+			insertCount++
+		}
+		if insertCount == kssCount+100 {
+			break
+		}
+	}
+	l.Unsubscribe()
+
+	// Sync TBC to latest block
+	if err := tbcServer.SyncIndexersToBest(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	_, kssList := testutil.MakeSharedKeystones(kssCount)
+	errCh := make(chan error, 10)
+	msgCh := make(chan string, 10)
+
+	// Create opgeth test server to generate and send keystones.
+	opgeth := mock.NewMockOpGeth(ctx, errCh, msgCh, kssList, kssCount)
+	defer opgeth.Shutdown()
+
+	// Setup pop miner
+	cfg := NewDefaultConfig()
+	cfg.BitcoinSource = "tbc"
+	cfg.BitcoinURL = "ws://" + tbcServer.HTTPAddress().String() + tbcapi.RouteWebsocket
+	cfg.OpgethURL = "ws" + strings.TrimPrefix(opgeth.URL(), "http")
+	cfg.BitcoinSecret = secret
+	cfg.Network = "localnet"
+	// cfg.LogLevel = "popm=TRACE;tbc=TRACE"
+	cfg.l2KeystonePollTimeout = 500 * time.Millisecond
+	cfg.StaticFee = 100
+
+	if err := loggo.ConfigureLoggers(cfg.LogLevel); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm our address has the expected balance
+	bal, err := tbcServer.BalanceByAddress(ctx, btcAddress.EncodeAddress())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedBal := uint64(kssCount * btcutil.SatoshiPerBitcoin * 50)
+	if bal != expectedBal {
+		t.Fatalf("expected balance of %d, got %d", expectedBal, bal)
+	}
+
+	// Create pop miner
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start pop miner
+	go func() {
+		if err := s.Run(ctx); !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	// Wait for pop miner to retrieve keystones and then
+	// send a request to start mining
+	expectedMsg := map[string]int{
+		"kss_subscribe":          1,
+		"kss_getLatestKeystones": 1,
+	}
+	err = testutil.MessageListener(t, expectedMsg, errCh, msgCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.workC <- struct{}{}
+
+	var (
+		listen    *tbc.Listener
+		txIDs     string
+		inMempool bool
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-time.Tick(250 * time.Millisecond):
+			// Check if bitcoind has received the PoP Txs
+			txIDs, err = testutil.RunBitcoindCommand(ctx, bitcoindContainer, []string{
+				"bitcoin-cli",
+				"-regtest",
+				"getrawmempool",
+				"false",
+			})
+			if err != nil {
+				panic(err)
+			}
+
+			var out []string
+			if err := json.Unmarshal([]byte(txIDs), &out); err != nil {
+				panic(err)
+			}
+
+			if len(out) == kssCount {
+				inMempool = true
+			}
+		}
+		if inMempool {
+			break
+		}
+	}
+
+	listen, err = tbcServer.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listen.Unsubscribe()
+
+	// Generate block with the new PoP TXs
+	_, err = testutil.RunBitcoindCommand(ctx, bitcoindContainer, []string{
+		"bitcoin-cli",
+		"-regtest",
+		"generateblock",
+		otherAddress.EncodeAddress(),
+		txIDs,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Wait for TBC to insert the new block
+	for {
+		notif, err := listen.Listen(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if notif.Is(tbc.NotificationBlock(chainhash.Hash{})) {
+			break
+		}
+	}
+	listen.Unsubscribe()
+
+	// Sync TBC to the new block
+	if err = tbcServer.SyncIndexersToBest(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm our address has a lower balance now
+	bal, err = tbcServer.BalanceByAddress(ctx, btcAddress.EncodeAddress())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Original balance - (STATIC_FEE * POP_TX_SIZE * KssCount)
+	newBal := expectedBal - (uint64(cfg.StaticFee) * 285 * kssCount)
+	if bal != newBal {
+		t.Fatalf("expected balance of %d, got %d", newBal, bal)
+	}
+
+	// Speed up pop miner and update keystone states
+	if _, err = s.updateKeystoneStates(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Ensure every keystone is marked as 'mined'
+	for kh, kss := range s.keystones {
+		if kss.state != keystoneStateMined {
+			t.Fatalf("expected keystone %s to be mined", kh)
 		}
 	}
 }

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -81,7 +81,7 @@ func slice2Header(header []byte) (*wire.BlockHeader, error) {
 }
 
 func TestBlockHeadersByHeightRaw(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
@@ -152,7 +152,7 @@ func TestBlockHeadersByHeightRaw(t *testing.T) {
 }
 
 func TestBlockHeadersByHeight(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
@@ -217,7 +217,7 @@ func TestBlockHeadersByHeight(t *testing.T) {
 }
 
 func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
@@ -276,7 +276,7 @@ func TestBlockHeadersByHeightDoesNotExist(t *testing.T) {
 }
 
 func TestBlockHeaderBestRaw(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
@@ -344,7 +344,7 @@ func TestBlockHeaderBestRaw(t *testing.T) {
 }
 
 func TestBtcBlockHeaderBest(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
@@ -406,7 +406,7 @@ func TestBtcBlockHeaderBest(t *testing.T) {
 }
 
 func TestBalanceByAddress(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	type testTableItem struct {
 		name          string
@@ -509,9 +509,8 @@ func TestBalanceByAddress(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = runBitcoinCommand(
+			r, err := testutil.RunBitcoindCommand(
 				ctx,
-				t,
 				bitcoindContainer,
 				[]string{
 					"bitcoin-cli",
@@ -523,6 +522,7 @@ func TestBalanceByAddress(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			t.Log(r)
 
 			tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
 
@@ -596,7 +596,7 @@ func TestBalanceByAddress(t *testing.T) {
 }
 
 func TestUtxosByAddressRaw(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	type testTableItem struct {
 		name          string
@@ -733,9 +733,8 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = runBitcoinCommand(
+			r, err := testutil.RunBitcoindCommand(
 				ctx,
-				t,
 				bitcoindContainer,
 				[]string{
 					"bitcoin-cli",
@@ -747,6 +746,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			t.Log(r)
 
 			tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
 
@@ -806,7 +806,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 }
 
 func TestUtxosByAddress(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	type testTableItem struct {
 		name          string
@@ -943,9 +943,8 @@ func TestUtxosByAddress(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = runBitcoinCommand(
+			r, err := testutil.RunBitcoindCommand(
 				ctx,
-				t,
 				bitcoindContainer,
 				[]string{
 					"bitcoin-cli",
@@ -957,6 +956,7 @@ func TestUtxosByAddress(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			t.Log(r)
 
 			tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
 
@@ -1016,7 +1016,7 @@ func TestUtxosByAddress(t *testing.T) {
 }
 
 func TestTxByIdRaw(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
@@ -1100,7 +1100,7 @@ func TestTxByIdRaw(t *testing.T) {
 }
 
 func TestTxByIdRawInvalid(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	_, _, address, err := bitcoin.KeysAndAddressFromHexString(
@@ -1175,7 +1175,7 @@ func TestTxByIdRawInvalid(t *testing.T) {
 }
 
 func TestTxByIdRawNotFound(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 0, "")
@@ -1193,9 +1193,8 @@ func TestTxByIdRawNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = runBitcoinCommand(
+	r, err := testutil.RunBitcoindCommand(
 		ctx,
-		t,
 		bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1207,6 +1206,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(r)
 
 	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
 
@@ -1265,7 +1265,7 @@ func TestTxByIdRawNotFound(t *testing.T) {
 }
 
 func TestTxById(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
@@ -1346,7 +1346,7 @@ func TestTxById(t *testing.T) {
 }
 
 func TestTxByIdInvalid(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	_, _, address, err := bitcoin.KeysAndAddressFromHexString(
@@ -1810,7 +1810,7 @@ func TestRpcZK(t *testing.T) {
 }
 
 func TestTxByIdNotFound(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 	bitcoindContainer, mappedPeerPort := createBitcoindWithInitialBlocks(ctx, t, 0, "")
@@ -1828,9 +1828,8 @@ func TestTxByIdNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = runBitcoinCommand(
+	r, err := testutil.RunBitcoindCommand(
 		ctx,
-		t,
 		bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1842,6 +1841,7 @@ func TestTxByIdNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(r)
 
 	tbcServer, tbcUrl := createTbcServer(ctx, t, mappedPeerPort)
 

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"sort"
@@ -31,7 +30,6 @@ import (
 	"github.com/juju/loggo/v2"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/hemilabs/heminetwork/v2/api"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
@@ -61,18 +59,6 @@ type StdoutLogConsumer struct {
 
 func (t *StdoutLogConsumer) Accept(l testcontainers.Log) {
 	fmt.Printf("%s: %s", t.Name, string(l.Content))
-}
-
-func skipIfNoDocker(t *testing.T) {
-	envValue := os.Getenv("HEMI_DOCKER_TESTS")
-	val, err := strconv.ParseBool(envValue)
-	if envValue != "" && err != nil {
-		t.Fatal(err)
-	}
-
-	if !val {
-		t.Skip("skipping docker tests")
-	}
 }
 
 func TestBlockHeaderEncodeDecode(t *testing.T) {
@@ -566,7 +552,7 @@ func TestKeystonesInBlock(t *testing.T) {
 }
 
 func TestServerBlockHeadersBest(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
@@ -598,7 +584,7 @@ func TestServerBlockHeadersBest(t *testing.T) {
 }
 
 func TestForksWithGen(t *testing.T) {
-	skipIfNoDocker(t)
+	testutil.SkipIfNoDocker(t)
 
 	t.Skip("need unwind functionality to run these tests, they need to be audited after that as well")
 
@@ -621,8 +607,8 @@ func TestForksWithGen(t *testing.T) {
 			name: "Split Tip, Single Block",
 			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, walletAddress string, tbcServer *Server) {
 				// block 1A, send 7 btc to otherAddress
-				_, err := runBitcoinCommand(
-					ctx, t, bitcoindContainer,
+				r, err := testutil.RunBitcoindCommand(
+					ctx, bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
 						"-regtest=1",
@@ -636,10 +622,10 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
-				blockHashesResponse, err := runBitcoinCommand(
+				blockHashesResponse, err := testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -650,6 +636,7 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(blockHashesResponse)
 
 				// XXX: Rewrite test to use tbcServer.SyncIndexersToHash
 				if true {
@@ -680,9 +667,8 @@ func TestForksWithGen(t *testing.T) {
 				// to the mempool
 				invalidateBlock(ctx, t, bitcoindContainer, blockHashes.Blocks[0])
 
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -695,12 +681,12 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
 				// create block 1B and 2B, the txs should be included
 				// in 1B.  use 2B to move tbc forward
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -711,6 +697,7 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 			},
 		},
 		{
@@ -732,9 +719,8 @@ func TestForksWithGen(t *testing.T) {
 					}
 
 					// block i*1A, send 7 btc to otherAddress
-					_, err := runBitcoinCommand(
+					r, err := testutil.RunBitcoindCommand(
 						ctx,
-						t,
 						bitcoindContainer,
 						[]string{
 							"bitcoin-cli",
@@ -750,10 +736,10 @@ func TestForksWithGen(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					t.Log(r)
 
-					blockHashesResponse, err := runBitcoinCommand(
+					blockHashesResponse, err := testutil.RunBitcoindCommand(
 						ctx,
-						t,
 						bitcoindContainer,
 						[]string{
 							"bitcoin-cli",
@@ -764,6 +750,7 @@ func TestForksWithGen(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					t.Log(blockHashesResponse)
 
 					var blockHashes struct {
 						Blocks []string `json:"blocks"`
@@ -786,9 +773,8 @@ func TestForksWithGen(t *testing.T) {
 						reconsiderBlock(ctx, t, bitcoindContainer, lastB)
 					}
 
-					_, err = runBitcoinCommand(
+					r, err = testutil.RunBitcoindCommand(
 						ctx,
-						t,
 						bitcoindContainer,
 						[]string{
 							"bitcoin-cli",
@@ -804,10 +790,10 @@ func TestForksWithGen(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					t.Log(r)
 
-					blockHashesResponse, err = runBitcoinCommand(
+					blockHashesResponse, err = testutil.RunBitcoindCommand(
 						ctx,
-						t,
 						bitcoindContainer,
 						[]string{
 							"bitcoin-cli",
@@ -818,6 +804,7 @@ func TestForksWithGen(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					t.Log(blockHashesResponse)
 
 					if err := json.Unmarshal([]byte(blockHashesResponse), &blockHashes); err != nil {
 						t.Fatal(err)
@@ -834,9 +821,8 @@ func TestForksWithGen(t *testing.T) {
 		{
 			name: "Long reorg",
 			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, walletAddress string, tbcServer *Server) {
-				_, err := runBitcoinCommand(
+				r, err := testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -851,10 +837,10 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -865,6 +851,7 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
 				// XXX: Rewrite test to use tbcServer.SyncIndexersToHash
 				if true {
@@ -884,9 +871,8 @@ func TestForksWithGen(t *testing.T) {
 					t.Fatalf("unexpected balance: %d", balance)
 				}
 
-				blockHash, err := runBitcoinCommand(
+				blockHash, err := testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -897,14 +883,14 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(blockHash)
 
 				// create fork, invalidate block at height 10, this means we
 				// generate blocks starting at 10
 				invalidateBlock(ctx, t, bitcoindContainer, blockHash)
 
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -917,11 +903,11 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
 				// create long new chain
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -932,6 +918,7 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
 				// XXX: Rewrite test to use tbcServer.SyncIndexersToHash
 				panic("replace tbcServer.SyncIndexersToHeight with tbcServer.SyncIndexersToHash")
@@ -944,9 +931,8 @@ func TestForksWithGen(t *testing.T) {
 		{
 			name: "Ancient orphan",
 			testForkScenario: func(t *testing.T, ctx context.Context, bitcoindContainer testcontainers.Container, walletAddress string, tbcServer *Server) {
-				_, err := runBitcoinCommand(
+				r, err := testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -961,10 +947,10 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -975,6 +961,7 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
 				// XXX: Rewrite test to use tbcServer.SyncIndexersToHash
 				if true {
@@ -994,9 +981,8 @@ func TestForksWithGen(t *testing.T) {
 					t.Fatalf("unexpected balance: %d", balance)
 				}
 
-				blockHash, err := runBitcoinCommand(
+				blockHash, err := testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -1007,14 +993,14 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(blockHash)
 
 				// create fork, invalidate block at height 10, this means we
 				// generate blocks starting at 10
 				invalidateBlock(ctx, t, bitcoindContainer, blockHash)
 
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -1027,11 +1013,11 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
 				// create long new chain
-				_, err = runBitcoinCommand(
+				r, err = testutil.RunBitcoindCommand(
 					ctx,
-					t,
 					bitcoindContainer,
 					[]string{
 						"bitcoin-cli",
@@ -1042,6 +1028,7 @@ func TestForksWithGen(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				t.Log(r)
 
 				// XXX: Rewrite test to use tbcServer.SyncIndexersToHash
 				panic("replace tbcServer.SyncIndexersToHeight with tbcServer.SyncIndexersToHash")
@@ -1066,9 +1053,8 @@ func TestForksWithGen(t *testing.T) {
 				}
 			}()
 
-			_, err = runBitcoinCommand(
+			r, err := testutil.RunBitcoindCommand(
 				ctx,
-				t,
 				bitcoindContainer,
 				[]string{
 					"bitcoin-cli",
@@ -1079,10 +1065,10 @@ func TestForksWithGen(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			t.Log(r)
 
-			walletAddress, err := runBitcoinCommand(
+			walletAddress, err := testutil.RunBitcoindCommand(
 				ctx,
-				t,
 				bitcoindContainer,
 				[]string{
 					"bitcoin-cli",
@@ -1092,10 +1078,10 @@ func TestForksWithGen(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			t.Log(walletAddress)
 
-			_, err = runBitcoinCommand(
+			r, err = testutil.RunBitcoindCommand(
 				ctx,
-				t,
 				bitcoindContainer,
 				[]string{
 					"bitcoin-cli",
@@ -1107,6 +1093,7 @@ func TestForksWithGen(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			t.Log(r)
 
 			tbcServer, _ := createTbcServer(ctx, t, mappedPeerPort)
 
@@ -1116,9 +1103,8 @@ func TestForksWithGen(t *testing.T) {
 }
 
 func invalidateBlock(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container, blockHash string) {
-	_, err := runBitcoinCommand(
+	r, err := testutil.RunBitcoindCommand(
 		ctx,
-		t,
 		bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1129,12 +1115,12 @@ func invalidateBlock(ctx context.Context, t *testing.T, bitcoindContainer testco
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(r)
 }
 
 func reconsiderBlock(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container, blockHash string) {
-	_, err := runBitcoinCommand(
+	r, err := testutil.RunBitcoindCommand(
 		ctx,
-		t,
 		bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1145,68 +1131,12 @@ func reconsiderBlock(ctx context.Context, t *testing.T, bitcoindContainer testco
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-func createBitcoind(ctx context.Context, t *testing.T) testcontainers.Container {
-	id, err := randHexId(6)
-	if err != nil {
-		t.Fatal("failed to generate random id:", err)
-	}
-
-	name := "bitcoind-" + id
-	req := testcontainers.ContainerRequest{
-		Image:        "kylemanna/bitcoind",
-		Cmd:          []string{"bitcoind", "-regtest=1", "-debug=1", "-rpcallowip=0.0.0.0/0", "-rpcbind=0.0.0.0:18443", "-txindex=1", "-noonion", "-listenonion=0", "-fallbackfee=0.01", "-peerbloomfilters=1", "-debug"},
-		ExposedPorts: []string{"18443", "18444"},
-		WaitingFor:   wait.ForLog("dnsseed thread exit").WithPollInterval(1 * time.Second),
-		LogConsumerCfg: &testcontainers.LogConsumerConfig{
-			Consumers: []testcontainers.LogConsumer{&StdoutLogConsumer{
-				Name: name,
-			}},
-		},
-		Name: name,
-	}
-
-	bitcoindContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return bitcoindContainer
-}
-
-func runBitcoinCommand(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container, cmd []string) (string, error) {
-	exitCode, result, err := bitcoindContainer.Exec(ctx, cmd)
-	if err != nil {
-		return "", err
-	}
-
-	buf := new(strings.Builder)
-	_, err = io.Copy(buf, result)
-	if err != nil {
-		return "", err
-	}
-	t.Log(buf.String())
-
-	if exitCode != 0 {
-		return "", fmt.Errorf("error code received: %d", exitCode)
-	}
-
-	if len(buf.String()) == 0 {
-		return "", nil
-	}
-
-	// first 8 bytes are header, there is also a newline character at the end of the response
-	return buf.String()[8 : len(buf.String())-1], nil
+	t.Log(r)
 }
 
 func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container) *chainhash.Hash {
-	blockHash, err := runBitcoinCommand(
+	blockHash, err := testutil.RunBitcoindCommand(
 		ctx,
-		t,
 		bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1217,10 +1147,10 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(blockHash)
 
-	blockJson, err := runBitcoinCommand(
+	blockJson, err := testutil.RunBitcoindCommand(
 		ctx,
-		t,
 		bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1231,6 +1161,7 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(blockJson)
 
 	var parsed struct {
 		Tx []string `json:"tx"`
@@ -1404,7 +1335,7 @@ func cliBlockHeaderToTBC(t *testing.T, btcCliBlockHeader *BtcCliBlockHeader) []*
 }
 
 func bitcoindBlockAtHeight(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container, height uint64) *BtcCliBlockHeader {
-	blockHash, err := runBitcoinCommand(ctx, t, bitcoindContainer, []string{
+	blockHash, err := testutil.RunBitcoindCommand(ctx, bitcoindContainer, []string{
 		"bitcoin-cli",
 		"-regtest=1",
 		"getblockhash",
@@ -1413,12 +1344,13 @@ func bitcoindBlockAtHeight(ctx context.Context, t *testing.T, bitcoindContainer 
 	if err != nil {
 		t.Fatal(fmt.Errorf("bitcoin-cli getblockhash %d: %w", height, err))
 	}
+	t.Log(blockHash)
 
 	return bitcoindBlockByHash(ctx, t, bitcoindContainer, blockHash)
 }
 
 func bitcoindBestBlock(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container) *BtcCliBlockHeader {
-	blockHash, err := runBitcoinCommand(ctx, t, bitcoindContainer, []string{
+	blockHash, err := testutil.RunBitcoindCommand(ctx, bitcoindContainer, []string{
 		"bitcoin-cli",
 		"-regtest=1",
 		"getbestblockhash",
@@ -1426,13 +1358,14 @@ func bitcoindBestBlock(ctx context.Context, t *testing.T, bitcoindContainer test
 	if err != nil {
 		t.Fatal(fmt.Errorf("bitcoin-cli getbestblockhash: %w", err))
 	}
+	t.Log(blockHash)
 
 	return bitcoindBlockByHash(ctx, t, bitcoindContainer, blockHash)
 }
 
 func bitcoindBlockByHash(ctx context.Context, t *testing.T, bitcoindContainer testcontainers.Container, blockHash string) *BtcCliBlockHeader {
-	blockHeaderJson, err := runBitcoinCommand(
-		ctx, t, bitcoindContainer,
+	blockHeaderJson, err := testutil.RunBitcoindCommand(
+		ctx, bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
 			"-regtest=1",
@@ -1442,6 +1375,7 @@ func bitcoindBlockByHash(ctx context.Context, t *testing.T, bitcoindContainer te
 	if err != nil {
 		t.Fatal(fmt.Errorf("bitcoin-cli getblockheader: %w", err))
 	}
+	t.Log(blockHeaderJson)
 
 	var btcCliBlockHeader BtcCliBlockHeader
 	if err = json.Unmarshal([]byte(blockHeaderJson), &btcCliBlockHeader); err != nil {
@@ -1454,7 +1388,7 @@ func bitcoindBlockByHash(ctx context.Context, t *testing.T, bitcoindContainer te
 func createBitcoindWithInitialBlocks(ctx context.Context, t *testing.T, blocks uint64, overrideAddress string) (testcontainers.Container, nat.Port) {
 	t.Helper()
 
-	bitcoindContainer := createBitcoind(ctx, t)
+	bitcoindContainer := testutil.CreateBitcoind(ctx)
 
 	_, _, btcAddress, err := bitcoin.KeysAndAddressFromHexString(
 		privateKey,
@@ -1471,9 +1405,8 @@ func createBitcoindWithInitialBlocks(ctx context.Context, t *testing.T, blocks u
 		address = btcAddress.EncodeAddress()
 	}
 
-	_, err = runBitcoinCommand(
+	r, err := testutil.RunBitcoindCommand(
 		ctx,
-		t,
 		bitcoindContainer,
 		[]string{
 			"bitcoin-cli",
@@ -1485,6 +1418,7 @@ func createBitcoindWithInitialBlocks(ctx context.Context, t *testing.T, blocks u
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(r)
 
 	mappedPeerPort, err := bitcoindContainer.MappedPort(ctx, "18444")
 	if err != nil {


### PR DESCRIPTION
**Summary**
Addresses #1038. Creates an E2E test of the expected general behavior of `popm` using a `bitcoind` container node.

**Changes**
- Create `popm` E2E test.
- Move `bitcoind` container node creation to `testutil`.
