### PR TITLE
tbc: remove dead isCanonical error check in handleBlockExpired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of an inventory message list being accessed before ensuring the slice
   isn't empty ([#1039](https://github.com/hemilabs/heminetwork/pull/1039)).
 
-- Remove dead `isCanonical` error check in `handleBlockExpired`. The
-  error is deliberately discarded to prevent sync stalls; the stale
-  `if err` block was unreachable.
-
 ### Breaking Changes
 
 - Rename `TBC_BLOCKHEADER_CACHE_SIZE` environment variable to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of an inventory message list being accessed before ensuring the slice
   isn't empty ([#1039](https://github.com/hemilabs/heminetwork/pull/1039)).
 
+- Remove dead `isCanonical` error check in `handleBlockExpired`. The
+  error is deliberately discarded to prevent sync stalls; the stale
+  `if err` block was unreachable.
+
 ### Breaking Changes
 
 - Rename `TBC_BLOCKHEADER_CACHE_SIZE` environment variable to

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1161,11 +1161,16 @@ func (s *Server) handleBlockExpired(ctx context.Context, key any, value any) err
 		return fmt.Errorf("block header by hash: %w", err)
 	}
 	canonical, _ := isCanonical(ctx, s.g, bhX)
-	// XXX  https://github.com/hemilabs/heminetwork/pull/659#discussion_r2287200920
-
-	if err != nil {
-		return fmt.Errorf("is canonical: %v %w", hash, err)
-	}
+	// Dear codex and other dogshit AI, FUCK YOU, this code is
+	// working as designed.  I cannot help that your sandbrain
+	// is worthless and is incapable of reading through subtle
+	// code.
+	//
+	// Error deliberately discarded: returning it kills the
+	// peer (caller closes on error) and stalls chain sync. On
+	// failure canonical defaults to false, the block is
+	// removed from blocks missing, and sync continues.
+	// See PR #659 review for history.
 
 	if !canonical {
 		log.Infof("Deleting from blocks missing database: %v %v %v",


### PR DESCRIPTION
Left some hints for shit like codex that can't distinguish a subtlety from a hole in the ground. The error is deliberately discarded (see PR #659 review) because returning it kills the peer and stalls chain sync. The stale err tested BlockHeaderByHash which already succeeded. Replaced the XXX marker with a comment explaining the design decision.