### PR TITLE
tbc: add block sanity check to insertBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a malicious or compromised fee source from draining PoP miner UTXOs.
   Set `POPM_MAX_FEE=0` to restore the previous uncapped behavior.
 - Fix `KeystonesByHeight` panic when primary keystone hash keys collide
+- Add `CheckBlockSanity` to `tbc` block insert RPC path as
+  defense-in-depth hardening. The RPC binds to localhost by default and
+  is used by internal services to feed forked-off blocks
+  ([#1057](https://github.com/hemilabs/heminetwork/pull/1057)).
+
 ### Breaking Changes
 
 - Rename `TBC_BLOCKHEADER_CACHE_SIZE` environment variable to

--- a/service/tbc/insertblock_test.go
+++ b/service/tbc/insertblock_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Use of this source code is governed by the MIT License,
+// which can be found in the LICENSE file.
+
+package tbc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+)
+
+func TestInsertBlockSanityCheck(t *testing.T) {
+	s := &Server{
+		cfg: &Config{
+			BlockSanity: true,
+		},
+		timeSource: blockchain.NewMedianTime(),
+	}
+	s.g.chain = &chaincfg.TestNet3Params
+
+	ctx := context.Background()
+
+	// A block with no transactions fails CheckBlockSanity.
+	invalidBlock := btcutil.NewBlock(wire.NewMsgBlock(&wire.BlockHeader{}))
+
+	_, err := s.insertBlock(ctx, invalidBlock)
+	if err == nil {
+		t.Fatal("expected insertBlock to reject invalid block")
+	}
+	if !strings.Contains(err.Error(), "insert block sanity check") {
+		t.Fatalf("expected sanity check error, got: %v", err)
+	}
+}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1730,6 +1730,15 @@ func (s *Server) handleHeaders(ctx context.Context, p *rawpeer.RawPeer, msg *wir
 }
 
 func (s *Server) insertBlock(ctx context.Context, block *btcutil.Block) (int64, error) {
+	if s.cfg.BlockSanity {
+		err := blockchain.CheckBlockSanity(block, s.g.chain.PowLimit,
+			s.timeSource)
+		if err != nil {
+			return 0, fmt.Errorf("insert block sanity check %v: %w",
+				block.Hash(), err)
+		}
+	}
+
 	height, err := s.g.db.BlockInsert(ctx, block)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## tbc: add block sanity check to insertBlock

### What

Adds `CheckBlockSanity` to `insertBlock()` so all block insertion paths
(RPC and P2P) validate blocks before storing them.

### Why

The block insert WebSocket RPCs (`BlockInsertRequest`,
`BlockInsertRawRequest`) were introduced to allow trusted internal
services — specifically op-geth — to feed blocks into tbcd that have
been discarded from the canonical chain after a fork. These RPCs call
`insertBlock()` which stores blocks via `db.BlockInsert()` without
running `CheckBlockSanity`.

The P2P path in `handleBlock` already runs `CheckBlockSanity` (gated on
the `BlockSanity` config flag, default: true) before calling the same
`insertBlock()`. This change adds the same check to `insertBlock()`
itself as defense in depth.

### Context

The WebSocket RPC binds to `localhost:8082` by default
(`tbcapi.DefaultListen`) and is not externally reachable in standard
deployments. This is a hardening measure, not a fix for an actively
exploitable vulnerability.

Addresses hemilabs/eng-security#10.
