### PR TITLE
tbc: guard MsgTx dispatch on MempoolEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Guard `MsgTx` dispatch on `MempoolEnabled` in `handleGeneric`. When
+  the mempool is disabled, unsolicited P2P transaction messages caused a
+  nil pointer dereference crash.
+
 - Fix a remote crash vulnerability in `tbc` caused by the first element
   of an inventory message list being accessed before ensuring the slice
   isn't empty ([#1039](https://github.com/hemilabs/heminetwork/pull/1039)).

--- a/service/tbc/tbc.go
+++ b/service/tbc/tbc.go
@@ -567,8 +567,10 @@ func (s *Server) handleGeneric(ctx context.Context, p *rawpeer.RawPeer, msg wire
 		}
 
 	case *wire.MsgTx:
-		if err := s.handleTx(ctx, p, m, raw); err != nil {
-			return fmt.Errorf("handle generic transaction: %w", err)
+		if s.cfg.MempoolEnabled {
+			if err := s.handleTx(ctx, p, m, raw); err != nil {
+				return fmt.Errorf("handle generic transaction: %w", err)
+			}
 		}
 
 	case *wire.MsgInv:

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -2541,10 +2541,10 @@ type indexerStub struct {
 	hash chainhash.Hash
 }
 
-func (s indexerStub) Enabled() bool                                           { return true }
-func (s indexerStub) Indexing() bool                                          { return false }
-func (s indexerStub) IndexToBest(context.Context) error                       { return nil }
-func (s indexerStub) IndexToHash(context.Context, chainhash.Hash) error       { return nil }
+func (s indexerStub) Enabled() bool                                     { return true }
+func (s indexerStub) Indexing() bool                                    { return false }
+func (s indexerStub) IndexToBest(context.Context) error                 { return nil }
+func (s indexerStub) IndexToHash(context.Context, chainhash.Hash) error { return nil }
 func (s indexerStub) IndexerAt(context.Context) (*tbcd.BlockHeader, error) {
 	return &tbcd.BlockHeader{Hash: s.hash}, nil
 }

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -2515,3 +2515,58 @@ func TestHandleGenericMsgTxMempoolEnabled(t *testing.T) {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
 }
+
+// txErrorDB makes synced() return Synced:true on the first BlockHeaderBest
+// call, then returns an error on the second call inside handleTx.
+type txErrorDB struct {
+	stubDB
+	calls int
+	hash  chainhash.Hash
+}
+
+func (d *txErrorDB) BlockHeaderBest(context.Context) (*tbcd.BlockHeader, error) {
+	d.calls++
+	if d.calls == 1 {
+		return &tbcd.BlockHeader{Hash: d.hash, Height: 100}, nil
+	}
+	return nil, errors.New("db error")
+}
+
+func (d *txErrorDB) BlocksMissing(context.Context, int) ([]tbcd.BlockIdentifier, error) {
+	return nil, nil
+}
+
+// indexerStub satisfies the Indexer interface, returning a fixed block header.
+type indexerStub struct {
+	hash chainhash.Hash
+}
+
+func (s indexerStub) Enabled() bool                                           { return true }
+func (s indexerStub) Indexing() bool                                          { return false }
+func (s indexerStub) IndexToBest(context.Context) error                       { return nil }
+func (s indexerStub) IndexToHash(context.Context, chainhash.Hash) error       { return nil }
+func (s indexerStub) IndexerAt(context.Context) (*tbcd.BlockHeader, error) {
+	return &tbcd.BlockHeader{Hash: s.hash}, nil
+}
+
+func TestHandleGenericMsgTxError(t *testing.T) {
+	hash := chainhash.Hash{1}
+	mp, err := NewMempool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := &txErrorDB{hash: hash}
+	s := &Server{
+		cfg:     &Config{MempoolEnabled: true},
+		mempool: mp,
+	}
+	s.g.db = db
+	s.ui = indexerStub{hash: hash}
+	s.ti = indexerStub{hash: hash}
+
+	tx := wire.NewMsgTx(2)
+	err = s.handleGeneric(t.Context(), nil, tx, nil)
+	if err == nil {
+		t.Fatal("expected error from handleTx, got nil")
+	}
+}

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -2469,3 +2469,49 @@ func TestEmptyInvMessage(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleGenericMsgTxMempoolDisabled(t *testing.T) {
+	s := &Server{
+		cfg: &Config{MempoolEnabled: false},
+	}
+	// s.mempool is nil — this panicked before the guard.
+	tx := wire.NewMsgTx(2)
+	err := s.handleGeneric(t.Context(), nil, tx, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}
+
+// syncedStub is a tbcd.Database that returns an error from
+// BlockHeaderBest so synced() exits early on a cancelled context.
+type syncedStub struct {
+	stubDB
+}
+
+func (syncedStub) BlockHeaderBest(context.Context) (*tbcd.BlockHeader, error) {
+	return nil, errors.New("stub")
+}
+
+func TestHandleGenericMsgTxMempoolEnabled(t *testing.T) {
+	mp, err := NewMempool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{
+		cfg:     &Config{MempoolEnabled: true},
+		mempool: mp,
+	}
+	s.g.db = syncedStub{}
+
+	// Use a cancelled context so synced() returns SyncInfo{Synced: false}
+	// after BlockHeaderBest errors. This exercises the MempoolEnabled=true
+	// branch in handleGeneric without needing full server infrastructure.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	tx := wire.NewMsgTx(2)
+	err = s.handleGeneric(ctx, nil, tx, nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}


### PR DESCRIPTION
When `MempoolEnabled` is false, `s.mempool` is nil. `handleGeneric` dispatched `MsgTx` to `handleTx` unconditionally, which dereferences `s.mempool` — an unsolicited P2P transaction message crashes the process.

Gate the dispatch on `s.cfg.MempoolEnabled`, matching the pattern already used by `handleInv`'s mempool block.