### PR TITLE
mock: treat websocket close frames as clean shutdown

### DIFF
--- a/internal/testutil/mock/geth.go
+++ b/internal/testutil/mock/geth.go
@@ -292,7 +292,10 @@ func (f *OpGethMockHandler) mockOpGethHandleFunc(w http.ResponseWriter, r *http.
 		if err != nil {
 			log.Errorf("exiting mockOpGethHandleFunc: %v", err)
 			if errors.Is(err, io.EOF) {
-				log.Tracef("websocket was closed")
+				return nil
+			}
+			var ce websocket.CloseError
+			if errors.As(err, &ce) {
 				return nil
 			}
 

--- a/internal/testutil/mock/tbc.go
+++ b/internal/testutil/mock/tbc.go
@@ -79,14 +79,6 @@ func NewMockTBC(pctx context.Context, errCh chan error, msgCh chan string, keyst
 func (f *TBCMockHandler) handle(c protocol.APIConn, utxos []tbcd.Utxo, mp *tbc.Mempool, w http.ResponseWriter, r *http.Request) (string, error) {
 	cmd, id, payload, err := tbcapi.Read(f.pctx, c)
 	if err != nil {
-		var ce websocket.CloseError
-		if errors.As(err, &ce) {
-			panic(fmt.Errorf("handleWebsocketRead: %w", err))
-		}
-		if errors.Is(err, io.EOF) {
-			panic(errors.New("handleWebsocketRead: EOF"))
-		}
-
 		return "", fmt.Errorf("handleWebsocketRead: %w", err)
 	}
 	log.Tracef("%v: command is %v", f.name, cmd)
@@ -383,6 +375,10 @@ func (f *TBCMockHandler) mockTBCHandleFunc(w http.ResponseWriter, r *http.Reques
 		method, err := f.handle(wsConn, utxos, mp, w, r)
 		if err != nil {
 			log.Errorf("exiting mockTBCHandleFunc: %v", err)
+			var ce websocket.CloseError
+			if errors.As(err, &ce) || errors.Is(err, io.EOF) {
+				return nil
+			}
 			return err
 		}
 		f.notifyMsg(f.pctx, method)


### PR DESCRIPTION
## Summary
- Fix flaky popm test failures (`TestPopmFilterUtxos`, `TestDisconnectedOpgeth`, `TestMaxFeeRemine`) caused by mock shutdown race
- The mock opgeth and tbc handlers returned close-frame errors to `errCh` during normal shutdown, causing `MessageListener` to race an error against expected messages and fail the test
- Treat `websocket.CloseError` and `io.EOF` as clean exits in both `mockOpGethHandleFunc` and `mockTBCHandleFunc`
- Remove the panic on `CloseError` in tbc mock's `handle()` — a normal close during read is not a bug

## Test plan
- [x] `go test ./service/popm/ -run 'TestPopmFilterUtxos|TestDisconnectedOpgeth|TestMaxFeeRemine'` passes consistently
- [ ] CI green