### PR TITLE
popmd: set default max fee to 100 sats/vB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of an inventory message list being accessed before ensuring the slice
   isn't empty ([#1039](https://github.com/hemilabs/heminetwork/pull/1039)).
 
+- Set default `POPM_MAX_FEE` to 100 sats/vB (was 0, uncapped). Prevents
+  a malicious or compromised fee source from draining PoP miner UTXOs.
+  Set `POPM_MAX_FEE=0` to restore the previous uncapped behavior.
+
 ### Breaking Changes
 
 - Rename `TBC_BLOCKHEADER_CACHE_SIZE` environment variable to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a malicious or compromised fee source from draining PoP miner UTXOs.
   Set `POPM_MAX_FEE=0` to restore the previous uncapped behavior.
 - Fix `KeystonesByHeight` panic when primary keystone hash keys collide
-  with the height-index key range in LevelDB. The iterator now filters
-  by key length before decoding
-  ([#1059](https://github.com/hemilabs/heminetwork/pull/1059)).
-
 ### Breaking Changes
 
 - Rename `TBC_BLOCKHEADER_CACHE_SIZE` environment variable to

--- a/cmd/popmd/popmd.go
+++ b/cmd/popmd/popmd.go
@@ -88,8 +88,8 @@ var (
 		},
 		"POPM_MAX_FEE": config.Config{
 			Value:        &cfg.MaxFee,
-			DefaultValue: float64(0),
-			Help:         "maximum fee in sats/vbyte for fee estimation, beyond which popm waits for lower fees to remine; 0 disables the cap",
+			DefaultValue: float64(100),
+			Help:         "maximum fee in sats/vbyte for fee estimation, beyond which popm waits for lower fees to remine; set to 0 to disable the cap",
 			Print:        config.PrintAll,
 		},
 	}

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -63,6 +63,8 @@ const (
 
 	minRelayFee = 1                // sats/vbyte
 	maxBlockAge = 30 * time.Second // XXX make this configurable?
+
+	defaultMaxFee = 100 // sats/vbyte
 )
 
 type health struct {
@@ -114,6 +116,7 @@ func NewDefaultConfig() *Config {
 		BitcoinConfirmations:    defaultBitcoinConfirmations,
 		BitcoinSource:           bitcoinSourceTBC,
 		BitcoinURL:              tbcgozer.DefaultURL,
+		MaxFee:                  defaultMaxFee,
 		opgethMinReconnectDelay: defaultMinReconnectDelay,
 		opgethMaxReconnectDelay: defaultMaxReconnectDelay,
 		l2KeystoneMaxAge:        defaultL2KeystoneMaxAge,

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -1039,3 +1039,67 @@ func TestPopMinerE2E(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaultMaxFee(t *testing.T) {
+	cfg := NewDefaultConfig()
+	if cfg.MaxFee != defaultMaxFee {
+		t.Fatalf("expected default MaxFee of %v, got %v",
+			defaultMaxFee, cfg.MaxFee)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 10)
+	msgCh := make(chan string, 10)
+
+	_, kssList := testutil.MakeSharedKeystones(1)
+	btcTip := uint(kssList[len(kssList)-1].L1BlockNumber)
+
+	emptyMap := make(map[chainhash.Hash]*hemi.L2KeystoneAbrev, 0)
+
+	mtbc := mock.NewMockTBC(ctx, errCh, msgCh, emptyMap, btcTip, 100)
+	defer mtbc.Shutdown()
+
+	cfg.BitcoinSource = "tbc"
+	cfg.BitcoinURL = "ws" + strings.TrimPrefix(mtbc.URL(), "http")
+	cfg.BitcoinSecret = "5e2deaa9f1bb2bcef294cc36513c591c5594d6b671fe83a104aa2708bc634c"
+
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gozerReady := make(chan struct{})
+	go func() {
+		err := s.gozer.Run(ctx, func() {
+			gozerReady <- struct{}{}
+		})
+		if err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	select {
+	case <-gozerReady:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	// Fee above default cap should be rejected.
+	mtbc.SetFeeEstimate(defaultMaxFee + 50)
+	_, err = s.estimateFee(ctx)
+	if !errors.Is(err, ErrFeeMaxExceeded) {
+		t.Fatalf("expected FeeMaxExceededError for fee above default cap, got: %v", err)
+	}
+
+	// Fee below default cap should pass.
+	mtbc.SetFeeEstimate(defaultMaxFee - 10)
+	fee, err := s.estimateFee(ctx)
+	if err != nil {
+		t.Fatalf("expected no error for fee below default cap, got: %v", err)
+	}
+	if fee.SatsPerVByte != defaultMaxFee-10 {
+		t.Fatalf("expected fee of %v, got %v", defaultMaxFee-10, fee.SatsPerVByte)
+	}
+}


### PR DESCRIPTION
## popmd: set default max fee to 100 sats/vB

### What

Sets `POPM_MAX_FEE` default to 100 sats/vB (was 0, uncapped).

### Why

With the default at 0, operators who do not explicitly configure
`POPM_MAX_FEE` have no protection against a malicious or compromised
upstream fee source returning arbitrarily high fee estimates. A crafted
estimate just below a selected UTXO value causes popmd to sign and
broadcast a transaction that pays nearly the entire UTXO as miner fee.

PR #1037 added the `MaxFee` cap mechanism but defaulted it to off. This
change enables it by default at a level (100 sats/vB) that covers normal
fee conditions including busy periods. When fees exceed the cap, the
keystone is retried after a cooldown. Operators can override via
`POPM_MAX_FEE` or set it to 0 to restore uncapped behavior.

Addresses hemilabs/eng-security#5.