### PR TITLE
all: fix usage of testcontainer ports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/crypto/ripemd160 v1.0.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1
-	github.com/docker/go-connections v0.7.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ethereum/go-ethereum v1.17.4
 	github.com/go-test/deep v1.1.1
@@ -24,6 +23,7 @@ require (
 	github.com/hemilabs/x/tss/v3 v3.0.0-alpha.1
 	github.com/juju/loggo/v2 v2.2.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/moby/moby/api v1.54.2
 	github.com/otiai10/copy v1.14.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/shirou/gopsutil/v4 v4.26.6
@@ -56,6 +56,7 @@ require (
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.6 // indirect
@@ -79,7 +80,6 @@ require (
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.54.2 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/service/tbc/rpc_test.go
+++ b/service/tbc/rpc_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	dcrsecp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	dcrecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"github.com/docker/go-connections/nat"
 	"github.com/go-test/deep"
 	"github.com/juju/loggo/v2"
+	"github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/hemilabs/heminetwork/v2/api"
@@ -716,7 +716,7 @@ func TestUtxosByAddressRaw(t *testing.T) {
 			defer cancel()
 
 			var bitcoindContainer testcontainers.Container
-			var mappedPeerPort nat.Port
+			var mappedPeerPort network.Port
 			initialBlocks := 0
 			if !tti.doNotGenerate {
 				initialBlocks = 4
@@ -926,7 +926,7 @@ func TestUtxosByAddress(t *testing.T) {
 			defer cancel()
 
 			var bitcoindContainer testcontainers.Container
-			var mappedPeerPort nat.Port
+			var mappedPeerPort network.Port
 			initialBlocks := 0
 			if !tti.doNotGenerate {
 				initialBlocks = 4
@@ -1954,7 +1954,7 @@ func TestL2BlockByAbrevHash(t *testing.T) {
 		t.Run(tti.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
-			port, err := nat.NewPort("tcp", "9999")
+			port, err := network.ParsePort("9999/tcp")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/service/tbc/tbc_test.go
+++ b/service/tbc/tbc_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/coder/websocket"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/docker/go-connections/nat"
 	"github.com/go-test/deep"
 	"github.com/hemilabs/x/leveldb/leveldb"
 	"github.com/juju/loggo/v2"
+	"github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/hemilabs/heminetwork/v2/api"
@@ -1182,7 +1182,7 @@ func getRandomTxId(ctx context.Context, t *testing.T, bitcoindContainer testcont
 	return hash
 }
 
-func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort nat.Port) (*Server, string) {
+func createTbcServer(ctx context.Context, t *testing.T, mappedPeerPort network.Port) (*Server, string) {
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -1386,7 +1386,7 @@ func bitcoindBlockByHash(ctx context.Context, t *testing.T, bitcoindContainer te
 	return &btcCliBlockHeader
 }
 
-func createBitcoindWithInitialBlocks(ctx context.Context, t *testing.T, blocks uint64, overrideAddress string) (testcontainers.Container, nat.Port) {
+func createBitcoindWithInitialBlocks(ctx context.Context, t *testing.T, blocks uint64, overrideAddress string) (testcontainers.Container, network.Port) {
 	t.Helper()
 
 	bitcoindContainer := testutil.CreateBitcoind(ctx)


### PR DESCRIPTION
**Summary**
Merged commit `c8ece6e2098f57c46d154613508d97baf94665f4` breaks code due to a `testcontainers` version bump that changes the return type of Mapped container ports. This PR changes the signature of the affected methods. 

**Changes**
See summary
