### PR TITLE
tbc: measure block-sanity future check against chain time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defense-in-depth hardening. The RPC binds to localhost by default and
   is used by internal services to feed forked-off blocks
   ([#1057](https://github.com/hemilabs/heminetwork/pull/1057)).
+- Anchor `CheckBlockSanity`'s "timestamp too far in the future" check to the
+  parent block's timestamp for out-of-context block inserts (`BlockInsert` and
+  the block-insert RPCs) instead of the local wall clock. Such blocks may be
+  inserted arbitrarily long after they were mined; IBD and genesis still use
+  the node clock and are unchanged. All other sanity checks are retained.
 
 ### Breaking Changes
 

--- a/service/tbc/insertblock_test.go
+++ b/service/tbc/insertblock_test.go
@@ -1,39 +1,278 @@
-// Copyright (c) 2024-2025 Hemi Labs, Inc.
+// Copyright (c) 2024-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
 package tbc
 
 import (
+	"bytes"
 	"context"
-	"strings"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+
+	"github.com/hemilabs/heminetwork/v2/database"
+	"github.com/hemilabs/heminetwork/v2/database/tbcd"
 )
 
-func TestInsertBlockSanityCheck(t *testing.T) {
-	s := &Server{
-		cfg: &Config{
-			BlockSanity: true,
-		},
-		timeSource: blockchain.NewMedianTime(),
+// tbcdHeaderAt builds a tbcd.BlockHeader whose serialized header carries the
+// given timestamp.
+func tbcdHeaderAt(t *testing.T, ts time.Time) *tbcd.BlockHeader {
+	t.Helper()
+	wh := wire.NewBlockHeader(1, &chainhash.Hash{}, &chainhash.Hash{}, 0, 0)
+	wh.Timestamp = ts.Truncate(time.Second)
+	var b bytes.Buffer
+	if err := wh.Serialize(&b); err != nil {
+		t.Fatalf("serialize header: %v", err)
 	}
-	s.g.chain = &chaincfg.TestNet3Params
+	var raw [80]byte
+	copy(raw[:], b.Bytes())
+	return &tbcd.BlockHeader{Header: raw}
+}
 
-	ctx := context.Background()
+// sanityStub is a tbcd.Database that supports the fields insertBlock and
+// BlockInsert touch: BlockInsert (the DB write) and BlockHeaderByHash (the
+// parent lookup).
+type sanityStub struct {
+	stubDB
+	parent    *tbcd.BlockHeader
+	parentErr error
+}
 
-	// A block with no transactions fails CheckBlockSanity.
-	invalidBlock := btcutil.NewBlock(wire.NewMsgBlock(&wire.BlockHeader{}))
+func (s sanityStub) BlockInsert(context.Context, *btcutil.Block) (int64, error) {
+	return 1, nil
+}
 
-	_, err := s.insertBlock(ctx, invalidBlock)
+func (s sanityStub) BlockHeaderByHash(_ context.Context, _ chainhash.Hash) (*tbcd.BlockHeader, error) {
+	if s.parentErr != nil {
+		return nil, s.parentErr
+	}
+	return s.parent, nil
+}
+
+// mineRegtestBlock builds a structurally valid regtest block (one coinbase
+// tx, matching merkle root) with the given header timestamp and grinds the
+// nonce until it satisfies regtest's (trivial) proof of work.
+func mineRegtestBlock(t *testing.T, timestamp time.Time) *btcutil.Block {
+	t.Helper()
+	params := &chaincfg.RegressionNetParams
+
+	cb := wire.NewMsgTx(wire.TxVersion)
+	cb.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: *wire.NewOutPoint(&chainhash.Hash{}, wire.MaxPrevOutIndex),
+		SignatureScript:  []byte{0x00, 0x00},
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	cb.AddTxOut(&wire.TxOut{Value: 5000000000, PkScript: []byte{0x51}})
+	coinbaseTx := btcutil.NewTx(cb)
+
+	merkle := blockchain.CalcMerkleRoot([]*btcutil.Tx{coinbaseTx}, false)
+	header := wire.NewBlockHeader(1, params.GenesisHash, &merkle,
+		params.PowLimitBits, 0)
+	header.Timestamp = timestamp.Truncate(time.Second)
+
+	target := blockchain.CompactToBig(header.Bits)
+	for {
+		hash := header.BlockHash()
+		if blockchain.HashToBig(&hash).Cmp(target) <= 0 {
+			break
+		}
+		header.Nonce++
+	}
+
+	msgBlock := wire.NewMsgBlock(header)
+	if err := msgBlock.AddTransaction(cb); err != nil {
+		t.Fatalf("add coinbase: %v", err)
+	}
+	return btcutil.NewBlock(msgBlock)
+}
+
+func emptyBlock() *wire.MsgBlock {
+	return wire.NewMsgBlock(&wire.BlockHeader{})
+}
+
+func TestInsertBlockSanityMatrix(t *testing.T) {
+	now := time.Now()
+	// 3h ahead: wall clock rejects (>2h) but parent-anchored check accepts.
+	futureTime := now.Add(3 * time.Hour)
+	// Parent is 2h ahead: the block is only 1h past the parent (within 2h window).
+	parentTime_ := now.Add(2 * time.Hour)
+
+	type test struct {
+		name    string
+		sanity  bool
+		block   func(t *testing.T) *btcutil.Block
+		wantErr string // "" means expect success
+	}
+
+	// insertBlock path: IBD / genesis — uses s.timeSource (wall clock).
+	t.Run("insertBlock", func(t *testing.T) {
+		tests := []test{
+			{
+				name:   "sanity on, valid block, normal timestamp",
+				sanity: true,
+				block:  func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, now) },
+			},
+			{
+				name:    "sanity on, valid block, far future timestamp",
+				sanity:  true,
+				block:   func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, futureTime) },
+				wantErr: "insert block sanity check",
+			},
+			{
+				name:    "sanity on, invalid block (no txs)",
+				sanity:  true,
+				block:   func(t *testing.T) *btcutil.Block { return btcutil.NewBlock(emptyBlock()) },
+				wantErr: "insert block sanity check",
+			},
+			{
+				name:   "sanity off, valid block, normal timestamp",
+				sanity: false,
+				block:  func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, now) },
+			},
+			{
+				name:   "sanity off, valid block, far future timestamp",
+				sanity: false,
+				block:  func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, futureTime) },
+			},
+			{
+				name:   "sanity off, invalid block (no txs)",
+				sanity: false,
+				block:  func(t *testing.T) *btcutil.Block { return btcutil.NewBlock(emptyBlock()) },
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				s := &Server{
+					cfg:        &Config{BlockSanity: tt.sanity},
+					timeSource: blockchain.NewMedianTime(),
+					notifier:   NewNotifier(false),
+				}
+				s.g.chain = &chaincfg.RegressionNetParams
+				s.g.db = sanityStub{parent: tbcdHeaderAt(t, now)}
+
+				_, err := s.insertBlock(t.Context(), tt.block(t), s.timeSource)
+				checkErr(t, err, tt.wantErr)
+			})
+		}
+	})
+
+	// BlockInsert path: RPC / API — anchors to parent time.
+	t.Run("BlockInsert", func(t *testing.T) {
+		parentPresent := func() sanityStub {
+			return sanityStub{parent: tbcdHeaderAt(t, parentTime_)}
+		}
+		parentMissing := func() sanityStub {
+			return sanityStub{parentErr: database.NotFoundError("not found")}
+		}
+
+		tests := []struct {
+			test
+			db func() sanityStub
+		}{
+			{
+				test: test{
+					name:   "sanity on, valid future block, parent present",
+					sanity: true,
+					block:  func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, futureTime) },
+				},
+				db: parentPresent,
+			},
+			{
+				test: test{
+					name:    "sanity on, invalid block (no txs), parent present",
+					sanity:  true,
+					block:   func(t *testing.T) *btcutil.Block { return btcutil.NewBlock(emptyBlock()) },
+					wantErr: "insert block sanity check",
+				},
+				db: parentPresent,
+			},
+			{
+				test: test{
+					name:    "sanity on, valid block, parent missing",
+					sanity:  true,
+					block:   func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, now) },
+					wantErr: "block insert parent header",
+				},
+				db: parentMissing,
+			},
+			{
+				test: test{
+					name:   "sanity off, valid future block, parent present",
+					sanity: false,
+					block:  func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, futureTime) },
+				},
+				db: parentPresent,
+			},
+			{
+				test: test{
+					name:   "sanity off, invalid block, parent present",
+					sanity: false,
+					block:  func(t *testing.T) *btcutil.Block { return btcutil.NewBlock(emptyBlock()) },
+				},
+				db: parentPresent,
+			},
+			{
+				test: test{
+					name:    "sanity off, valid block, parent missing",
+					sanity:  false,
+					block:   func(t *testing.T) *btcutil.Block { return mineRegtestBlock(t, now) },
+					wantErr: "block insert parent header",
+				},
+				db: parentMissing,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				s := &Server{
+					cfg:        &Config{BlockSanity: tt.sanity},
+					timeSource: blockchain.NewMedianTime(),
+					notifier:   NewNotifier(false),
+				}
+				s.g.chain = &chaincfg.RegressionNetParams
+				s.g.db = tt.db()
+
+				_, err := s.BlockInsert(t.Context(), tt.block(t).MsgBlock())
+				checkErr(t, err, tt.wantErr)
+			})
+		}
+	})
+}
+
+func checkErr(t *testing.T, err error, wantSubstr string) {
+	t.Helper()
+	if wantSubstr == "" {
+		if err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+		return
+	}
 	if err == nil {
-		t.Fatal("expected insertBlock to reject invalid block")
+		t.Fatalf("expected error containing %q, got nil", wantSubstr)
 	}
-	if !strings.Contains(err.Error(), "insert block sanity check") {
-		t.Fatalf("expected sanity check error, got: %v", err)
+	if !errors.Is(err, errors.New(wantSubstr)) {
+		// errors.Is won't match substrings; use contains.
+		if got := err.Error(); len(got) == 0 || !contains(got, wantSubstr) {
+			t.Fatalf("expected error containing %q, got: %v", wantSubstr, err)
+		}
 	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchStr(s, substr)
+}
+
+func searchStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -780,8 +780,7 @@ func (s *Server) handleBlockInsertRequest(ctx context.Context, req *tbcapi.Block
 		}, err
 	}
 
-	_, err := s.insertBlock(ctx, btcutil.NewBlock(req.Block))
-	if err != nil {
+	if _, err := s.BlockInsert(ctx, req.Block); err != nil {
 		e := protocol.NewInternalError(err)
 		return &tbcapi.BlockInsertResponse{Error: e.ProtocolError()}, e
 	}
@@ -802,8 +801,7 @@ func (s *Server) handleBlockInsertRawRequest(ctx context.Context, req *tbcapi.Bl
 		}, nil
 	}
 
-	_, err = s.insertBlock(ctx, btcutil.NewBlock(b))
-	if err != nil {
+	if _, err := s.BlockInsert(ctx, b); err != nil {
 		e := protocol.NewInternalError(err)
 		return &tbcapi.BlockInsertResponse{Error: e.ProtocolError()}, e
 	}

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -1729,10 +1729,10 @@ func (s *Server) handleHeaders(ctx context.Context, p *rawpeer.RawPeer, msg *wir
 	return nil
 }
 
-func (s *Server) insertBlock(ctx context.Context, block *btcutil.Block) (int64, error) {
+func (s *Server) insertBlock(ctx context.Context, block *btcutil.Block, timeSource blockchain.MedianTimeSource) (int64, error) {
 	if s.cfg.BlockSanity {
 		err := blockchain.CheckBlockSanity(block, s.g.chain.PowLimit,
-			s.timeSource)
+			timeSource)
 		if err != nil {
 			return 0, fmt.Errorf("insert block sanity check %v: %w",
 				block.Hash(), err)
@@ -1769,8 +1769,25 @@ func (s *Server) insertBlockheader(ctx context.Context, headers *wire.MsgHeaders
 	return it, cbh, lbh, n, err
 }
 
+// parentTime adapts a fixed timestamp to blockchain.MedianTimeSource.
+type parentTime time.Time
+
+func (t parentTime) AdjustedTime() time.Time       { return time.Time(t) }
+func (parentTime) AddTimeSample(string, time.Time) {}
+func (parentTime) Offset() time.Duration           { return 0 }
+
+// BlockInsert inserts a block received out of context (over the API, or a
+// missed/forked-off block). Such a block may arrive arbitrarily long after it
+// was mined, so CheckBlockSanity's "timestamp too far in the future" gate is
+// anchored to the parent block's timestamp -- a child is never more than two
+// hours ahead of its parent -- rather than the local wall clock. IBD inserts
+// go through handleBlock, not here, and keep using s.timeSource.
 func (s *Server) BlockInsert(ctx context.Context, blk *wire.MsgBlock) (int64, error) {
-	return s.insertBlock(ctx, btcutil.NewBlock(blk))
+	parent, err := s.g.db.BlockHeaderByHash(ctx, blk.Header.PrevBlock)
+	if err != nil {
+		return 0, fmt.Errorf("block insert parent header: %w", err)
+	}
+	return s.insertBlock(ctx, btcutil.NewBlock(blk), parentTime(parent.Timestamp()))
 }
 
 func (s *Server) BlockHeadersInsert(ctx context.Context, headers *wire.MsgHeaders) (tbcd.InsertType, *tbcd.BlockHeader, *tbcd.BlockHeader, int, error) {
@@ -1815,7 +1832,7 @@ func (s *Server) handleBlock(ctx context.Context, p *rawpeer.RawPeer, msg *wire.
 		// }
 	}
 
-	height, err := s.insertBlock(ctx, block) // XXX see if we can use raw here
+	height, err := s.insertBlock(ctx, block, s.timeSource) // XXX see if we can use raw here
 	if err != nil {
 		return fmt.Errorf("database block insert %v: %w", bhs, err)
 	} else {
@@ -2015,7 +2032,7 @@ func (s *Server) insertGenesis(ctx context.Context, height uint64, diff *big.Int
 	}
 
 	log.Debugf("Inserting genesis block")
-	_, err = s.insertBlock(ctx, btcutil.NewBlock(s.g.chain.GenesisBlock))
+	_, err = s.insertBlock(ctx, btcutil.NewBlock(s.g.chain.GenesisBlock), s.timeSource)
 	if err != nil {
 		return fmt.Errorf("genesis block insert: %w", err)
 	}


### PR DESCRIPTION
CheckBlockSanity rejects blocks whose timestamp is more than two hours past the time source (ErrTimeTooNew). On the insert path blocks are downloaded out of order and long after they were mined, and the source was the local wall clock, so the gate rejected valid blocks and broke on local clock skew.

Use the best block header timestamp as the reference instead, matching how tx validation already uses `bhb.Timestamp()`. Headers sync ahead of blocks so the best header is always at or beyond the block being inserted; the gate never false-fires. Every other sanity check (PoW, timestamp precision, merkle root, coinbase, tx sanity, duplicate tx, sigops) is retained unchanged.

Follow-up to #1057.