### PR TITLE
popm: prevent remining of previously broadcasted keystone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in `popm` that led to a panic when prometheus called geth before
  the client was set ([#1030](https://github.com/hemilabs/heminetwork/pull/1030)).
 
+- Fix bug in `popm` that led to attempting to remine a keystones that were
+ successfully broadcasted by `tbc` ([#1156](https://github.com/hemilabs/heminetwork/pull/1156/changes))
+
 ## [v2.0.0]
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,7 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in `popm` that led to a panic when prometheus called geth before
  the client was set ([#1030](https://github.com/hemilabs/heminetwork/pull/1030)).
 
-- Fix bug in `popm` that led to attempting to remine a keystones that were
+- Fix bug in `popm` that led to attempting to remine keystones that were
  successfully broadcasted by `tbc` ([#1156](https://github.com/hemilabs/heminetwork/pull/1156/changes))
 
 ## [v2.0.0]

--- a/api/tbcapi/tbcapi.go
+++ b/api/tbcapi/tbcapi.go
@@ -398,8 +398,9 @@ type TxBroadcastRequest struct {
 }
 
 type TxBroadcastResponse struct {
-	TxID  *chainhash.Hash `json:"tx_id"`
-	Error *protocol.Error `json:"error,omitempty"`
+	TxID             *chainhash.Hash `json:"tx_id"`
+	AlreadyBroadcast bool            `json:"already_broadcast,omitempty"`
+	Error            *protocol.Error `json:"error,omitempty"`
 }
 
 type TxBroadcastRawRequest struct {

--- a/bitcoin/wallet/gozer/gozer.go
+++ b/bitcoin/wallet/gozer/gozer.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -38,6 +39,19 @@ type Gozer interface {
 	Run(ctx context.Context, connected func()) error
 
 	Connected() bool // ready to use
+}
+
+type TxBroadcastErr struct {
+	chainhash.Hash
+}
+
+func (tbe TxBroadcastErr) Error() string {
+	return fmt.Sprintf("failed to broadcast tx: %v", tbe.Hash)
+}
+
+func (tbe TxBroadcastErr) Is(target error) bool {
+	_, ok := target.(TxBroadcastErr)
+	return ok
 }
 
 // FeeByConfirmations picks a suitable fee by matching the exact number of

--- a/bitcoin/wallet/gozer/gozer.go
+++ b/bitcoin/wallet/gozer/gozer.go
@@ -43,6 +43,7 @@ type Gozer interface {
 
 type TxBroadcastError struct {
 	chainhash.Hash
+	AlreadyBroadcast bool
 }
 
 func (tbe TxBroadcastError) Error() string {

--- a/bitcoin/wallet/gozer/gozer.go
+++ b/bitcoin/wallet/gozer/gozer.go
@@ -41,16 +41,16 @@ type Gozer interface {
 	Connected() bool // ready to use
 }
 
-type TxBroadcastErr struct {
+type TxBroadcastError struct {
 	chainhash.Hash
 }
 
-func (tbe TxBroadcastErr) Error() string {
+func (tbe TxBroadcastError) Error() string {
 	return fmt.Sprintf("failed to broadcast tx: %v", tbe.Hash)
 }
 
-func (tbe TxBroadcastErr) Is(target error) bool {
-	_, ok := target.(TxBroadcastErr)
+func (tbe TxBroadcastError) Is(target error) bool {
+	_, ok := target.(TxBroadcastError)
 	return ok
 }
 

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -140,7 +140,7 @@ func (t *tbcGozer) BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.
 
 	res, err := t.callTBC(ctx, DefaultRequestTimeout, bur)
 	if err != nil {
-		return nil, gozer.TxBroadcastErr{Hash: tx.TxHash()}
+		return nil, gozer.TxBroadcastError{Hash: tx.TxHash()}
 	}
 
 	buResp, ok := res.(*tbcapi.TxBroadcastResponse)

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer"
-	"github.com/hemilabs/heminetwork/v2/service/tbc"
 )
 
 const (
@@ -150,7 +149,10 @@ func (t *tbcGozer) BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.
 
 	if buResp.Error != nil {
 		if buResp.AlreadyBroadcast {
-			return nil, tbc.ErrTxAlreadyBroadcast
+			return nil, gozer.TxBroadcastError{
+				Hash:             tx.TxHash(),
+				AlreadyBroadcast: true,
+			}
 		}
 		return nil, buResp.Error
 	}

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hemilabs/heminetwork/v2/api/protocol"
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer"
+	"github.com/hemilabs/heminetwork/v2/service/tbc"
 )
 
 const (
@@ -139,7 +140,7 @@ func (t *tbcGozer) BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.
 
 	res, err := t.callTBC(ctx, DefaultRequestTimeout, bur)
 	if err != nil {
-		return nil, err
+		return nil, gozer.TxBroadcastErr{Hash: tx.TxHash()}
 	}
 
 	buResp, ok := res.(*tbcapi.TxBroadcastResponse)
@@ -148,6 +149,9 @@ func (t *tbcGozer) BroadcastTx(ctx context.Context, tx *wire.MsgTx) (*chainhash.
 	}
 
 	if buResp.Error != nil {
+		if buResp.AlreadyBroadcast {
+			return nil, tbc.ErrTxAlreadyBroadcast
+		}
 		return nil, buResp.Error
 	}
 

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -127,6 +127,107 @@ func TestTBCGozerConnection(t *testing.T) {
 	}
 }
 
+func TestTBCGozerAlreadyBroadcast(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
+	defer cancel()
+
+	tbcCfg := &tbc.Config{
+		AutoIndex:               false,
+		BlockCacheSize:          "10mb",
+		HeaderCacheSize:         "1mb",
+		LevelDBHome:             t.TempDir(),
+		MaxCachedTxs:            1000,
+		Network:                 "localnet",
+		PrometheusListenAddress: "",
+		MempoolEnabled:          true,
+		Seeds:                   []string{"127.0.0.1:18444"},
+		ListenAddress:           "127.0.0.1:0",
+		NotificationBlocking:    true,
+	}
+	s, err := tbc.NewServer(tbcCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// subscribe to tbc notifications
+	l, err := s.SubscribeNotifications(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Unsubscribe()
+
+	go func() {
+		err := s.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	// Wait for http service to start up
+	var tbcURL string
+	for {
+		msg, err := l.Listen(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(msg)
+		if msg.Error != nil {
+			t.Fatal(msg.Error)
+		}
+		// TBC sends a notification when the http service has started.
+		if !msg.Is(tbc.NotificationService("", "")) {
+			continue
+		}
+
+		if msg.ID != "tbc_http_server" || msg.Msg != "ready" {
+			continue
+		}
+
+		if addr := s.HTTPAddress(); addr != nil {
+			tbcURL = addr.String()
+			break
+		}
+	}
+	l.Unsubscribe()
+
+	connChan := make(chan struct{})
+	connFunc := func() {
+		connChan <- struct{}{}
+	}
+
+	DefaultRequestTimeout = 10 * time.Second
+	b := New(fmt.Sprintf("http://%s/v1/ws", tbcURL))
+	if err = b.Run(ctx, connFunc); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	case <-connChan:
+	}
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("test")),
+			Index: 0,
+		},
+	})
+	tx.AddTxOut(wire.NewTxOut(50000, []byte{0x51}))
+
+	// first attempt fails with no peers, but is marked as broadcast by TBC
+	if _, err := b.BroadcastTx(ctx, tx); err == nil ||
+		!strings.Contains(err.Error(), tbc.ErrTxBroadcastNoPeers.Error()) {
+		t.Fatalf("expected error %v, got %v", tbc.ErrTxBroadcastNoPeers, err)
+	}
+
+	// second attempt fails with already broadcast
+	if _, err := b.BroadcastTx(ctx, tx); !errors.Is(err, tbc.ErrTxAlreadyBroadcast) {
+		t.Fatalf("expected error %v, got %v", tbc.ErrTxAlreadyBroadcast, err)
+	}
+}
+
 func TestTBCGozerCalls(t *testing.T) {
 	testAddrString := "n2BosBT7DvxWk1tZprk1tR1kyQmXwcv8M8"
 

--- a/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
+++ b/bitcoin/wallet/gozer/tbcgozer/tbcgozer_test.go
@@ -223,8 +223,11 @@ func TestTBCGozerAlreadyBroadcast(t *testing.T) {
 	}
 
 	// second attempt fails with already broadcast
-	if _, err := b.BroadcastTx(ctx, tx); !errors.Is(err, tbc.ErrTxAlreadyBroadcast) {
-		t.Fatalf("expected error %v, got %v", tbc.ErrTxAlreadyBroadcast, err)
+	_, err = b.BroadcastTx(ctx, tx)
+	if gErr, ok := errors.AsType[gozer.TxBroadcastError](err); !ok {
+		t.Fatalf("expected error %v, got %v", gozer.TxBroadcastError{}, err)
+	} else if !gErr.AlreadyBroadcast {
+		t.Fatal("expected error to include 'already broadcast' flag")
 	}
 }
 

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -40,7 +40,6 @@ import (
 	"github.com/hemilabs/heminetwork/v2/hemi"
 	"github.com/hemilabs/heminetwork/v2/service/deucalion"
 	"github.com/hemilabs/heminetwork/v2/service/pprof"
-	"github.com/hemilabs/heminetwork/v2/service/tbc"
 )
 
 const (
@@ -382,11 +381,10 @@ func (s *Server) createAndBroadcastKeystone(ctx context.Context, ks *keystone) e
 	}
 
 	err := s.broadcastKeystone(ctx, ks.popTx)
-	if !errors.Is(err, gozer.TxBroadcastError{}) {
-		ks.popTx = nil
-	}
-	if errors.Is(err, tbc.ErrTxAlreadyBroadcast) {
-		return nil
+	if gErr, ok := errors.AsType[gozer.TxBroadcastError](err); !ok {
+		ks.popTx = nil // not a broadcast error, create new popTx
+	} else if gErr.AlreadyBroadcast {
+		return nil // successfully broadcast
 	}
 	return err
 }

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -382,7 +382,7 @@ func (s *Server) createAndBroadcastKeystone(ctx context.Context, ks *keystone) e
 	}
 
 	err := s.broadcastKeystone(ctx, ks.popTx)
-	if !errors.Is(err, gozer.TxBroadcastErr{}) {
+	if !errors.Is(err, gozer.TxBroadcastError{}) {
 		ks.popTx = nil
 	}
 	if errors.Is(err, tbc.ErrTxAlreadyBroadcast) {

--- a/service/popm/popm.go
+++ b/service/popm/popm.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hemilabs/heminetwork/v2/hemi"
 	"github.com/hemilabs/heminetwork/v2/service/deucalion"
 	"github.com/hemilabs/heminetwork/v2/service/pprof"
+	"github.com/hemilabs/heminetwork/v2/service/tbc"
 )
 
 const (
@@ -151,6 +152,7 @@ type keystone struct {
 	// comes from opgeth
 	keystone *hemi.L2Keystone
 	hash     *chainhash.Hash // map key
+	popTx    *wire.MsgTx
 
 	retry   *time.Time // Used to delay mining if fees are high
 	expires *time.Time // Used to age out of cache
@@ -370,12 +372,23 @@ func (s *Server) broadcastKeystone(pctx context.Context, popTx *wire.MsgTx) erro
 	return nil
 }
 
-func (s *Server) createAndBroadcastKeystone(ctx context.Context, ks *hemi.L2Keystone) error {
-	popTx, err := s.createKeystoneTx(ctx, ks)
-	if err != nil {
-		return err
+func (s *Server) createAndBroadcastKeystone(ctx context.Context, ks *keystone) error {
+	if ks.popTx == nil {
+		var err error
+		ks.popTx, err = s.createKeystoneTx(ctx, ks.keystone)
+		if err != nil {
+			return err
+		}
 	}
-	return s.broadcastKeystone(ctx, popTx)
+
+	err := s.broadcastKeystone(ctx, ks.popTx)
+	if !errors.Is(err, gozer.TxBroadcastErr{}) {
+		ks.popTx = nil
+	}
+	if errors.Is(err, tbc.ErrTxAlreadyBroadcast) {
+		return nil
+	}
+	return err
 }
 
 func (s *Server) latestKeystones(ctx context.Context, count int) (*gethapi.L2KeystoneLatestResponse, error) {
@@ -705,7 +718,7 @@ func (s *Server) mine(ctx context.Context) error {
 				}
 				continue
 			}
-			err := s.createAndBroadcastKeystone(ctx, ks.keystone)
+			err := s.createAndBroadcastKeystone(ctx, ks)
 			if err != nil {
 				log.Errorf("new keystone: %v", err)
 				ks.state = keystoneStateError

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -56,10 +56,12 @@ func TestCreateAndBroadcastKeystoneRetry(t *testing.T) {
 			wantNilTx:    false,
 		},
 		{
-			name:         "already broadcast",
-			broadcastErr: tbc.ErrTxAlreadyBroadcast,
-			wantErr:      nil,
-			wantNilTx:    true,
+			name: "already broadcast",
+			broadcastErr: gozer.TxBroadcastError{
+				AlreadyBroadcast: true,
+			},
+			wantErr:   nil,
+			wantNilTx: true,
 		},
 		{
 			name:         "other error",

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -20,13 +20,75 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/juju/loggo/v2"
 
+	"github.com/btcsuite/btcd/wire"
+
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin"
+	"github.com/hemilabs/heminetwork/v2/bitcoin/wallet/gozer"
 	"github.com/hemilabs/heminetwork/v2/hemi"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil"
 	"github.com/hemilabs/heminetwork/v2/internal/testutil/mock"
 	"github.com/hemilabs/heminetwork/v2/service/tbc"
 )
+
+type broadcastTxGozer struct {
+	gozer.Gozer
+	broadcastErr error
+}
+
+func (g *broadcastTxGozer) BroadcastTx(_ context.Context, _ *wire.MsgTx) (*chainhash.Hash, error) {
+	if g.broadcastErr != nil {
+		return nil, g.broadcastErr
+	}
+	return &chainhash.Hash{}, nil
+}
+
+func TestCreateAndBroadcastKeystoneRetry(t *testing.T) {
+	tests := []struct {
+		name         string
+		broadcastErr error
+		wantErr      error
+		wantNilTx    bool
+	}{
+		{
+			name:         "connection failure",
+			broadcastErr: gozer.TxBroadcastErr{},
+			wantErr:      gozer.TxBroadcastErr{},
+			wantNilTx:    false,
+		},
+		{
+			name:         "already broadcast",
+			broadcastErr: tbc.ErrTxAlreadyBroadcast,
+			wantErr:      nil,
+			wantNilTx:    true,
+		},
+		{
+			name:         "other error",
+			broadcastErr: tbc.ErrJobNotFound,
+			wantErr:      tbc.ErrJobNotFound,
+			wantNilTx:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				gozer:  &broadcastTxGozer{broadcastErr: tt.broadcastErr},
+				params: &chaincfg.RegressionNetParams,
+			}
+
+			ks := &keystone{popTx: wire.NewMsgTx(wire.TxVersion)}
+
+			err := s.createAndBroadcastKeystone(t.Context(), ks)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+			if ks.popTx == nil && !tt.wantNilTx {
+				t.Fatal("tx unexpectedly cleared")
+			}
+		})
+	}
+}
 
 const wantedKeystones = 20
 

--- a/service/popm/popm_test.go
+++ b/service/popm/popm_test.go
@@ -18,9 +18,8 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/juju/loggo/v2"
-
 	"github.com/btcsuite/btcd/wire"
+	"github.com/juju/loggo/v2"
 
 	"github.com/hemilabs/heminetwork/v2/api/tbcapi"
 	"github.com/hemilabs/heminetwork/v2/bitcoin"
@@ -52,8 +51,8 @@ func TestCreateAndBroadcastKeystoneRetry(t *testing.T) {
 	}{
 		{
 			name:         "connection failure",
-			broadcastErr: gozer.TxBroadcastErr{},
-			wantErr:      gozer.TxBroadcastErr{},
+			broadcastErr: gozer.TxBroadcastError{},
+			wantErr:      gozer.TxBroadcastError{},
 			wantNilTx:    false,
 		},
 		{

--- a/service/tbc/rpc.go
+++ b/service/tbc/rpc.go
@@ -698,7 +698,8 @@ func (s *Server) handleTxBroadcastRequest(ctx context.Context, req *tbcapi.TxBro
 		if errors.Is(err, ErrTxAlreadyBroadcast) ||
 			errors.Is(err, ErrTxBroadcastNoPeers) {
 			return &tbcapi.TxBroadcastResponse{
-				Error: protocol.RequestError(err),
+				AlreadyBroadcast: errors.Is(err, ErrTxAlreadyBroadcast),
+				Error:            protocol.RequestError(err),
 			}, err
 		}
 		e := protocol.NewInternalError(err)
@@ -724,7 +725,8 @@ func (s *Server) handleTxBroadcastRawRequest(ctx context.Context, req *tbcapi.Tx
 		if errors.Is(err, ErrTxAlreadyBroadcast) ||
 			errors.Is(err, ErrTxBroadcastNoPeers) {
 			return &tbcapi.TxBroadcastResponse{
-				Error: protocol.RequestError(err),
+				AlreadyBroadcast: errors.Is(err, ErrTxAlreadyBroadcast),
+				Error:            protocol.RequestError(err),
 			}, err
 		}
 		e := protocol.NewInternalError(err)


### PR DESCRIPTION
**Summary**
Addresses an issue where upon attempting to broadcast a transaction through TBC, the miner could lose connection. In this scenario, the miner would create a new transaction to mine the same keystone, even if it was processed on the server side, leading to paying for extra fees.

**Changes**
Errors during broadcast caused due to connection issues (disconnect, timeouts...) now return `TxBroadcastError`, which stores the generated `popTx` for rebroadcasting. If the `popTx` was successfully processed by `tbc`, `ErrTxAlreadyBroadcast` is returned, and the keystone is marked as `keystoneStateBroadcast` and waits for mining confirmation. 
