### PR TITLE
ci: disable golangci-lint action cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,7 @@ jobs:
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
+          cache: false
 
       - name: "golangci-lint fmt"
         run: golangci-lint fmt --diff ./...


### PR DESCRIPTION
The built-in cache key does not include `go.sum`, so dependency changes (new module paths) cause stale type-analysis results to be restored, producing false SA5011 staticcheck positives. Lint takes ~1 minute; the cache saves little and causes recurring CI breakage.