### PR TITLE
hproxy: add HTTP server timeouts and control body limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defense-in-depth hardening. The RPC binds to localhost by default and
   is used by internal services to feed forked-off blocks
   ([#1057](https://github.com/hemilabs/heminetwork/pull/1057)).
-- Add `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, and
-  `IdleTimeout` to the `hproxy` proxy and control HTTP servers.
-  Zero timeouts allowed slowloris-style connection exhaustion.
-- Add `MaxBytesReader` to `hproxy` control add and remove endpoints.
-  Unbounded request bodies could cause OOM.
+- Add HTTP server timeouts and `MaxBytesReader` body limits to `hproxy`.
+  Zero timeouts allowed slowloris-style connection exhaustion and
+  unbounded request bodies could cause OOM
+  ([#1079](https://github.com/hemilabs/heminetwork/pull/1079)).
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defense-in-depth hardening. The RPC binds to localhost by default and
   is used by internal services to feed forked-off blocks
   ([#1057](https://github.com/hemilabs/heminetwork/pull/1057)).
+- Add `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, and
+  `IdleTimeout` to the `hproxy` proxy and control HTTP servers.
+  Zero timeouts allowed slowloris-style connection exhaustion.
+- Add `MaxBytesReader` to `hproxy` control add and remove endpoints.
+  Unbounded request bodies could cause OOM.
 
 ### Breaking Changes
 

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -133,9 +133,9 @@ var (
 				return time.ParseDuration(envValue)
 			},
 		},
-		"HPROXY_SERVER_IDLE_TIMEOUT": config.Config{
-			Value:        &cfg.ServerIdleTimeout,
-			DefaultValue: hproxy.DefaultServerIdleTimeout,
+		"HPROXY_IDLE_TIMEOUT": config.Config{
+			Value:        &cfg.IdleTimeout,
+			DefaultValue: hproxy.DefaultIdleTimeout,
 			Help:         "HTTP server idle connection timeout",
 			Print:        config.PrintAll,
 			Parse: func(envValue string) (any, error) {

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -108,7 +108,7 @@ var (
 		},
 		"HPROXY_READ_HEADER_TIMEOUT": config.Config{
 			Value:        &cfg.ReadHeaderTimeout,
-			DefaultValue: cfg.ReadHeaderTimeout,
+			DefaultValue: hproxy.DefaultReadHeaderTimeout,
 			Help:         "HTTP server read header timeout",
 			Print:        config.PrintAll,
 			Parse: func(envValue string) (any, error) {
@@ -117,7 +117,7 @@ var (
 		},
 		"HPROXY_READ_TIMEOUT": config.Config{
 			Value:        &cfg.ReadTimeout,
-			DefaultValue: cfg.ReadTimeout,
+			DefaultValue: hproxy.DefaultReadTimeout,
 			Help:         "HTTP server read timeout",
 			Print:        config.PrintAll,
 			Parse: func(envValue string) (any, error) {
@@ -126,7 +126,7 @@ var (
 		},
 		"HPROXY_WRITE_TIMEOUT": config.Config{
 			Value:        &cfg.WriteTimeout,
-			DefaultValue: cfg.WriteTimeout,
+			DefaultValue: hproxy.DefaultWriteTimeout,
 			Help:         "HTTP server write timeout",
 			Print:        config.PrintAll,
 			Parse: func(envValue string) (any, error) {
@@ -135,7 +135,7 @@ var (
 		},
 		"HPROXY_SERVER_IDLE_TIMEOUT": config.Config{
 			Value:        &cfg.ServerIdleTimeout,
-			DefaultValue: cfg.ServerIdleTimeout,
+			DefaultValue: hproxy.DefaultServerIdleTimeout,
 			Help:         "HTTP server idle connection timeout",
 			Print:        config.PrintAll,
 			Parse: func(envValue string) (any, error) {
@@ -144,7 +144,7 @@ var (
 		},
 		"HPROXY_MAX_CONTROL_BODY_SIZE": config.Config{
 			Value:        &cfg.MaxControlBodySize,
-			DefaultValue: cfg.MaxControlBodySize,
+			DefaultValue: hproxy.DefaultMaxControlBodySize,
 			Help:         "max request body size for control endpoints (bytes)",
 			Print:        config.PrintAll,
 		},

--- a/cmd/hproxyd/hproxyd.go
+++ b/cmd/hproxyd/hproxyd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 
@@ -105,6 +105,48 @@ var (
 			Parse: func(envValue string) (any, error) {
 				return time.ParseDuration(envValue)
 			},
+		},
+		"HPROXY_READ_HEADER_TIMEOUT": config.Config{
+			Value:        &cfg.ReadHeaderTimeout,
+			DefaultValue: cfg.ReadHeaderTimeout,
+			Help:         "HTTP server read header timeout",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
+		},
+		"HPROXY_READ_TIMEOUT": config.Config{
+			Value:        &cfg.ReadTimeout,
+			DefaultValue: cfg.ReadTimeout,
+			Help:         "HTTP server read timeout",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
+		},
+		"HPROXY_WRITE_TIMEOUT": config.Config{
+			Value:        &cfg.WriteTimeout,
+			DefaultValue: cfg.WriteTimeout,
+			Help:         "HTTP server write timeout",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
+		},
+		"HPROXY_SERVER_IDLE_TIMEOUT": config.Config{
+			Value:        &cfg.ServerIdleTimeout,
+			DefaultValue: cfg.ServerIdleTimeout,
+			Help:         "HTTP server idle connection timeout",
+			Print:        config.PrintAll,
+			Parse: func(envValue string) (any, error) {
+				return time.ParseDuration(envValue)
+			},
+		},
+		"HPROXY_MAX_CONTROL_BODY_SIZE": config.Config{
+			Value:        &cfg.MaxControlBodySize,
+			DefaultValue: cfg.MaxControlBodySize,
+			Help:         "max request body size for control endpoints (bytes)",
+			Print:        config.PrintAll,
 		},
 	}
 )

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -56,7 +56,7 @@ const (
 	DefaultReadHeaderTimeout  = 10 * time.Second // Slowloris header defense
 	DefaultReadTimeout        = 30 * time.Second // Full request read ceiling
 	DefaultWriteTimeout       = 30 * time.Second // Response write ceiling
-	DefaultServerIdleTimeout  = 60 * time.Second // Keep-alive reap
+	DefaultIdleTimeout        = 60 * time.Second // Keep-alive reap
 	DefaultMaxControlBodySize = int64(1 << 20)   // 1 MiB, control endpoint body limit
 	DefaultPollFrequency      = 11 * time.Second // Smaller than 12s
 	DefaultListenAddress      = "localhost:8545" // Default geth port
@@ -178,7 +178,7 @@ type Config struct {
 	ReadHeaderTimeout       time.Duration
 	ReadTimeout             time.Duration
 	RequestTimeout          time.Duration
-	ServerIdleTimeout       time.Duration
+	IdleTimeout             time.Duration
 	WriteTimeout            time.Duration
 	MaxControlBodySize      int64
 }
@@ -194,7 +194,7 @@ func NewDefaultConfig() *Config {
 		ReadHeaderTimeout:   DefaultReadHeaderTimeout,
 		ReadTimeout:         DefaultReadTimeout,
 		RequestTimeout:      DefaultRequestTimeout,
-		ServerIdleTimeout:   DefaultServerIdleTimeout,
+		IdleTimeout:         DefaultIdleTimeout,
 		WriteTimeout:        DefaultWriteTimeout,
 		MaxControlBodySize:  DefaultMaxControlBodySize,
 		MaxRequestSize:      defaultMaxRequestSize,
@@ -1084,7 +1084,7 @@ func (s *Server) Run(pctx context.Context) error {
 		ReadHeaderTimeout: s.cfg.ReadHeaderTimeout,
 		ReadTimeout:       s.cfg.ReadTimeout,
 		WriteTimeout:      s.cfg.WriteTimeout,
-		IdleTimeout:       s.cfg.ServerIdleTimeout,
+		IdleTimeout:       s.cfg.IdleTimeout,
 	}
 	go func() {
 		log.Infof("Listening: %s", ln.Addr())
@@ -1113,7 +1113,7 @@ func (s *Server) Run(pctx context.Context) error {
 			ReadHeaderTimeout: s.cfg.ReadHeaderTimeout,
 			ReadTimeout:       s.cfg.ReadTimeout,
 			WriteTimeout:      s.cfg.WriteTimeout,
-			IdleTimeout:       s.cfg.ServerIdleTimeout,
+			IdleTimeout:       s.cfg.IdleTimeout,
 		}
 		go func() {
 			log.Infof("Control listening: %s", s.cfg.ControlAddress)

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -51,12 +51,16 @@ const (
 	logLevel = "INFO"
 
 	// XXX think about these durations
-	DefaultClientIdleTimeout = 5 * time.Minute  // Reap timer for client persistence
-	DefaultRequestTimeout    = 9 * time.Second  // Smaller than 12s
-	DefaultMaxControlBody    = 1 << 20          // 1 MiB, control endpoint body limit
-	DefaultPollFrequency     = 11 * time.Second // Smaller than 12s
-	DefaultListenAddress     = "localhost:8545" // Default geth port
-	DefaultControlAddress    = "localhost:1337" // Default control port
+	DefaultClientIdleTimeout  = 5 * time.Minute  // Reap timer for client persistence
+	DefaultRequestTimeout     = 9 * time.Second  // Smaller than 12s
+	DefaultReadHeaderTimeout  = 10 * time.Second // Slowloris header defense
+	DefaultReadTimeout        = 30 * time.Second // Full request read ceiling
+	DefaultWriteTimeout       = 30 * time.Second // Response write ceiling
+	DefaultServerIdleTimeout  = 60 * time.Second // Keep-alive reap
+	DefaultMaxControlBodySize = int64(1 << 20)   // 1 MiB, control endpoint body limit
+	DefaultPollFrequency      = 11 * time.Second // Smaller than 12s
+	DefaultListenAddress      = "localhost:8545" // Default geth port
+	DefaultControlAddress     = "localhost:1337" // Default control port
 
 	expectedClients = 1000
 
@@ -187,12 +191,12 @@ func NewDefaultConfig() *Config {
 		PollFrequency:       DefaultPollFrequency,
 		Network:             "mainnet",
 		PrometheusNamespace: appName,
-		ReadHeaderTimeout:   10 * time.Second,
-		ReadTimeout:         30 * time.Second,
+		ReadHeaderTimeout:   DefaultReadHeaderTimeout,
+		ReadTimeout:         DefaultReadTimeout,
 		RequestTimeout:      DefaultRequestTimeout,
-		ServerIdleTimeout:   60 * time.Second,
-		WriteTimeout:        30 * time.Second,
-		MaxControlBodySize:  DefaultMaxControlBody,
+		ServerIdleTimeout:   DefaultServerIdleTimeout,
+		WriteTimeout:        DefaultWriteTimeout,
+		MaxControlBodySize:  DefaultMaxControlBodySize,
 		MaxRequestSize:      defaultMaxRequestSize,
 	}
 }
@@ -361,7 +365,8 @@ func (s *Server) Collectors() []prometheus.Collector {
 			}, s.promConnections),
 		}
 		if measureLatency {
-			s.promCollectors = append(s.promCollectors,
+			s.promCollectors = append(
+				s.promCollectors,
 				prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 					Namespace: s.cfg.PrometheusNamespace,
 					Name:      "avg_client_setup_latency",
@@ -1105,10 +1110,10 @@ func (s *Server) Run(pctx context.Context) error {
 			Addr:              s.cfg.ControlAddress,
 			Handler:           cmux,
 			BaseContext:       func(_ net.Listener) context.Context { return ctx },
-			ReadHeaderTimeout: s.cfg.ReadHeaderTimeout / 2,
-			ReadTimeout:       s.cfg.ReadTimeout / 2,
-			WriteTimeout:      s.cfg.WriteTimeout / 2,
-			IdleTimeout:       s.cfg.ServerIdleTimeout / 2,
+			ReadHeaderTimeout: s.cfg.ReadHeaderTimeout,
+			ReadTimeout:       s.cfg.ReadTimeout,
+			WriteTimeout:      s.cfg.WriteTimeout,
+			IdleTimeout:       s.cfg.ServerIdleTimeout,
 		}
 		go func() {
 			log.Infof("Control listening: %s", s.cfg.ControlAddress)

--- a/service/hproxy/hproxy.go
+++ b/service/hproxy/hproxy.go
@@ -53,6 +53,7 @@ const (
 	// XXX think about these durations
 	DefaultClientIdleTimeout = 5 * time.Minute  // Reap timer for client persistence
 	DefaultRequestTimeout    = 9 * time.Second  // Smaller than 12s
+	DefaultMaxControlBody    = 1 << 20          // 1 MiB, control endpoint body limit
 	DefaultPollFrequency     = 11 * time.Second // Smaller than 12s
 	DefaultListenAddress     = "localhost:8545" // Default geth port
 	DefaultControlAddress    = "localhost:1337" // Default control port
@@ -170,7 +171,12 @@ type Config struct {
 	PrometheusListenAddress string
 	PrometheusNamespace     string
 	PprofListenAddress      string
+	ReadHeaderTimeout       time.Duration
+	ReadTimeout             time.Duration
 	RequestTimeout          time.Duration
+	ServerIdleTimeout       time.Duration
+	WriteTimeout            time.Duration
+	MaxControlBodySize      int64
 }
 
 func NewDefaultConfig() *Config {
@@ -181,7 +187,12 @@ func NewDefaultConfig() *Config {
 		PollFrequency:       DefaultPollFrequency,
 		Network:             "mainnet",
 		PrometheusNamespace: appName,
+		ReadHeaderTimeout:   10 * time.Second,
+		ReadTimeout:         30 * time.Second,
 		RequestTimeout:      DefaultRequestTimeout,
+		ServerIdleTimeout:   60 * time.Second,
+		WriteTimeout:        30 * time.Second,
+		MaxControlBodySize:  DefaultMaxControlBody,
 		MaxRequestSize:      defaultMaxRequestSize,
 	}
 }
@@ -942,6 +953,7 @@ func (s *Server) handleControlAddRequest(w http.ResponseWriter, r *http.Request)
 	log.Tracef("handleControlAddRequest: %v", r.RemoteAddr)
 	defer log.Tracef("handleControlAddRequest exit: %v", r.RemoteAddr)
 
+	r.Body = http.MaxBytesReader(w, r.Body, s.cfg.MaxControlBodySize)
 	ns := make([]Node, 0, 16)
 	err := json.NewDecoder(r.Body).Decode(&ns)
 	if err != nil {
@@ -971,6 +983,7 @@ func (s *Server) handleControlRemoveRequest(w http.ResponseWriter, r *http.Reque
 	log.Tracef("handleControlRemoveRequest: %v", r.RemoteAddr)
 	defer log.Tracef("handleControlRemoveRequest exit: %v", r.RemoteAddr)
 
+	r.Body = http.MaxBytesReader(w, r.Body, s.cfg.MaxControlBodySize)
 	ns := make([]Node, 0, 16)
 	err := json.NewDecoder(r.Body).Decode(&ns)
 	if err != nil {
@@ -1061,8 +1074,12 @@ func (s *Server) Run(pctx context.Context) error {
 	mux.HandleFunc("/", s.handleProxyRequest)
 
 	s.httpServer = &http.Server{
-		Handler:     mux,
-		BaseContext: func(_ net.Listener) context.Context { return ctx },
+		Handler:           mux,
+		BaseContext:       func(_ net.Listener) context.Context { return ctx },
+		ReadHeaderTimeout: s.cfg.ReadHeaderTimeout,
+		ReadTimeout:       s.cfg.ReadTimeout,
+		WriteTimeout:      s.cfg.WriteTimeout,
+		IdleTimeout:       s.cfg.ServerIdleTimeout,
 	}
 	go func() {
 		log.Infof("Listening: %s", ln.Addr())
@@ -1085,9 +1102,13 @@ func (s *Server) Run(pctx context.Context) error {
 		handle("Control", cmux, RouteControlList, s.handleControlListRequest)
 
 		ctrlHttpServer := &http.Server{
-			Addr:        s.cfg.ControlAddress,
-			Handler:     cmux,
-			BaseContext: func(_ net.Listener) context.Context { return ctx },
+			Addr:              s.cfg.ControlAddress,
+			Handler:           cmux,
+			BaseContext:       func(_ net.Listener) context.Context { return ctx },
+			ReadHeaderTimeout: s.cfg.ReadHeaderTimeout / 2,
+			ReadTimeout:       s.cfg.ReadTimeout / 2,
+			WriteTimeout:      s.cfg.WriteTimeout / 2,
+			IdleTimeout:       s.cfg.ServerIdleTimeout / 2,
 		}
 		go func() {
 			log.Infof("Control listening: %s", s.cfg.ControlAddress)

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -239,8 +239,8 @@ func TestClientReap(t *testing.T) {
 			t.Fatal(t.Context().Err())
 		case <-time.After(10 * time.Millisecond):
 		}
-		if hp.HTTPAddress() != nil {
-			hpCfg.ListenAddress = hp.HTTPAddress().String()
+		if addr := hp.HTTPAddress(); addr != nil {
+			hpCfg.ListenAddress = addr.String()
 			break
 		}
 	}
@@ -250,11 +250,9 @@ func TestClientReap(t *testing.T) {
 	// Phase 1: establish clients with infinite idle timeout.
 	var wg sync.WaitGroup
 	for i := range clientCount {
-		wg.Add(1)
-		go func(x int) {
-			defer wg.Done()
-			doRequest(t.Context(), hpCfg.ListenAddress, x)
-		}(i)
+		wg.Go(func() {
+			doRequest(t.Context(), hpCfg.ListenAddress, i)
+		})
 	}
 	wg.Wait()
 
@@ -276,11 +274,9 @@ func TestClientReap(t *testing.T) {
 
 	// Phase 3: new requests after reap must create fresh clients.
 	for i := range clientCount {
-		wg.Add(1)
-		go func(x int) {
-			defer wg.Done()
-			doRequest(t.Context(), hpCfg.ListenAddress, x+clientCount)
-		}(i)
+		wg.Go(func() {
+			doRequest(t.Context(), hpCfg.ListenAddress, i+clientCount)
+		})
 	}
 	wg.Wait()
 
@@ -868,8 +864,8 @@ func TestServerTimeoutsConfigured(t *testing.T) {
 	if srv.WriteTimeout != DefaultWriteTimeout {
 		t.Fatalf("WriteTimeout = %v, want %v", srv.WriteTimeout, DefaultWriteTimeout)
 	}
-	if srv.IdleTimeout != DefaultServerIdleTimeout {
-		t.Fatalf("IdleTimeout = %v, want %v", srv.IdleTimeout, DefaultServerIdleTimeout)
+	if srv.IdleTimeout != DefaultIdleTimeout {
+		t.Fatalf("IdleTimeout = %v, want %v", srv.IdleTimeout, DefaultIdleTimeout)
 	}
 }
 
@@ -886,7 +882,7 @@ func TestServerTimeoutsCustom(t *testing.T) {
 	cfg.ReadHeaderTimeout = 5 * time.Second
 	cfg.ReadTimeout = 15 * time.Second
 	cfg.WriteTimeout = 20 * time.Second
-	cfg.ServerIdleTimeout = 45 * time.Second
+	cfg.IdleTimeout = 45 * time.Second
 
 	hp, err := NewServer(cfg)
 	if err != nil {

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/hemilabs/heminetwork/v2/internal/testutil/mock"
 )
 
@@ -159,15 +157,67 @@ func TestNobodyHome(t *testing.T) {
 // func TestDialTimeout(t *testing.T) {
 // XXX tried to build a test for this but did not succeed. Remove or fix.
 // }
+// clientCount returns the number of tracked clients.
+func (s *Server) clientCount() int {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return len(s.clients)
+}
+
+// waitClients polls until the client count equals want or the context
+// expires.  Returns the final count.
+func waitClients(ctx context.Context, hp *Server, want int) int {
+	for {
+		n := hp.clientCount()
+		if n == want {
+			return n
+		}
+		select {
+		case <-ctx.Done():
+			return n
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// doRequest sends one JSON-RPC request through the proxy using a
+// fresh transport (so hproxy sees a distinct client).  Panics on
+// failure because t.Fatal in a goroutine only kills that goroutine.
+func doRequest(ctx context.Context, addr string, id int) {
+	c := &http.Client{Transport: &http.Transport{}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"http://"+addr, newEthReq("ping"))
+	if err != nil {
+		panic(fmt.Errorf("client %d: new request: %w", id, err))
+	}
+	reply, err := c.Do(req)
+	if err != nil {
+		panic(fmt.Errorf("client %d: do: %w", id, err))
+	}
+	defer reply.Body.Close()
+	if reply.StatusCode != http.StatusOK {
+		panic(fmt.Errorf("client %d: status %d", id, reply.StatusCode))
+	}
+	hdr := reply.Header.Get("X-Hproxy")
+	if hdr == "" {
+		panic(fmt.Errorf("client %d: missing X-Hproxy header", id))
+	}
+	var jr serverReply
+	if err = json.NewDecoder(reply.Body).Decode(&jr); err != nil {
+		panic(fmt.Errorf("client %d: decode: %w", id, err))
+	}
+	if strconv.Itoa(jr.ID) != hdr {
+		panic(fmt.Errorf("client %d: id mismatch header=%s json=%d", id, hdr, jr.ID))
+	}
+}
+
 func TestClientReap(t *testing.T) {
 	s := newServer(0, nil)
 	defer s.Close()
-	servers := []string{s.URL}
 
 	hpCfg := NewDefaultConfig()
-	hpCfg.HVMURLs = servers
-	hpCfg.LogLevel = "hproxy=TRACE"                 // XXX figure out why this isn't working
-	hpCfg.ClientIdleTimeout = mock.InfiniteDuration // will timeout manually later
+	hpCfg.HVMURLs = []string{s.URL}
+	hpCfg.ClientIdleTimeout = mock.InfiniteDuration
 	hpCfg.RequestTimeout = time.Second
 	hpCfg.PollFrequency = time.Second
 	hpCfg.ListenAddress = "127.0.0.1:0"
@@ -178,96 +228,82 @@ func TestClientReap(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		err = hp.Run(t.Context())
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err := hp.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
 	}()
 
-	// Wait for HTTP server to start
 	for {
 		select {
 		case <-t.Context().Done():
 			t.Fatal(t.Context().Err())
 		case <-time.After(10 * time.Millisecond):
 		}
-		if addr := hp.HTTPAddress(); addr != nil {
-			hpCfg.ListenAddress = addr.String()
+		if hp.HTTPAddress() != nil {
+			hpCfg.ListenAddress = hp.HTTPAddress().String()
 			break
 		}
 	}
 
-	testDuration := 5 * time.Second
-	ctx, cancel := context.WithTimeout(t.Context(), testDuration)
-	defer cancel()
+	const clientCount = 5
 
-	// Launch 5 clients
+	// Phase 1: establish clients with infinite idle timeout.
 	var wg sync.WaitGroup
-	clientCount := 5
 	for i := range clientCount {
 		wg.Add(1)
 		go func(x int) {
 			defer wg.Done()
-			// This uses a new http.Transport to prevent using idle connections,
-			// which would result in a new client not being created.
-			c := &http.Client{Transport: &http.Transport{}}
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-				"http://"+hpCfg.ListenAddress, newEthReq("ping"))
-			if err != nil {
-				panic(fmt.Errorf("get %v: %w", x, err))
-			}
-			reply, err := c.Do(req)
-			if err != nil {
-				panic(fmt.Errorf("do %v: %w", x, err))
-			}
-			defer reply.Body.Close()
-			switch reply.StatusCode {
-			case http.StatusOK:
-			default:
-				panic(fmt.Errorf("%v replied %v",
-					hpCfg.ListenAddress, reply.StatusCode))
-			}
-
-			// Require X-Hproxy
-			ids := reply.Header.Get("X-Hproxy")
-			if ids == "" {
-				panic("expected X-Hproxy being set")
-			}
-
-			var jr serverReply
-			if err = json.NewDecoder(reply.Body).Decode(&jr); err != nil {
-				panic(fmt.Errorf("decode %v: %w", x, err))
-			}
-
-			// Verify that json id matches header id, a bit silly
-			// but keeps us honest.
-			if strconv.Itoa(jr.ID) != ids {
-				panic(fmt.Errorf("id mismatch header: %s, json: %d", ids, jr.ID))
-			}
+			doRequest(t.Context(), hpCfg.ListenAddress, x)
 		}(i)
 	}
-
 	wg.Wait()
-	hp.mtx.RLock()
-	if len(hp.clients) != clientCount {
-		t.Fatalf("got %v clients, want %v", len(hp.clients), clientCount)
-	}
-	hp.mtx.RUnlock()
 
+	if n := hp.clientCount(); n != clientCount {
+		t.Fatalf("after requests: got %d clients, want %d", n, clientCount)
+	}
+
+	// Phase 2: reset all timers to 1ns — reaper fires almost immediately.
 	hp.mtx.Lock()
 	for _, v := range hp.clients {
 		v.reset(1 * time.Nanosecond)
 	}
 	hp.mtx.Unlock()
 
-	time.Sleep(250 * time.Millisecond)
-
-	hp.mtx.RLock()
-	if len(hp.clients) != 0 {
-		t.Logf("not reaped clients: %v", spew.Sdump(hp.clients))
-		time.Sleep(50 * time.Millisecond)
+	got := waitClients(t.Context(), hp, 0)
+	if got != 0 {
+		t.Fatalf("after reap: got %d clients, want 0", got)
 	}
-	hp.mtx.RUnlock()
+
+	// Phase 3: new requests after reap must create fresh clients.
+	for i := range clientCount {
+		wg.Add(1)
+		go func(x int) {
+			defer wg.Done()
+			doRequest(t.Context(), hpCfg.ListenAddress, x+clientCount)
+		}(i)
+	}
+	wg.Wait()
+
+	if n := hp.clientCount(); n != clientCount {
+		t.Fatalf("after re-register: got %d clients, want %d", n, clientCount)
+	}
+
+	// Phase 4: verify that activity resets the idle timer.  Set a
+	// short timeout, then send a request before it expires — the
+	// client must survive because the request resets the ticker.
+	hp.mtx.Lock()
+	for _, v := range hp.clients {
+		v.reset(200 * time.Millisecond)
+	}
+	hp.mtx.Unlock()
+
+	time.Sleep(100 * time.Millisecond)
+	doRequest(t.Context(), hpCfg.ListenAddress, 99)
+	time.Sleep(150 * time.Millisecond)
+
+	if n := hp.clientCount(); n == 0 {
+		t.Fatal("activity should have prevented reap but all clients were reaped")
+	}
 }
 
 func TestRequestTimeout(t *testing.T) {

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -812,3 +812,31 @@ func TestNodePoking(t *testing.T) {
 		t.Errorf("got %v unhealthy, want %v", unhealthy, unhealthyCount)
 	}
 }
+
+func TestControlAddBodyLimit(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a valid JSON array of nodes that exceeds DefaultMaxControlBody.
+	// Each entry is ~30 bytes of JSON; we need enough to cross the limit.
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	entry := []byte(`{"node_url":"http://x.example.com:8545"},`)
+	for buf.Len() < int(DefaultMaxControlBody)+1 {
+		buf.Write(entry)
+	}
+	buf.Truncate(buf.Len() - 1) // drop trailing comma
+	buf.WriteByte(']')
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader(buf.Bytes()))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized body, got %d", rec.Code)
+	}
+}

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -813,6 +813,84 @@ func TestNodePoking(t *testing.T) {
 	}
 }
 
+func TestServerTimeoutsConfigured(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	hp, _ := newHproxy(t, []string{s.URL}, []string{"ping"})
+
+	hp.mtx.RLock()
+	srv := hp.httpServer
+	hp.mtx.RUnlock()
+
+	if srv.ReadHeaderTimeout != DefaultReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", srv.ReadHeaderTimeout, DefaultReadHeaderTimeout)
+	}
+	if srv.ReadTimeout != DefaultReadTimeout {
+		t.Fatalf("ReadTimeout = %v, want %v", srv.ReadTimeout, DefaultReadTimeout)
+	}
+	if srv.WriteTimeout != DefaultWriteTimeout {
+		t.Fatalf("WriteTimeout = %v, want %v", srv.WriteTimeout, DefaultWriteTimeout)
+	}
+	if srv.IdleTimeout != DefaultServerIdleTimeout {
+		t.Fatalf("IdleTimeout = %v, want %v", srv.IdleTimeout, DefaultServerIdleTimeout)
+	}
+}
+
+func TestServerTimeoutsCustom(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	cfg := NewDefaultConfig()
+	cfg.HVMURLs = []string{s.URL}
+	cfg.RequestTimeout = time.Second
+	cfg.PollFrequency = time.Second
+	cfg.ListenAddress = "127.0.0.1:0"
+	cfg.ControlAddress = "127.0.0.1:0"
+	cfg.ReadHeaderTimeout = 5 * time.Second
+	cfg.ReadTimeout = 15 * time.Second
+	cfg.WriteTimeout = 20 * time.Second
+	cfg.ServerIdleTimeout = 45 * time.Second
+
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		if err := hp.Run(t.Context()); err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	for {
+		select {
+		case <-t.Context().Done():
+			t.Fatal(t.Context().Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+		if hp.HTTPAddress() != nil {
+			break
+		}
+	}
+
+	hp.mtx.RLock()
+	srv := hp.httpServer
+	hp.mtx.RUnlock()
+
+	if srv.ReadHeaderTimeout != 5*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want 5s", srv.ReadHeaderTimeout)
+	}
+	if srv.ReadTimeout != 15*time.Second {
+		t.Fatalf("ReadTimeout = %v, want 15s", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 20*time.Second {
+		t.Fatalf("WriteTimeout = %v, want 20s", srv.WriteTimeout)
+	}
+	if srv.IdleTimeout != 45*time.Second {
+		t.Fatalf("IdleTimeout = %v, want 45s", srv.IdleTimeout)
+	}
+}
+
 func TestControlAddBodyLimit(t *testing.T) {
 	cfg := NewDefaultConfig()
 	hp, err := NewServer(cfg)
@@ -820,18 +898,18 @@ func TestControlAddBodyLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build a valid JSON array of nodes that exceeds DefaultMaxControlBody.
+	// Build a valid JSON array of nodes that exceeds DefaultMaxControlBodySize.
 	// Each entry is ~30 bytes of JSON; we need enough to cross the limit.
 	var buf bytes.Buffer
 	buf.WriteByte('[')
 	entry := []byte(`{"node_url":"http://x.example.com:8545"},`)
-	for buf.Len() < int(DefaultMaxControlBody)+1 {
+	for buf.Len() < int(DefaultMaxControlBodySize)+1 {
 		buf.Write(entry)
 	}
 	buf.Truncate(buf.Len() - 1) // drop trailing comma
 	buf.WriteByte(']')
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RouteControlAdd,
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
 		bytes.NewReader(buf.Bytes()))
 	rec := httptest.NewRecorder()
 	hp.handleControlAddRequest(rec, req)

--- a/service/hproxy/hproxy_test.go
+++ b/service/hproxy/hproxy_test.go
@@ -934,15 +934,13 @@ func TestControlAddBodyLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Build a valid JSON array of nodes that exceeds DefaultMaxControlBodySize.
-	// Each entry is ~30 bytes of JSON; we need enough to cross the limit.
 	var buf bytes.Buffer
 	buf.WriteByte('[')
 	entry := []byte(`{"node_url":"http://x.example.com:8545"},`)
 	for buf.Len() < int(DefaultMaxControlBodySize)+1 {
 		buf.Write(entry)
 	}
-	buf.Truncate(buf.Len() - 1) // drop trailing comma
+	buf.Truncate(buf.Len() - 1)
 	buf.WriteByte(']')
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
@@ -953,4 +951,857 @@ func TestControlAddBodyLimit(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for oversized body, got %d", rec.Code)
 	}
+}
+
+// --- NewServer edge cases --------------------------------------------------
+
+func TestNewServerNilConfig(t *testing.T) {
+	s, err := NewServer(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.cfg == nil {
+		t.Fatal("expected default config")
+	}
+}
+
+func TestNewServerBadNetwork(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.Network = "krypton"
+	_, err := NewServer(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown network")
+	}
+}
+
+func TestNewServerBadMaxRequestSize(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.MaxRequestSize = "not-a-size"
+	_, err := NewServer(cfg)
+	if err == nil {
+		t.Fatal("expected error for bad max request size")
+	}
+}
+
+func TestNewServerZeroRequestTimeout(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.RequestTimeout = 0
+	s, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.cfg.RequestTimeout != DefaultRequestTimeout {
+		t.Fatalf("expected default timeout, got %v", s.cfg.RequestTimeout)
+	}
+}
+
+// --- ForbiddenMethodError --------------------------------------------------
+
+func TestForbiddenMethodError(t *testing.T) {
+	e := ForbiddenMethodError{method: "debug_traceCall"}
+	if e.Error() != "method not allowed: debug_traceCall" {
+		t.Fatalf("unexpected error string: %v", e.Error())
+	}
+	if !errors.Is(e, ErrForbiddenMethod) {
+		t.Fatal("ForbiddenMethodError should match ErrForbiddenMethod")
+	}
+}
+
+// --- Prometheus gauge helpers ----------------------------------------------
+
+func TestPromGauges(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hp.mtx.Lock()
+	hp.promHealth = health{
+		NewNodes:       1,
+		HealthyNodes:   2,
+		UnhealthyNodes: 3,
+		RemovedNodes:   4,
+	}
+	hp.persistentConnections = 5
+	hp.proxyCalls = 10
+	hp.setupDuration = 100
+	hp.proxyDuration = 200
+	hp.mtx.Unlock()
+
+	if v := hp.promHVMNew(); v != 1 {
+		t.Fatalf("promHVMNew = %v, want 1", v)
+	}
+	if v := hp.promHVMHealthy(); v != 2 {
+		t.Fatalf("promHVMHealthy = %v, want 2", v)
+	}
+	if v := hp.promHVMUnhealthy(); v != 3 {
+		t.Fatalf("promHVMUnhealthy = %v, want 3", v)
+	}
+	if v := hp.promHVMRemoved(); v != 4 {
+		t.Fatalf("promHVMRemoved = %v, want 4", v)
+	}
+	if v := hp.promConnections(); v != 5 {
+		t.Fatalf("promConnections = %v, want 5", v)
+	}
+	if v := hp.promAvgClientSetupLatency(); v != 10 {
+		t.Fatalf("promAvgClientSetupLatency = %v, want 10", v)
+	}
+	if v := hp.promAvgProxyLatency(); v != 20 {
+		t.Fatalf("promAvgProxyLatency = %v, want 20", v)
+	}
+}
+
+func TestPromLatencyZeroCalls(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := hp.promAvgClientSetupLatency(); v != 0 {
+		t.Fatalf("expected 0 with zero calls, got %v", v)
+	}
+	if v := hp.promAvgProxyLatency(); v != 0 {
+		t.Fatalf("expected 0 with zero calls, got %v", v)
+	}
+}
+
+func TestCollectors(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c1 := hp.Collectors()
+	if len(c1) == 0 {
+		t.Fatal("expected collectors")
+	}
+	c2 := hp.Collectors()
+	if len(c1) != len(c2) {
+		t.Fatal("collectors should be cached")
+	}
+}
+
+// --- Running / promRunning -------------------------------------------------
+
+func TestRunningAndPromRunning(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hp.running() {
+		t.Fatal("should not be running initially")
+	}
+	if v := hp.promRunning(); v != 0 {
+		t.Fatalf("promRunning = %v, want 0", v)
+	}
+
+	hp.testAndSetRunning(true)
+
+	if !hp.running() {
+		t.Fatal("should be running after set")
+	}
+	if v := hp.promRunning(); v != 1 {
+		t.Fatalf("promRunning = %v, want 1", v)
+	}
+}
+
+// --- isHealthy / health ----------------------------------------------------
+
+func TestIsHealthy(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	hp, _ := newHproxy(t, []string{s.URL}, []string{"ping"})
+	time.Sleep(250 * time.Millisecond)
+
+	if !hp.isHealthy(t.Context()) {
+		t.Fatal("expected healthy with one live backend")
+	}
+
+	ok, _, err := hp.health(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("health should report healthy")
+	}
+}
+
+func TestIsHealthyUnhealthy(t *testing.T) {
+	hp, _ := newHproxy(t, []string{"http://localhost:1"}, []string{"ping"})
+	time.Sleep(250 * time.Millisecond)
+
+	if hp.isHealthy(t.Context()) {
+		t.Fatal("expected unhealthy with dead backend")
+	}
+}
+
+// --- Control add/remove/list via handler -----------------------------------
+
+func TestControlAddRemoveList(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addBody := `[{"node_url":"http://add1.example.com:8545"},{"node_url":"http://add2.example.com:8545"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(addBody)))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("add: expected 200, got %d", rec.Code)
+	}
+
+	// List should return 2 nodes.
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, RouteControlList, nil)
+	rec = httptest.NewRecorder()
+	hp.handleControlListRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", rec.Code)
+	}
+	var listed []NodeHealth
+	if err := json.NewDecoder(rec.Body).Decode(&listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("list: expected 2 nodes, got %d", len(listed))
+	}
+
+	// Remove one.
+	removeBody := `[{"node_url":"http://add1.example.com:8545"}]`
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte(removeBody)))
+	rec = httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("remove: expected 200, got %d", rec.Code)
+	}
+
+	// List again — still 2 entries but one is "removed".
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, RouteControlList, nil)
+	rec = httptest.NewRecorder()
+	hp.handleControlListRequest(rec, req)
+	var listed2 []NodeHealth
+	if err := json.NewDecoder(rec.Body).Decode(&listed2); err != nil {
+		t.Fatal(err)
+	}
+	removed := 0
+	for _, n := range listed2 {
+		if n.Status == "removed" {
+			removed++
+		}
+	}
+	if removed != 1 {
+		t.Fatalf("expected 1 removed node, got %d", removed)
+	}
+}
+
+func TestControlAddDuplicate(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"http://dup.example.com:8545"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first add: expected 200, got %d", rec.Code)
+	}
+
+	// Second add — duplicate error in response body.
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(body)))
+	rec = httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second add: expected 200, got %d", rec.Code)
+	}
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error != "duplicate" {
+		t.Fatalf("expected duplicate error, got %+v", nes)
+	}
+}
+
+func TestControlAddBadScheme(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"ftp://bad.example.com"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error == "" {
+		t.Fatalf("expected unsupported scheme error, got %+v", nes)
+	}
+}
+
+func TestControlAddBadJSON(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte("not json")))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestControlRemoveBadJSON(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte("not json")))
+	rec := httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestControlRemoveNotFound(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"http://ghost.example.com:8545"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error != "not found" {
+		t.Fatalf("expected not found error, got %+v", nes)
+	}
+}
+
+func TestControlRemoveAlreadyRemoved(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"http://once.example.com:8545"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte(body)))
+	rec = httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+
+	// Remove again.
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte(body)))
+	rec = httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error != "already removed" {
+		t.Fatalf("expected already removed error, got %+v", nes)
+	}
+}
+
+func TestControlAddReAddsRemovedNode(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"http://comeback.example.com:8545"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte(body)))
+	rec = httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+
+	// Re-add — should succeed (re-adds the removed node).
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(body)))
+	rec = httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error != "" {
+		t.Fatalf("expected no error on re-add, got %+v", nes)
+	}
+}
+
+func TestControlRemoveBodyLimit(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	entry := []byte(`{"node_url":"http://x.example.com:8545"},`)
+	for buf.Len() < int(DefaultMaxControlBodySize)+1 {
+		buf.Write(entry)
+	}
+	buf.Truncate(buf.Len() - 1)
+	buf.WriteByte(']')
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader(buf.Bytes()))
+	rec := httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized body, got %d", rec.Code)
+	}
+}
+
+// --- Run double-start ------------------------------------------------------
+
+func TestRunDoubleStart(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	hp, _ := newHproxy(t, []string{s.URL}, []string{"ping"})
+
+	// hp is already running via newHproxy. Try to run again.
+	err := hp.Run(t.Context())
+	if err == nil {
+		t.Fatal("expected error on double start")
+	}
+}
+
+// --- CallEthereum ----------------------------------------------------------
+
+func TestCallEthereum(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req EthereumRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			panic(err)
+		}
+		resp := EthereumResponse{
+			Version: EthereumVersion,
+			ID:      req.ID,
+			Result:  json.RawMessage(`"0x1"`),
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			panic(err)
+		}
+	}))
+	defer srv.Close()
+
+	resp, err := CallEthereum(t.Context(), srv.Client(), srv.URL, "eth_blockNumber")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(resp.Result) != `"0x1"` {
+		t.Fatalf("unexpected result: %s", resp.Result)
+	}
+}
+
+func TestCallEthereumBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := CallEthereum(t.Context(), srv.Client(), srv.URL, "eth_blockNumber")
+	if err == nil {
+		t.Fatal("expected error for 500 status")
+	}
+}
+
+func TestCallEthereumBadVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req EthereumRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			panic(err)
+		}
+		resp := EthereumResponse{
+			Version: "1.0",
+			ID:      req.ID,
+			Result:  json.RawMessage(`"0x1"`),
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			panic(err)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := CallEthereum(t.Context(), srv.Client(), srv.URL, "eth_blockNumber")
+	if err == nil {
+		t.Fatal("expected error for wrong version")
+	}
+}
+
+func TestCallEthereumBadID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := EthereumResponse{
+			Version: EthereumVersion,
+			ID:      "wrong-id",
+			Result:  json.RawMessage(`"0x1"`),
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			panic(err)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := CallEthereum(t.Context(), srv.Client(), srv.URL, "eth_blockNumber")
+	if err == nil {
+		t.Fatal("expected error for mismatched ID")
+	}
+}
+
+func TestCallEthereumBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	_, err := CallEthereum(t.Context(), srv.Client(), srv.URL, "eth_blockNumber")
+	if err == nil {
+		t.Fatal("expected error for bad JSON response")
+	}
+}
+
+func TestCallEthereumBadURL(t *testing.T) {
+	_, err := CallEthereum(t.Context(), http.DefaultClient, "://bad", "eth_blockNumber")
+	if err == nil {
+		t.Fatal("expected error for bad URL")
+	}
+}
+
+func TestRemoveBadScheme(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"ftp://bad.example.com"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error == "" {
+		t.Fatalf("expected unsupported scheme error, got %+v", nes)
+	}
+}
+
+func TestNewServerOverflowRequestSize(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.MaxRequestSize = "10EiB"
+	_, err := NewServer(cfg)
+	if err == nil {
+		t.Fatal("expected error for overflow request size")
+	}
+}
+
+func TestControlListWithConnectedClients(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	hp, hpCfg := newHproxy(t, []string{s.URL}, []string{"ping"})
+	time.Sleep(250 * time.Millisecond)
+
+	body := `{"jsonrpc":"2.0","method":"ping","id":"1"}`
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		"http://"+hpCfg.ListenAddress+"/", bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, RouteControlList, nil)
+	rec := httptest.NewRecorder()
+	hp.handleControlListRequest(rec, req)
+	var listed []NodeHealth
+	if err := json.NewDecoder(rec.Body).Decode(&listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(listed))
+	}
+	if listed[0].Connections < 1 {
+		t.Fatalf("expected at least 1 connection, got %d", listed[0].Connections)
+	}
+}
+
+func TestHTTPAddressNil(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hp.HTTPAddress() != nil {
+		t.Fatal("expected nil address before Run")
+	}
+}
+
+func TestNodeAddBadURL(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"://bad-url"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlAdd,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlAddRequest(rec, req)
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error == "" {
+		t.Fatalf("expected invalid url error, got %+v", nes)
+	}
+}
+
+func TestRemoveBadURL(t *testing.T) {
+	cfg := NewDefaultConfig()
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `[{"node_url":"://bad-url"}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, RouteControlRemove,
+		bytes.NewReader([]byte(body)))
+	rec := httptest.NewRecorder()
+	hp.handleControlRemoveRequest(rec, req)
+	var nes []NodeError
+	if err := json.NewDecoder(rec.Body).Decode(&nes); err != nil {
+		t.Fatal(err)
+	}
+	if len(nes) != 1 || nes[0].Error == "" {
+		t.Fatalf("expected invalid url error, got %+v", nes)
+	}
+}
+
+func postProxy(t *testing.T, addr string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		"http://"+addr+"/", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestFilterRequestMaxBytes(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	hp, hpCfg := newHproxy(t, []string{s.URL}, []string{"ping"})
+	time.Sleep(250 * time.Millisecond)
+
+	big := make([]byte, hp.maxRequestSize+1)
+	for i := range big {
+		big[i] = 'x'
+	}
+
+	resp := postProxy(t, hpCfg.ListenAddress, big)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", resp.StatusCode)
+	}
+}
+
+func TestFilterRequestBadJSON(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	_, hpCfg := newHproxy(t, []string{s.URL}, []string{"ping"})
+	time.Sleep(250 * time.Millisecond)
+
+	resp := postProxy(t, hpCfg.ListenAddress, []byte("not json"))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnsupportedMediaType {
+		t.Fatalf("expected 415, got %d", resp.StatusCode)
+	}
+}
+
+func TestFilterRequestForbiddenMethod(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	_, hpCfg := newHproxy(t, []string{s.URL}, []string{"ping"})
+	time.Sleep(250 * time.Millisecond)
+
+	body := `{"jsonrpc":"2.0","method":"debug_traceCall","id":"1"}`
+	resp := postProxy(t, hpCfg.ListenAddress, []byte(body))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxyNoCandidates(t *testing.T) {
+	_, hpCfg := newHproxy(t, []string{"http://localhost:1"}, []string{"ping"})
+	time.Sleep(250 * time.Millisecond)
+
+	body := `{"jsonrpc":"2.0","method":"ping","id":"1"}`
+	resp := postProxy(t, hpCfg.ListenAddress, []byte(body))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestRunNoURLs(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.HVMURLs = nil
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = hp.Run(t.Context())
+	if err == nil {
+		t.Fatal("expected error for no HVM URLs")
+	}
+}
+
+func TestRunWithPrometheus(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	cfg := NewDefaultConfig()
+	cfg.HVMURLs = []string{s.URL}
+	cfg.MethodFilter = []string{"ping"}
+	cfg.ListenAddress = "127.0.0.1:0"
+	cfg.ControlAddress = "127.0.0.1:0"
+	cfg.PrometheusListenAddress = "127.0.0.1:0"
+	cfg.RequestTimeout = time.Second
+	cfg.PollFrequency = time.Second
+
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 6*time.Second)
+	defer cancel()
+
+	go func() {
+		err := hp.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			panic(err)
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for server to start")
+		case <-time.After(10 * time.Millisecond):
+		}
+		if addr := hp.HTTPAddress(); addr != nil {
+			break
+		}
+	}
+
+	time.Sleep(5500 * time.Millisecond)
+	cancel()
+}
+
+func TestRunWithPprof(t *testing.T) {
+	s := newServer(0, nil)
+	defer s.Close()
+
+	cfg := NewDefaultConfig()
+	cfg.HVMURLs = []string{s.URL}
+	cfg.MethodFilter = []string{"ping"}
+	cfg.ListenAddress = "127.0.0.1:0"
+	cfg.ControlAddress = "127.0.0.1:0"
+	cfg.PprofListenAddress = "127.0.0.1:0"
+	cfg.RequestTimeout = time.Second
+	cfg.PollFrequency = time.Second
+
+	hp, err := NewServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		err := hp.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for server to start")
+		case <-time.After(10 * time.Millisecond):
+		}
+		if addr := hp.HTTPAddress(); addr != nil {
+			break
+		}
+	}
+
+	time.Sleep(250 * time.Millisecond)
+	cancel()
 }


### PR DESCRIPTION
Both the proxy and control HTTP servers had zero timeouts, allowing slowloris-style attacks to hold connections open indefinitely and exhaust file descriptors. The control add and remove endpoints decoded JSON from `r.Body` without `MaxBytesReader`, allowing unbounded body reads to cause OOM.

Adds configurable `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, `ServerIdleTimeout`, and `MaxControlBodySize` to the hproxy Config, with defaults and `HPROXY_*` environment variable wiring in `cmd/hproxyd`.

Addresses #695.