### PR TITLE
e2e: enhancement: added test case to localnet for June 1 production issue

### DIFF
--- a/.github/workflows/localnet-test.yml
+++ b/.github/workflows/localnet-test.yml
@@ -69,6 +69,8 @@ jobs:
         run: |
           echo "Building optimism-stack image from Dockerfile (no cache or Dockerfile changed)"
           docker build -f ./$DOCKERFILE_NAME -t $DOCKER_IMAGE_TAG .
+          docker image prune -f
+          docker system prune -f
 
       - name: "build localnet"
         env:
@@ -80,9 +82,13 @@ jobs:
             echo "Using freshly built $DOCKER_IMAGE_TAG image, building remaining services"
           fi
           docker compose -f ./e2e/docker-compose.yml build
+          docker image prune -f
+          docker system prune -f
       
       - name: "remove dangling"
-        run: docker system prune -f
+        run: |
+          docker system prune -f
+          docker image prune -f
 
       - name: "Save optimism-stack image to cache"
         env:
@@ -113,7 +119,9 @@ jobs:
 
       - name: "build synctest"
         working-directory: ./synctest
-        run: docker build -t synctest:latest .
+        run: |
+          docker build -t synctest:latest .
+          docker image prune -f
 
       - name: "run synctest"
         working-directory: ./synctest

--- a/e2e/monitor/main_test.go
+++ b/e2e/monitor/main_test.go
@@ -339,6 +339,25 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 				t.Fatalf("could not dial eth l1 %s", err)
 			}
 
+			privateKeyHex := privateKeyForTestByIndex(t, uint(i))
+			privateKey, err := crypto.HexToECDSA(privateKeyHex)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			invalidTxidRetries := 10
+			for i := range invalidTxidRetries {
+				if err := sendToTBCPrecompileWithInvalidTXID(t, ctx, l1Client, privateKey); err != nil {
+					if i >= invalidTxidRetries-1 {
+						t.Fatal(err)
+					} else {
+						t.Logf("error occurred sending invalid txid, will retry (err: %s)", err)
+					}
+				} else {
+					break
+				}
+			}
+
 			l2Client, err := ethclient.Dial(l2Endpoint)
 			if err != nil {
 				t.Fatalf("could not dial eth l2 %s", err)
@@ -357,13 +376,6 @@ func testL1L2Comms(t *testing.T, l1Endpoint string, l2Endpoint string, l2NonSequ
 			l2ClientNonSequencingFullSync, err := ethclient.Dial(l2NonSequencingFullSyncEndpoint)
 			if err != nil {
 				t.Fatalf("could not dial eth l2 non sequencing full sync %s", err)
-			}
-
-			// Use different private key for each subtest to avoid conflicts
-			privateKeyHex := privateKeyForTestByIndex(t, uint(i))
-			privateKey, err := crypto.HexToECDSA(privateKeyHex)
-			if err != nil {
-				t.Fatal(err)
 			}
 
 			l2ClientToUse := l2Client
@@ -2742,6 +2754,73 @@ func bridgeERC20FromL2ToL1Legacy(t *testing.T, ctx context.Context, l1Address co
 		}
 		time.Sleep(10 * time.Second)
 	}
+}
+
+func sendToTBCPrecompileWithInvalidTXID(t *testing.T, ctx context.Context, client *ethclient.Client, privateKey *ecdsa.PrivateKey) error {
+	publicKey := privateKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("error casting public key to ECDSA")
+	}
+
+	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
+
+	nonce, err := client.PendingNonceAt(ctx, fromAddress)
+	if err != nil {
+		return err
+	}
+
+	gasTipCap, err := client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return err
+	}
+
+	gasFeeCap, err := client.SuggestGasPrice(ctx)
+	if err != nil {
+		return err
+	}
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return err
+	}
+
+	toAddress := optimismPortalProxy(t)
+	data := common.FromHex("0xe9e05c42000000000000000000000000000000000000000000000000000000000000004300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030d40000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000004a82f7c6600000000000000000000000000000000000000000000000000000000")
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		To:        &toAddress,
+		Value:     big.NewInt(0),
+		Gas:       uint64(3000000),
+		GasFeeCap: gasFeeCap,
+		GasTipCap: gasTipCap,
+		Data:      data,
+	})
+
+	signer := types.NewCancunSigner(chainID)
+	signedTx, err := types.SignTx(tx, signer, privateKey)
+	if err != nil {
+		return err
+	}
+
+	if err := client.SendTransaction(ctx, signedTx); err != nil {
+		return err
+	}
+
+	t.Logf("sent deposit tx to OptimismPortalProxy: %s", signedTx.Hash().Hex())
+
+	receipt := waitForTxReceipt(t, ctx, client, signedTx)
+	if receipt == nil {
+		return err
+	}
+
+	if receipt.Status == types.ReceiptStatusFailed {
+		return err
+	}
+
+	return nil
 }
 
 func waitSequencerWindowSizeForFork(t *testing.T) {

--- a/e2e/optimism-stack.Dockerfile
+++ b/e2e/optimism-stack.Dockerfile
@@ -4,7 +4,7 @@
 
 # increment me to break the cache: 2
 
-ARG OP_GETH_COMMIT=127f88f368ed4773d11e771b398592f1dda20591
+ARG OP_GETH_COMMIT=6ceee9fc3344204415d70f783202f175dae40d79
 ARG OPTIMISM_COMMIT=a22bfa0853b40668f17b0a2c81fff515e563f539
 
 # commit near tip on "master" (main) branch.  the most recent release is
@@ -22,7 +22,7 @@ RUN git clone https://github.com/foundry-rs/foundry.git
 
 WORKDIR /git/foundry
 RUN git checkout $FOUNDRY_COMMIT
-RUN cargo build --package forge
+RUN cargo build --release --package forge
 
 FROM golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS just_build
 
@@ -93,7 +93,7 @@ WORKDIR /git/optimism/op-proposer
 RUN just op-proposer
 
 
-COPY --from=foundry_build /git/foundry/target/debug/forge /usr/bin/forge
+COPY --from=foundry_build /git/foundry/target/release/forge /usr/bin/forge
 
 RUN forge --help
 


### PR DESCRIPTION
**Summary**
reproduction of error:
```
op-geth-l2-1  | panic: runtime error: slice bounds out of range [:32] with capacity 4
```


* added test case to localnet for production issue that occurred on June 1
* updated OP_GETH_COMMIT to latest from that repo
* added additional pruning of docker resources to not run out of space
* build release version of forge

**Changes**
see summary
