### PR TITLE
database/tbcd/level: handle BIP30 duplicate txids in BlockHashByTxId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix `BlockHashByTxId` panic on BIP30 duplicate coinbase txids. Two
-  mainnet Bitcoin transactions exist in two blocks each; querying either
-  txid via RPC crashed `tbcd`.
-
 ### Security
 
 - Fix a remote crash vulnerability in `tbc` caused by the first element
@@ -134,6 +128,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `BlockHashByTxId` panic on BIP30 duplicate coinbase txids. Two
+  mainnet Bitcoin transactions exist in two blocks each; querying either
+  txid via RPC crashed `tbcd`.
 - Fix `BlockHeadersInsert` marking blocks as missing even when their
   bodies already exist on disk; the existence check used the wrong key
   format (41-byte height+hash instead of 32-byte hash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `BlockHashByTxId` panic on BIP30 duplicate coinbase txids. Two
+  mainnet Bitcoin transactions exist in two blocks each; querying either
+  txid via RPC crashed `tbcd`.
+
 ### Security
 
 - Fix a remote crash vulnerability in `tbc` caused by the first element

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -104,6 +104,34 @@ type ldb struct {
 
 var _ tbcd.Database = (*ldb)(nil)
 
+// BIP30: two coinbase transactions on mainnet are byte-identical across two
+// blocks each. Map each txid to the later (spendable) block hash.
+var bip30DuplicateBlocks map[chainhash.Hash]chainhash.Hash
+
+func init() {
+	bip30DuplicateBlocks = make(map[chainhash.Hash]chainhash.Hash, 2)
+	for _, pair := range [][2]string{
+		{
+			"e3bf3d07d4b0375638d5f1db5255fe07ba2c4cb067cd81b84ee974b6585fb468",
+			"00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e",
+		},
+		{
+			"d5d27987d2a3dfc724e359870c6644b40e497bdc0589a033220fe15429d88599",
+			"00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec",
+		},
+	} {
+		txId, err := chainhash.NewHashFromStr(pair[0])
+		if err != nil {
+			panic(err)
+		}
+		blockHash, err := chainhash.NewHashFromStr(pair[1])
+		if err != nil {
+			panic(err)
+		}
+		bip30DuplicateBlocks[*txId] = *blockHash
+	}
+}
+
 func h2b(wbh *wire.BlockHeader) [80]byte {
 	var b bytes.Buffer
 	err := wbh.Serialize(&b)
@@ -1649,7 +1677,13 @@ func (l *ldb) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainh
 	var locp *wire.TxLoc
 	for it.Next() {
 		if found {
-			panic(fmt.Sprintf("multiple blocks for tx %v", txId))
+			bh, ok := bip30DuplicateBlocks[txId]
+			if !ok {
+				panic(fmt.Sprintf("multiple blocks for tx %v", txId))
+			}
+			log.Debugf("multiple blocks for tx %v", txId)
+			correctBlock := bh
+			return &correctBlock, nil, nil
 		}
 		copy(blockHash[:], it.Key()[33:])
 		if v := it.Value(); len(v) >= 8 {

--- a/database/tbcd/level/level.go
+++ b/database/tbcd/level/level.go
@@ -122,11 +122,11 @@ func init() {
 	} {
 		txId, err := chainhash.NewHashFromStr(pair[0])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("database/tbcd/level: invalid bip30 duplicate block txID: %q", pair[0]))
 		}
 		blockHash, err := chainhash.NewHashFromStr(pair[1])
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("database/tbcd/level: invalid bip30 duplicate block hash: %q", pair[1]))
 		}
 		bip30DuplicateBlocks[*txId] = *blockHash
 	}
@@ -1679,7 +1679,7 @@ func (l *ldb) BlockHashByTxId(ctx context.Context, txId chainhash.Hash) (*chainh
 		if found {
 			bh, ok := bip30DuplicateBlocks[txId]
 			if !ok {
-				panic(fmt.Sprintf("multiple blocks for tx %v", txId))
+				panic(fmt.Errorf("multiple blocks for tx: %v", txId))
 			}
 			log.Debugf("multiple blocks for tx %v", txId)
 			correctBlock := bh


### PR DESCRIPTION
## Summary

- Two coinbase transactions on mainnet Bitcoin are byte-identical across two blocks each (`e3bf3d07...` in blocks 91,722/91,880 and `d5d27987...` in blocks 91,812/91,842). When both blocks are indexed, `BlockHashByTxId` panics on the duplicate iterator entries, crashing `tbcd` on any RPC query for these txids.
- Add a hardcoded sentinel map of the two known BIP30 txids to their correct (later, spendable) block hash. When a duplicate is detected, return the mapped block directly. Any other unexpected duplicate preserves the existing panic.
- All callers (`rpc.go`, `tbc.go`, `utxoindex.go`, `hemictl`) go through the single `ldb.BlockHashByTxId` implementation — one fix covers all paths.

## Test plan

- [x] Reproduced crash on mainnet node by querying both txids via `hemictl api tbcapi-block-hash-by-tx-id-request`
- [x] Deployed fixed binary to mainnet node, confirmed both duplicate txids return correct block hashes without crashing
- [x] Verified normal txid lookups still work (tested with pizza transaction `a1075db5...`)
- [x] `make lint` passes