### PR TITLE
synctest: limit docker log reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in `popm` that led to attempting to remine keystones that were
  successfully broadcasted by `tbc` ([#1156](https://github.com/hemilabs/heminetwork/pull/1156/changes))
 
+- Fix bug in `synctester` where unbounded reads of the docker logs could lead
+to an OOM crash ([#1159](https://github.com/hemilabs/heminetwork/pull/1159)).
+
 ## [v2.0.0]
 
 ### Breaking Changes

--- a/synctest/synctest.go
+++ b/synctest/synctest.go
@@ -452,7 +452,9 @@ func l2TipsMatch(ctx context.Context, c *config, lastl2BlockNumber *uint64) (boo
 	return false, nil
 }
 
-// this portion is untested for now
+// Max size of docker logs to retrieve
+const maxByteRead = 1000
+
 func getLogsFromDocker(ctx context.Context) string {
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -504,25 +506,22 @@ func getLogsFromDocker(ctx context.Context) string {
 		reader, err := dockerClient.ContainerLogs(ctx, c.ID, container.LogsOptions{
 			ShowStdout: true,
 			ShowStderr: true,
+			Tail:       "12",
 		})
 		if err != nil {
 			log.Warningf("could not get logs from running container %s: %s", c.ID, err)
 			return ""
 		}
 
-		b, err := io.ReadAll(reader)
+		r := io.LimitReader(reader, maxByteRead)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			log.Warningf("could not read logs: %s", err)
 			return ""
 		}
-
 		reader.Close()
 
-		const byteCount = 1000
-		if len(b) >= byteCount {
-			b = b[len(b)-byteCount:]
-		}
-		logs = fmt.Sprintf("%s\n%s", logs, string(b))
+		logs = fmt.Sprintf("%s\n\n%s", logs, string(b))
 	}
 	return logs
 }

--- a/synctest/synctest_test.go
+++ b/synctest/synctest_test.go
@@ -293,6 +293,27 @@ func TestGetLogsFromDockerContainers(t *testing.T) {
 	}
 }
 
+func TestDockerLogsLimit(t *testing.T) {
+	redisC, err := testcontainers.Run(
+		t.Context(), "redis:8.2.4-alpine3.22@sha256:a308ca111032fa8f306a2dc7be7ba5deb8b777ed5d258c733cddba48a1fd7904",
+		testcontainers.WithCmd("sh", "-c",
+			fmt.Sprintf("echo '%s'; echo test-print-done; sleep 1", testBlock1),
+		),
+		testcontainers.WithWaitStrategy(wait.ForLog("test-print-done")),
+		testcontainers.WithName("op-node"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testcontainers.CleanupContainer(t, redisC)
+
+	logs := getLogsFromDocker(t.Context())
+
+	if len(logs) > maxByteRead+100 {
+		t.Fatalf("unexpected log size %d > %d", len(logs), maxByteRead+100)
+	}
+}
+
 func setupServers(t *testing.T, useSlack bool, delaySeconds uint, useValidOtherBlock bool, syncInfo tbc.SyncInfo, useDocker bool, tbcErrors uint) func() {
 	lastRequestMtx.Lock()
 	defer lastRequestMtx.Unlock()


### PR DESCRIPTION
**Summary**
Limits the docker logs reader in `synctest`. 

**Changes**
See above.
